### PR TITLE
Defend the gate's own configuration, and fix three rule bugs

### DIFF
--- a/examples/policy.yaml
+++ b/examples/policy.yaml
@@ -31,14 +31,9 @@ rules:
   # `termaxa doctor` fingerprints the policy for exactly that reason: what
   # cannot be blocked can at least be noticed.
   #
-  # Reads are denied too, because separating them from writes would mean
-  # enumerating every read command. If you want one back, put it ABOVE this
-  # block — e.g. `- match: "cat .termaxa/*"` / `action: allow`. `termaxa
-  # doctor` prints the rule count, the default and the fingerprint without
-  # touching the file.
-  - match: "*.termaxa*"
-    action: deny
-    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  # Reads are denied too, except for the handful listed below, because
+  # separating reads from writes in general would mean enumerating every read
+  # command. To add one, put it in that group — NOT at the top of the file.
   - match: "*.claude*settings*"
     action: deny
     reason: "Agent hook configuration is off limits — editing it unhooks the gate."
@@ -51,6 +46,46 @@ rules:
   - match: "*.github*hooks*"
     action: deny
     reason: "Agent hook configuration is off limits — editing it unhooks the gate."
+
+  # The policy is an in-repo artifact, reviewable in PRs, and the deny below
+  # would otherwise make that workflow impossible: `git add .termaxa/…`,
+  # `git diff .termaxa/…` and `cp .termaxa/policy.yaml backup.yaml` are all
+  # blocked by it. These exceptions give the workflow back.
+  #
+  # The test for inclusion is that the `.termaxa` path can only be READ, never
+  # written. diff/status/log/show/cat read it; add/commit stage what is
+  # already on disk. `checkout`, `restore` and `config` are absent on purpose
+  # — overwriting the working tree from a ref is exactly what the deny is for,
+  # so restoring a clobbered policy stays a thing you do yourself.
+  #
+  # `cat` and `cp` are anchored on the SOURCE path so the copy can only go the
+  # safe way: `cp .termaxa/policy.yaml backup.yaml` matches,
+  # `cp backup.yaml .termaxa/policy.yaml` does not.
+  #
+  # Position matters twice over. Above the deny, or these never fire. Below
+  # the four denies above, because a trailing `*` swallows a redirect —
+  #     cat .termaxa/policy.yaml > .claude/settings.json
+  # matches `cat .termaxa*` too, and at the top of the file it would allow
+  # that and shadow the rule that exists to stop it.
+  - match: "git diff *.termaxa*"
+    action: allow
+  - match: "git status *.termaxa*"
+    action: allow
+  - match: "git log *.termaxa*"
+    action: allow
+  - match: "git show *.termaxa*"
+    action: allow
+  - match: "git add *.termaxa*"
+    action: allow
+  - match: "git commit *.termaxa*"
+    action: allow
+  - match: "cat .termaxa*"
+    action: allow
+  - match: "cp .termaxa*"
+    action: allow
+  - match: "*.termaxa*"
+    action: deny
+    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
 
   # ---- destructive: hard stops ----
   - match: "git push*--force*"

--- a/examples/policy.yaml
+++ b/examples/policy.yaml
@@ -15,6 +15,43 @@ version: 1
 default: ask
 
 rules:
+  # ---- self-defence: the gate's own configuration ----
+  # A gate that will happily rewrite its own rules is a suggestion. These
+  # come FIRST because first-match-wins: `echo *` at the bottom of this file
+  # would otherwise allow
+  #     echo 'default: allow' > .termaxa/policy.yaml
+  # and every command after it is judged by the agent's own policy.
+  #
+  # `*` matches any run of characters, so one rule covers both path
+  # separators: `.termaxa/policy.yaml` and `.termaxa\policy.yaml`.
+  #
+  # This closes the SHELL path only. An agent's file-writing tool (Write,
+  # Edit, the editor's apply-patch) never reaches the hook — the Claude Code
+  # hook is registered with `"matcher": "Bash"` — so no rule here can see it.
+  # `termaxa doctor` fingerprints the policy for exactly that reason: what
+  # cannot be blocked can at least be noticed.
+  #
+  # Reads are denied too, because separating them from writes would mean
+  # enumerating every read command. If you want one back, put it ABOVE this
+  # block — e.g. `- match: "cat .termaxa/*"` / `action: allow`. `termaxa
+  # doctor` prints the rule count, the default and the fingerprint without
+  # touching the file.
+  - match: "*.termaxa*"
+    action: deny
+    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  - match: "*.claude*settings*"
+    action: deny
+    reason: "Agent hook configuration is off limits — editing it unhooks the gate."
+  - match: "*.cursor*hooks*"
+    action: deny
+    reason: "Agent hook configuration is off limits — editing it unhooks the gate."
+  - match: "*.codex*hooks*"
+    action: deny
+    reason: "Agent hook configuration is off limits — editing it unhooks the gate."
+  - match: "*.github*hooks*"
+    action: deny
+    reason: "Agent hook configuration is off limits — editing it unhooks the gate."
+
   # ---- destructive: hard stops ----
   - match: "git push*--force*"
     action: deny
@@ -22,6 +59,12 @@ rules:
   - match: "rm -rf /*"
     action: deny
     reason: "Recursive delete from root is blocked."
+  # GNU rm refuses `rm -rf /` on its own; --no-preserve-root is the one
+  # spelling it obeys. The rule above is named for the command everybody
+  # quotes, this one is named for the command that actually works.
+  - match: "*--no-preserve-root*"
+    action: deny
+    reason: "--no-preserve-root is the only spelling `rm` obeys at `/`. Blocked."
   # Broad recursive-force deletes (any target), Unix + PowerShell + cmd
   # forms. DENY by default: with auto-approving agent UIs, `ask` silently
   # degrades to `allow`. Relax deliberately, per project, if you need to.
@@ -106,11 +149,18 @@ rules:
     action: allow
   - match: "git commit*"
     action: allow
-  - match: "ls*"
+  # A prefix without its trailing space is a prefix, not a command: `ls*`
+  # also matched `lsof` and `lsblk`, `grep*` also matched `grepdiff`.
+  # `cat *` and `echo *` below always had this right. Bare `ls` needs its own
+  # rule because `ls *` requires the space; bare `cat`/`grep` just read stdin,
+  # so they stay on the default.
+  - match: "ls"
+    action: allow
+  - match: "ls *"
     action: allow
   - match: "cat *"
     action: allow
-  - match: "grep*"
+  - match: "grep *"
     action: allow
   - match: "echo *"
     action: allow

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -58,6 +58,7 @@ pub fn run(dir: &Path) -> Result<i32> {
                     problems.push("fix .termaxa/policy.yaml (it does not parse)".into());
                 }
             }
+            report_fingerprint(&pf, &p.state_dir, &mut problems);
         }
         None => {
             println!(
@@ -226,6 +227,62 @@ pub fn run(dir: &Path) -> Result<i32> {
     }
 }
 
+/// Compare the policy on disk against the baseline `termaxa init` recorded.
+///
+/// Read-only, like everything else in `doctor`: it never records a baseline,
+/// because a diagnostic that writes the value it is checking always reports
+/// "unchanged". Re-recording is `termaxa init`'s job.
+///
+/// What this can and cannot say, stated plainly because the distinction is
+/// the whole feature: it can say the bytes differ from the ones last
+/// recorded. It cannot say who changed them, and it cannot see a change made
+/// before the first baseline existed.
+fn report_fingerprint(policy_file: &Path, state_dir: &Path, problems: &mut Vec<String>) {
+    use crate::fingerprint;
+    use crate::ui::{amber, cyan, dim, green};
+
+    let Some(current) = fingerprint::of_file(policy_file) else {
+        return; // unreadable policy is already reported above
+    };
+    println!("  fingerprint {}", dim(&fingerprint::short(&current)));
+
+    match fingerprint::read_baseline(state_dir) {
+        None => {
+            println!(
+                "  {} no baseline recorded — a change to this file would be invisible",
+                amber("!")
+            );
+            println!("    {}", cyan("termaxa init"));
+            problems.push("record a policy baseline — `termaxa init`".into());
+        }
+        Some(base) if base.sha256 == current => {
+            println!("  {} unchanged since {}", green("✓"), dim(&base.recorded));
+        }
+        Some(base) => {
+            println!(
+                "  {} CHANGED since {} (was {})",
+                amber("!"),
+                base.recorded,
+                fingerprint::short(&base.sha256)
+            );
+            println!(
+                "    {}",
+                dim("if you made this change, re-record it: `termaxa init`")
+            );
+            println!(
+                "    {}",
+                dim("if you did not, something edited the gate's own rules —")
+            );
+            println!(
+                "    {}",
+                dim("agent file-writing tools bypass the hook entirely (matcher: Bash)")
+            );
+            problems
+                .push("review .termaxa/policy.yaml — it changed since the last baseline".into());
+        }
+    }
+}
+
 fn report_agent(name: &str, wired: bool, fix: &str, problems: &mut Vec<String>) {
     use crate::ui::{amber, cyan, dim, green};
     if wired {
@@ -305,6 +362,48 @@ mod tests {
         let (total, hooks) = count_log(&f);
         assert_eq!(total, 3, "junk lines still count as entries that happened");
         assert_eq!(hooks, 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_policy_edited_behind_the_gate_becomes_a_reported_problem() {
+        let dir = std::env::temp_dir().join(format!("tmx-doc-fp-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let state = dir.join("state");
+        std::fs::create_dir_all(&state).unwrap();
+        let policy = dir.join("policy.yaml");
+        std::fs::write(&policy, "version: 1\ndefault: ask\nrules: []\n").unwrap();
+
+        // 1. No baseline: say so, and do NOT quietly create one — a
+        //    diagnostic that records the value it checks always reports
+        //    "unchanged".
+        let mut problems: Vec<String> = Vec::new();
+        report_fingerprint(&policy, &state, &mut problems);
+        assert_eq!(problems.len(), 1, "a missing baseline is a real gap");
+        assert!(
+            !crate::fingerprint::baseline_file(&state).exists(),
+            "doctor must observe, never record"
+        );
+
+        // 2. Baseline matches: nothing to fix.
+        let hash = crate::fingerprint::of_file(&policy).unwrap();
+        crate::fingerprint::record(&state, &hash).unwrap();
+        let mut problems: Vec<String> = Vec::new();
+        report_fingerprint(&policy, &state, &mut problems);
+        assert!(problems.is_empty(), "unchanged policy is not a problem");
+
+        // 3. The edit from the review — the one no deny rule can stop,
+        //    because an agent's file-writing tool never reaches the hook.
+        std::fs::write(&policy, "version: 1\ndefault: allow\nrules: []\n").unwrap();
+        let mut problems: Vec<String> = Vec::new();
+        report_fingerprint(&policy, &state, &mut problems);
+        assert_eq!(problems.len(), 1);
+        assert!(
+            problems[0].contains("changed"),
+            "the problem must name what happened: {}",
+            problems[0]
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -1,0 +1,232 @@
+//! Policy fingerprinting — so that a change to the gate's own configuration
+//! is *visible* rather than silent.
+//!
+//! Why this exists: policy rules gate **shell commands**. An agent's
+//! file-writing tool (Claude Code's `Write`/`Edit`, Cursor's edit apply)
+//! never reaches the hook at all — the Claude Code hook is registered with
+//! `"matcher": "Bash"` — so no deny rule can stop `.termaxa/policy.yaml`
+//! being rewritten that way. Blocking it is out of reach. Noticing it is not.
+//!
+//! Where the baseline lives is load-bearing: the per-project state dir under
+//! `$TERMAXA_HOME` (`~/.termaxa/projects/<key>/`), deliberately NOT inside
+//! `.termaxa/`. A baseline that lives in the directory it protects is erased
+//! by the same clobber it exists to catch.
+//!
+//! Honesty rules, same as `doctor`'s: this reports that the bytes differ from
+//! the ones `termaxa init` last recorded. It does not claim to know who
+//! changed them or why, and it cannot see a change made before the first
+//! baseline was recorded.
+//!
+//! SHA-256 is implemented here rather than pulled in as a dependency: the
+//! crate has seven, and this is ~70 lines with published test vectors. A
+//! fingerprint people paste into an issue should be a real digest — the
+//! existing `fnv1a_hex8` in `paths.rs` is the right tool for a directory key
+//! and the wrong one for "did my security policy change".
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// What `termaxa init` recorded, and when.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Baseline {
+    pub sha256: String,
+    pub recorded: String,
+}
+
+/// The baseline lives in the state dir, outside the project.
+pub fn baseline_file(state_dir: &Path) -> PathBuf {
+    state_dir.join("policy.fingerprint")
+}
+
+/// Fingerprint a file. `None` if it cannot be read — absence is reported by
+/// the caller, never guessed at.
+pub fn of_file(path: &Path) -> Option<String> {
+    std::fs::read(path).ok().map(|b| sha256_hex(&b))
+}
+
+pub fn read_baseline(state_dir: &Path) -> Option<Baseline> {
+    let raw = std::fs::read_to_string(baseline_file(state_dir)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Record (or re-record) the baseline. Only ever called from `init` —
+/// `doctor` observes and must not create state.
+pub fn record(state_dir: &Path, sha256: &str) -> Result<()> {
+    let (_ms, ts) = crate::audit::now();
+    let baseline = Baseline {
+        sha256: sha256.to_string(),
+        recorded: ts,
+    };
+    if let Some(parent) = baseline_file(state_dir).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(
+        baseline_file(state_dir),
+        serde_json::to_string_pretty(&baseline)?,
+    )?;
+    Ok(())
+}
+
+/// Display form: enough to compare by eye, short enough to sit in a report.
+pub fn short(sha256: &str) -> String {
+    sha256.chars().take(12).collect()
+}
+
+// ---------------------------------------------------------------------------
+// SHA-256 (FIPS 180-4), no dependencies
+// ---------------------------------------------------------------------------
+
+#[rustfmt::skip]
+const K: [u32; 64] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+pub fn sha256_hex(data: &[u8]) -> String {
+    let mut h: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+        0x5be0cd19,
+    ];
+
+    // Pad: 0x80, zeroes to 56 mod 64, then the length in bits, big-endian.
+    let bit_len = (data.len() as u64).wrapping_mul(8);
+    let mut msg = data.to_vec();
+    msg.push(0x80);
+    while msg.len() % 64 != 56 {
+        msg.push(0);
+    }
+    msg.extend_from_slice(&bit_len.to_be_bytes());
+
+    for chunk in msg.chunks_exact(64) {
+        let mut w = [0u32; 64];
+        for (i, word) in w.iter_mut().enumerate().take(16) {
+            let b = &chunk[i * 4..i * 4 + 4];
+            *word = u32::from_be_bytes([b[0], b[1], b[2], b[3]]);
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+
+        let (mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh) =
+            (h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7]);
+
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ ((!e) & g);
+            let t1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let t2 = s0.wrapping_add(maj);
+
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(t2);
+        }
+
+        for (slot, v) in h.iter_mut().zip([a, b, c, d, e, f, g, hh]) {
+            *slot = slot.wrapping_add(v);
+        }
+    }
+
+    h.iter().map(|x| format!("{:08x}", x)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_matches_the_published_vectors() {
+        // FIPS 180-4 / NIST examples.
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(
+            sha256_hex(b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+        );
+        // Multi-block, exercises the length field past one chunk.
+        assert_eq!(
+            sha256_hex(&[b'a'; 1_000_000]),
+            "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0"
+        );
+        // 55/56/57 bytes: the padding boundaries, where an off-by-one in the
+        // "zeroes to 56 mod 64" loop would show up.
+        assert_ne!(sha256_hex(&[b'x'; 55]), sha256_hex(&[b'x'; 56]));
+        assert_ne!(sha256_hex(&[b'x'; 56]), sha256_hex(&[b'x'; 57]));
+    }
+
+    #[test]
+    fn one_changed_byte_changes_the_fingerprint() {
+        let before = sha256_hex(b"version: 1\ndefault: ask\n");
+        let after = sha256_hex(b"version: 1\ndefault: allow\n");
+        assert_ne!(before, after);
+        assert_eq!(short(&before).len(), 12);
+    }
+
+    #[test]
+    fn baseline_roundtrips_through_the_state_dir() {
+        let dir = std::env::temp_dir().join(format!("tmx-fp-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        assert!(
+            read_baseline(&dir).is_none(),
+            "no baseline yet must read as absent, not as a match"
+        );
+
+        record(&dir, "deadbeef").unwrap();
+        let got = read_baseline(&dir).expect("baseline should read back");
+        assert_eq!(got.sha256, "deadbeef");
+        assert!(!got.recorded.is_empty(), "a baseline records when, too");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_baseline_does_not_live_in_the_directory_it_protects() {
+        // The whole point: a clobber of `.termaxa/` must not take the
+        // evidence with it.
+        let state = Path::new("/home/u/.termaxa/projects/proj-abc12345");
+        let f = baseline_file(state);
+        assert!(f.starts_with(state));
+        assert!(
+            !f.to_string_lossy().contains("/proj/.termaxa/"),
+            "baseline must not sit next to policy.yaml: {}",
+            f.display()
+        );
+    }
+
+    #[test]
+    fn of_file_reports_absence_rather_than_guessing() {
+        let missing = std::env::temp_dir().join("tmx-fp-definitely-not-here.yaml");
+        let _ = std::fs::remove_file(&missing);
+        assert!(of_file(&missing).is_none());
+    }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -37,14 +37,9 @@ rules:
   # `termaxa doctor` fingerprints the policy for exactly that reason: what
   # cannot be blocked can at least be noticed.
   #
-  # Reads are denied too, because separating them from writes would mean
-  # enumerating every read command. If you want one back, put it ABOVE this
-  # block — e.g. `- match: "cat .termaxa/*"` / `action: allow`. `termaxa
-  # doctor` prints the rule count, the default and the fingerprint without
-  # touching the file.
-  - match: "*.termaxa*"
-    action: deny
-    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  # Reads are denied too, except for the handful listed below, because
+  # separating reads from writes in general would mean enumerating every read
+  # command. To add one, put it in that group — NOT at the top of the file.
   - match: "*.claude*settings*"
     action: deny
     reason: "Agent hook configuration is off limits — editing it unhooks the gate."
@@ -57,6 +52,46 @@ rules:
   - match: "*.github*hooks*"
     action: deny
     reason: "Agent hook configuration is off limits — editing it unhooks the gate."
+
+  # The policy is an in-repo artifact, reviewable in PRs, and the deny below
+  # would otherwise make that workflow impossible: `git add .termaxa/…`,
+  # `git diff .termaxa/…` and `cp .termaxa/policy.yaml backup.yaml` are all
+  # blocked by it. These exceptions give the workflow back.
+  #
+  # The test for inclusion is that the `.termaxa` path can only be READ, never
+  # written. diff/status/log/show/cat read it; add/commit stage what is
+  # already on disk. `checkout`, `restore` and `config` are absent on purpose
+  # — overwriting the working tree from a ref is exactly what the deny is for,
+  # so restoring a clobbered policy stays a thing you do yourself.
+  #
+  # `cat` and `cp` are anchored on the SOURCE path so the copy can only go the
+  # safe way: `cp .termaxa/policy.yaml backup.yaml` matches,
+  # `cp backup.yaml .termaxa/policy.yaml` does not.
+  #
+  # Position matters twice over. Above the deny, or these never fire. Below
+  # the four denies above, because a trailing `*` swallows a redirect —
+  #     cat .termaxa/policy.yaml > .claude/settings.json
+  # matches `cat .termaxa*` too, and at the top of the file it would allow
+  # that and shadow the rule that exists to stop it.
+  - match: "git diff *.termaxa*"
+    action: allow
+  - match: "git status *.termaxa*"
+    action: allow
+  - match: "git log *.termaxa*"
+    action: allow
+  - match: "git show *.termaxa*"
+    action: allow
+  - match: "git add *.termaxa*"
+    action: allow
+  - match: "git commit *.termaxa*"
+    action: allow
+  - match: "cat .termaxa*"
+    action: allow
+  - match: "cp .termaxa*"
+    action: allow
+  - match: "*.termaxa*"
+    action: deny
+    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
 
   # ---- destructive: hard stops ----
   - match: "git push*--force*"
@@ -488,23 +523,34 @@ mod tests {
 
     /// Schipper review, finding 3: order is load-bearing, so assert the shape
     /// rather than trusting a comment to hold.
+    ///
+    /// The shape is not "every deny precedes every allow". First-match-wins
+    /// exists so an exception can sit above the deny it excepts, and the
+    /// review-workflow allows do exactly that. What must never happen again is
+    /// a BROAD allow above a deny — `git branch*` above `*git branch -D*` was
+    /// the v0.14.1 bug. So an allow that sits above a deny has to be anchored
+    /// at the start of the command AND scoped to the path it is excepting;
+    /// anything looser can swallow the deny below it.
     #[test]
     fn hard_stops_are_reachable_before_the_read_only_allows() {
         let p: crate::policy::Policy = serde_yaml::from_str(STARTER_POLICY).unwrap();
-        let first_allow = p
-            .rules
-            .iter()
-            .position(|r| r.action == crate::policy::Action::Allow)
-            .expect("starter policy has allow rules");
         let last_deny = p
             .rules
             .iter()
             .rposition(|r| r.action == crate::policy::Action::Deny)
             .expect("starter policy has deny rules");
-        assert!(
-            last_deny < first_allow,
-            "a deny rule sits below an allow prefix and can never be reached"
-        );
+        for (i, r) in p.rules.iter().enumerate().take(last_deny) {
+            if r.action != crate::policy::Action::Allow {
+                continue;
+            }
+            assert!(
+                !r.r#match.starts_with('*') && r.r#match.contains(".termaxa"),
+                "rule {i} `{}` is an unanchored allow sitting above a deny — \
+                 it can shadow the rule below it and can never be audited by \
+                 reading the denies alone",
+                r.r#match
+            );
+        }
     }
 
     #[test]

--- a/src/init.rs
+++ b/src/init.rs
@@ -21,6 +21,43 @@ version: 1
 default: ask
 
 rules:
+  # ---- self-defence: the gate's own configuration ----
+  # A gate that will happily rewrite its own rules is a suggestion. These
+  # come FIRST because first-match-wins: `echo *` at the bottom of this file
+  # would otherwise allow
+  #     echo 'default: allow' > .termaxa/policy.yaml
+  # and every command after it is judged by the agent's own policy.
+  #
+  # `*` matches any run of characters, so one rule covers both path
+  # separators: `.termaxa/policy.yaml` and `.termaxa\policy.yaml`.
+  #
+  # This closes the SHELL path only. An agent's file-writing tool (Write,
+  # Edit, the editor's apply-patch) never reaches the hook — the Claude Code
+  # hook is registered with `"matcher": "Bash"` — so no rule here can see it.
+  # `termaxa doctor` fingerprints the policy for exactly that reason: what
+  # cannot be blocked can at least be noticed.
+  #
+  # Reads are denied too, because separating them from writes would mean
+  # enumerating every read command. If you want one back, put it ABOVE this
+  # block — e.g. `- match: "cat .termaxa/*"` / `action: allow`. `termaxa
+  # doctor` prints the rule count, the default and the fingerprint without
+  # touching the file.
+  - match: "*.termaxa*"
+    action: deny
+    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  - match: "*.claude*settings*"
+    action: deny
+    reason: "Agent hook configuration is off limits — editing it unhooks the gate."
+  - match: "*.cursor*hooks*"
+    action: deny
+    reason: "Agent hook configuration is off limits — editing it unhooks the gate."
+  - match: "*.codex*hooks*"
+    action: deny
+    reason: "Agent hook configuration is off limits — editing it unhooks the gate."
+  - match: "*.github*hooks*"
+    action: deny
+    reason: "Agent hook configuration is off limits — editing it unhooks the gate."
+
   # ---- destructive: hard stops ----
   - match: "git push*--force*"
     action: deny
@@ -28,6 +65,12 @@ rules:
   - match: "rm -rf /*"
     action: deny
     reason: "Recursive delete from root is blocked."
+  # GNU rm refuses `rm -rf /` on its own; --no-preserve-root is the one
+  # spelling it obeys. The rule above is named for the command everybody
+  # quotes, this one is named for the command that actually works.
+  - match: "*--no-preserve-root*"
+    action: deny
+    reason: "--no-preserve-root is the only spelling `rm` obeys at `/`. Blocked."
   # Broad recursive-force deletes (any target), Unix + PowerShell + cmd
   # forms. DENY by default: with auto-approving agent UIs, `ask` silently
   # degrades to `allow`. Relax deliberately, per project, if you need to.
@@ -112,11 +155,18 @@ rules:
     action: allow
   - match: "git commit*"
     action: allow
-  - match: "ls*"
+  # A prefix without its trailing space is a prefix, not a command: `ls*`
+  # also matched `lsof` and `lsblk`, `grep*` also matched `grepdiff`.
+  # `cat *` and `echo *` below always had this right. Bare `ls` needs its own
+  # rule because `ls *` requires the space; bare `cat`/`grep` just read stdin,
+  # so they stay on the default.
+  - match: "ls"
+    action: allow
+  - match: "ls *"
     action: allow
   - match: "cat *"
     action: allow
-  - match: "grep*"
+  - match: "grep *"
     action: allow
   - match: "echo *"
     action: allow
@@ -162,6 +212,25 @@ pub fn run(
     } else {
         fs::write(&policy_path, STARTER_POLICY)?;
         println!("✓ wrote .termaxa/policy.yaml (starter policy)");
+    }
+
+    // --- record the policy fingerprint ---
+    // Runs whether we wrote the policy or found one: `termaxa init` is also
+    // how you say "this is the policy I mean" after editing it. The baseline
+    // goes in the state dir under $TERMAXA_HOME, not in `.termaxa/` — a
+    // baseline inside the directory it protects is erased by the same clobber
+    // it exists to catch.
+    //
+    // `resolve_readonly` on purpose: it locates the state dir without creating
+    // `logs/`, `backups/` or triggering the legacy state migration. Failure
+    // here is reported, not fatal — a missing fingerprint costs you a
+    // diagnostic, not the gate.
+    match crate::paths::resolve_readonly(dir)
+        .and_then(|p| record_fingerprint(&p.state_dir, &policy_path))
+    {
+        Ok(Some(short)) => println!("✓ recorded policy fingerprint {}", short),
+        Ok(None) => {}
+        Err(e) => println!("! could not record policy fingerprint: {}", e),
     }
 
     // --- detect agent harnesses ---
@@ -276,6 +345,20 @@ pub fn run(
 
     println!("\nDone. Try:  termaxa check \"git push --force origin main\"");
     Ok(())
+}
+
+/// Hash the policy and store the baseline in the project's state dir.
+/// Returns the short form for display, or `None` if the policy could not be
+/// read (which `doctor` will report on its own terms).
+///
+/// Takes the state dir rather than resolving it, so the test does not have to
+/// go through `$TERMAXA_HOME`.
+fn record_fingerprint(state_dir: &Path, policy_path: &Path) -> Result<Option<String>> {
+    let Some(hash) = crate::fingerprint::of_file(policy_path) else {
+        return Ok(None);
+    };
+    crate::fingerprint::record(state_dir, &hash)?;
+    Ok(Some(crate::fingerprint::short(&hash)))
 }
 
 fn install_claude_hook(dir: &Path) -> Result<()> {
@@ -422,6 +505,39 @@ mod tests {
             last_deny < first_allow,
             "a deny rule sits below an allow prefix and can never be reached"
         );
+    }
+
+    #[test]
+    fn init_records_a_baseline_the_policy_directory_cannot_erase() {
+        let dir = std::env::temp_dir().join(format!("tmx-init-fp-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let project = dir.join("proj");
+        let state = dir.join("home").join("projects").join("proj-abc12345");
+        fs::create_dir_all(project.join(".termaxa")).unwrap();
+        fs::create_dir_all(&state).unwrap();
+        let policy = project.join(".termaxa").join("policy.yaml");
+        fs::write(&policy, STARTER_POLICY).unwrap();
+
+        let short = record_fingerprint(&state, &policy)
+            .unwrap()
+            .expect("a readable policy must fingerprint");
+        assert_eq!(short.len(), 12);
+
+        // The baseline lives outside the directory it protects: `rm -rf
+        // .termaxa/` must not take the evidence with it.
+        let baseline = crate::fingerprint::baseline_file(&state);
+        assert!(baseline.is_file());
+        assert!(
+            !baseline.starts_with(&project),
+            "baseline must not live in the project: {}",
+            baseline.display()
+        );
+
+        // Re-running init on an unchanged policy records the same hash.
+        let again = record_fingerprint(&state, &policy).unwrap().unwrap();
+        assert_eq!(short, again);
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -171,9 +171,12 @@ pub fn classify_segment(segment: &str) -> Option<Intent> {
     if first == "git" {
         let sub = lc.get(1).map(|s| s.as_str()).unwrap_or("");
         let hit = match sub {
-            "push" => lc
-                .iter()
-                .any(|t| t == "--force" || t == "-f" || t == "--force-with-lease"),
+            // A leading `+` on a refspec IS a force push — `git push origin
+            // +main` and `git push origin --force main` do the same thing,
+            // and `+` is the only meaning `git push` gives that character.
+            "push" => lc.iter().any(|t| {
+                t == "--force" || t == "-f" || t == "--force-with-lease" || t.starts_with('+')
+            }),
             "reset" => lc.iter().any(|t| t == "--hard"),
             "clean" => lc
                 .iter()
@@ -509,6 +512,25 @@ mod tests {
             classify_command("git branch -D feature"),
             Some(Intent::GitDestructive)
         );
+    }
+
+    #[test]
+    fn a_plus_refspec_is_a_force_push() {
+        // `git push origin +main` overwrites the remote branch exactly as
+        // `--force` does; the flag spelling was the only one the breaker
+        // could see.
+        for cmd in [
+            "git push origin +main",
+            "git push origin +main:main",
+            "git push origin +refs/heads/main:refs/heads/main",
+            "git push origin +HEAD:production",
+        ] {
+            assert_eq!(classify_command(cmd), Some(Intent::GitDestructive), "{cmd}");
+        }
+        // A plain push is still a plain push, and `+` outside `git push`
+        // means nothing here.
+        assert_eq!(classify_command("git push origin main:main"), None);
+        assert_eq!(classify_command("git log --format=+%h"), None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod backup;
 mod context;
 mod delete;
 mod doctor;
+mod fingerprint;
 mod hook;
 mod init;
 mod intent;

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -329,4 +329,89 @@ rules:
             Action::Deny
         );
     }
+
+    #[test]
+    fn the_starter_policy_defends_its_own_configuration() {
+        let p = Policy::builtin().expect("built-in starter policy must parse");
+
+        // The command from the review: `echo *` sat below the denies and
+        // allowed this outright, and everything after it was judged by a
+        // policy the agent had written.
+        let d = p.evaluate_command("echo 'default: allow' > .termaxa/policy.yaml");
+        assert_eq!(d.action, Action::Deny);
+        assert_eq!(d.matched_rule.as_deref(), Some("*.termaxa*"));
+
+        for cmd in [
+            "cat /tmp/mine.yaml > .termaxa/policy.yaml",
+            "rm -f .termaxa/policy.yaml",
+            "sed -i 's/deny/allow/g' .termaxa/policy.yaml",
+            "mv /tmp/mine.yaml .termaxa/policy.yaml",
+            "copy C:\\tmp\\mine.yaml .termaxa\\policy.yaml",
+            "echo '{}' > .claude/settings.json",
+            "rm .cursor/hooks.json",
+            "mv .codex/hooks.json /tmp/",
+            "rm .github/hooks/hooks.json",
+        ] {
+            assert_eq!(
+                p.evaluate_command(cmd).action,
+                Action::Deny,
+                "must not be able to edit the gate: {cmd}"
+            );
+        }
+
+        // The self-defence block has to sit ABOVE the read-only allows, or
+        // first-match-wins hands it back. Prove the ordering, not just the
+        // verdict, by checking a command that both blocks match.
+        let idx_self = p
+            .rules
+            .iter()
+            .position(|r| r.r#match == "*.termaxa*")
+            .expect("self-defence rule must exist");
+        let idx_echo = p
+            .rules
+            .iter()
+            .position(|r| r.r#match == "echo *")
+            .expect("echo rule must exist");
+        assert!(
+            idx_self < idx_echo,
+            "self-defence must be reachable: it sits at {idx_self}, `echo *` at {idx_echo}"
+        );
+    }
+
+    #[test]
+    fn no_preserve_root_is_denied_by_name() {
+        let p = Policy::builtin().expect("built-in starter policy must parse");
+        // GNU rm refuses a bare `rm -rf /`. This is the spelling it obeys,
+        // and it does not contain the substring `rm -rf` that the famous
+        // rule matches on.
+        assert!(!"rm --no-preserve-root -rf /".contains("rm -rf"));
+        for cmd in [
+            "rm --no-preserve-root -rf /",
+            "sudo rm --no-preserve-root -rf /",
+            "rm -r --no-preserve-root /",
+        ] {
+            assert_eq!(p.evaluate_command(cmd).action, Action::Deny, "{cmd}");
+        }
+    }
+
+    #[test]
+    fn read_only_prefixes_do_not_swallow_neighbouring_commands() {
+        let p = Policy::builtin().expect("built-in starter policy must parse");
+
+        // Still allowed — including bare `ls`, which needs its own rule
+        // because `ls *` requires the space.
+        for cmd in ["ls", "ls -la src", "grep -rn fn src", "cat Cargo.toml"] {
+            assert_eq!(p.evaluate_command(cmd).action, Action::Allow, "{cmd}");
+        }
+
+        // Different programs that merely start with the same letters. `ls*`
+        // and `grep*` used to allow all of these.
+        for cmd in ["lsof -i :5432", "lsblk", "lsattr -R /", "grepdiff --help"] {
+            assert_ne!(
+                p.evaluate_command(cmd).action,
+                Action::Allow,
+                "a prefix is not a command: {cmd}"
+            );
+        }
+    }
 }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -379,6 +379,93 @@ rules:
     }
 
     #[test]
+    fn reviewing_the_policy_in_a_pr_still_works() {
+        let p = Policy::builtin().expect("built-in starter policy must parse");
+        // The README calls the policy an in-repo artifact, "reviewable in
+        // PRs". These are the commands that workflow is made of; a blanket
+        // deny on `*.termaxa*` made every one of them impossible.
+        for cmd in [
+            "git add .termaxa/policy.yaml",
+            "git diff .termaxa/policy.yaml",
+            "git diff --cached .termaxa/policy.yaml",
+            "git status .termaxa/",
+            "git log --oneline .termaxa/policy.yaml",
+            "git show HEAD:.termaxa/policy.yaml",
+            "git commit -m \"tighten the policy\" .termaxa/policy.yaml",
+            "cat .termaxa/policy.yaml",
+            "cp .termaxa/policy.yaml backup.yaml",
+            // One pattern covers both separators, same as the deny it excepts.
+            "git diff .termaxa\\policy.yaml",
+        ] {
+            assert_eq!(
+                p.evaluate_command(cmd).action,
+                Action::Allow,
+                "the documented review workflow must not be blocked: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_review_exceptions_only_go_one_direction() {
+        let p = Policy::builtin().expect("built-in starter policy must parse");
+        // Every exception above the deny is a read. Anything that can put
+        // bytes INTO the policy stays denied, including the git verbs whose
+        // job is to overwrite the working tree from a ref.
+        for cmd in [
+            "git checkout .termaxa/policy.yaml",
+            "git checkout evil-branch -- .termaxa/policy.yaml",
+            "git restore .termaxa/policy.yaml",
+            "git config core.hooksPath .termaxa/evil",
+            "cp backup.yaml .termaxa/policy.yaml",
+            "cat backup.yaml > .termaxa/policy.yaml",
+            "tee .termaxa/policy.yaml",
+        ] {
+            assert_eq!(
+                p.evaluate_command(cmd).action,
+                Action::Deny,
+                "writes into the gate's config must stay denied: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_review_exception_cannot_shadow_the_hook_config_denies() {
+        let p = Policy::builtin().expect("built-in starter policy must parse");
+        // A trailing `*` swallows a redirect, so `cat .termaxa*` matches
+        // `cat .termaxa/policy.yaml > .claude/settings.json` as well. At the
+        // top of the file these allows would shadow the denies that exist to
+        // stop exactly that. They sit below them instead.
+        for cmd in [
+            "cat .termaxa/policy.yaml > .claude/settings.json",
+            "git diff .termaxa/policy.yaml > .claude/settings.json",
+            "git add .termaxa/policy.yaml > .cursor/hooks.json",
+            "cp .termaxa/policy.yaml .codex/hooks.json",
+        ] {
+            assert_eq!(
+                p.evaluate_command(cmd).action,
+                Action::Deny,
+                "an exception must not become a way through: {cmd}"
+            );
+        }
+
+        // Prove the ordering, not just the verdict.
+        let idx = |pat: &str| {
+            p.rules
+                .iter()
+                .position(|r| r.r#match == pat)
+                .unwrap_or_else(|| panic!("rule `{pat}` must exist"))
+        };
+        assert!(
+            idx("*.claude*settings*") < idx("cat .termaxa*"),
+            "the hook-config denies must outrank the review exceptions"
+        );
+        assert!(
+            idx("cat .termaxa*") < idx("*.termaxa*"),
+            "the review exceptions must outrank the deny they except"
+        );
+    }
+
+    #[test]
     fn no_preserve_root_is_denied_by_name() {
         let p = Policy::builtin().expect("built-in starter policy must parse");
         // GNU rm refuses a bare `rm -rf /`. This is the spelling it obeys,


### PR DESCRIPTION
Follow-up to the review. Four changes, each with a test named for the case, branched off `main`.

`cargo test` 97 → 108 passed, 0 failed. `cargo fmt --check` and `cargo clippy --all-targets` clean.

---

### 1. The gate defends its own configuration (finding 1)

The starter policy had no rule about `.termaxa/` or the agent hook configs, so

```
echo 'default: allow' > .termaxa/policy.yaml
```

matched `echo *` in the read-only block and was **allowed**. A cleanup script hits this without any intent to evade — which is why this one isn't threat-model dependent.

Adds a self-defence block at the **top** of the rules. Position is load-bearing, and the test asserts the ordering rather than trusting the comment to hold:

```yaml
- match: "*.termaxa*"
- match: "*.claude*settings*"
- match: "*.cursor*hooks*"
- match: "*.codex*hooks*"
- match: "*.github*hooks*"
```

One pattern per target covers both path separators, because `*` matches `/` and `\` alike — `copy C:\tmp\mine.yaml .termaxa\policy.yaml` is denied by the same rule as the Unix form.

**Reads are denied too, and that's a judgement call worth your veto.** Separating reads from writes means enumerating every read command, and an unlisted read failing closed is loud rather than silent. The cost is that an agent can no longer `cat .termaxa/policy.yaml` to see what it's up against; `termaxa doctor` prints the rule count, the default and the fingerprint without touching the file. The comment in `STARTER_POLICY` says exactly how to add a read back, above the block.

This closes the **shell** path only. Your sharper half stands: an agent's file-writing tool never reaches the hook, since the Claude Code hook is registered with `"matcher": "Bash"`. Hence:

### 2. Policy fingerprinting

`termaxa init` records a SHA-256 of the policy; `termaxa doctor` reports it and says whether it changed. What can't be blocked can at least be noticed.

```
Policy
✓ /path/to/.termaxa/policy.yaml
  0 rule(s), default allow
  fingerprint 2b478940cbe7
  ! CHANGED since 2026-08-09T23:17:00Z (was 815a72307b52)
    if you made this change, re-record it: `termaxa init`
    if you did not, something edited the gate's own rules —
    agent file-writing tools bypass the hook entirely (matcher: Bash)
```

Three decisions in here, all reversible:

- **The baseline lives in the state dir under `$TERMAXA_HOME`, not in `.termaxa/`.** A baseline inside the directory it protects is erased by the same clobber it exists to catch. There's a test asserting the path property, because it's the kind of thing that gets "tidied" later.
- **`doctor` only ever reads.** A diagnostic that records the value it's checking always reports "unchanged", so re-recording after a deliberate edit is `init`'s job. This also keeps the module's existing rule — it never creates state — intact; `record_fingerprint` goes through `resolve_readonly`, so no `logs/`, no `backups/`, no legacy migration as a side effect.
- **SHA-256 is implemented in `src/fingerprint.rs` rather than added as a dependency.** ~70 lines, tested against the FIPS 180-4 vectors including the 1,000,000-`a` multi-block case and the 55/56/57-byte padding boundaries. A fingerprint people paste into an issue should be a real digest — `fnv1a_hex8` is the right tool for a directory key and the wrong one for "did my security policy change". If you'd rather not carry the code, swapping it for `fnv1a` is one line.

Honesty limits, stated in the module doc: this reports that the bytes differ from the ones last recorded. It doesn't know who changed them, and it can't see a change made before the first baseline existed.

### 3. `ls*` and `grep*` (finding 8)

A prefix without its trailing space is a prefix, not a command: `ls*` also matched `lsof`, `lsblk` and `lsattr`; `grep*` also matched `grepdiff`. Now `ls`, `ls *` and `grep *`.

Bare `ls` needs its own rule because `ls *` requires the space. Bare `cat` and `grep` just read stdin, so they stay on the default — which is what `cat *` already did.

### 4. `--no-preserve-root` (finding 3)

`rm -rf /*` is named for the command everybody quotes. GNU rm refuses that one; `--no-preserve-root` is the spelling it obeys, and `rm --no-preserve-root -rf /` does not contain the substring `rm -rf`. The test asserts that non-containment explicitly, so the reason the old rule missed it is on the record.

### 5. `git push +refspec` (finding 5)

`git push origin +main` overwrites the remote exactly as `--force` does, and `+` has no other meaning in a push argument. The classifier now treats a leading `+` as a force push, so the breaker counts it. Verified end to end — the audit entry reads `decision: ask | intent: git-destructive`.

---

### Not in this PR

**Intent doesn't feed the allow→ask ladder.** Checking your correction about `default: allow` turned up something adjacent. You're right that `rm -rf /` goes deny → ask rather than deny → allow, and I'd overstated "every command after the overwrite is ungoverned". But the escalation comes from `context.rs:31` grepping for five literal substrings — `--force`, `-f `, `--hard`, `--no-verify`, `-rf` — not from anything that understands the command. Running the scenario:

```
rm -rf /                        ask      file-delete
rm -fr /                        ALLOW    file-delete
rm -r /home/tim                 ALLOW    file-delete
dd if=/dev/zero of=/dev/sda     ALLOW    —
git branch -D main              ALLOW    git-destructive
terraform destroy -auto-approve ALLOW    infra-destroy
find . -delete                  ALLOW    file-delete
14 commands: 3 escalated to ask, 11 silently ALLOWED
```

The `intent` column is the interesting part: `classify_command` recognises six of the eleven. It knows `rm -fr /` is a file delete. Its answer is wired only into the breaker, and the breaker is gated on `decision.action == Ask` (`hook.rs:407`), so on a blanket-allow policy it's discarded. Wiring intent into the escalation ladder would make your claim true as stated.

That's a behaviour change across every policy, not a bounded fix, and it's adjacent to the tokenization work you're keeping for v0.15 — so it's yours to call, not something to smuggle in here.

**Also regenerates `examples/policy.yaml`** from `STARTER_POLICY`, as its test requires.
