### PR TITLE
Make the isolated way to write a test the only obvious way

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,8 @@ mod preview;
 mod report;
 mod runner;
 mod shell;
+#[cfg(test)]
+mod testutil;
 mod ui;
 
 use anyhow::{bail, Result};

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -287,26 +287,7 @@ fn copy_recursive(src: &Path, dst: &Path) -> Result<()> {
 mod tests {
     use super::*;
 
-    /// `TERMAXA_HOME` and the process cwd are per-PROCESS, and cargo runs the
-    /// tests in one process on several threads. Three tests here mutate one or
-    /// both, so without a lock they interleave: a test that never sets
-    /// `TERMAXA_HOME` picks up a sibling's value, resolves its state dir inside
-    /// the sibling's temp tree, and `create_dir_all` races the sibling's
-    /// `remove_dir_all` of that tree. The failure surfaces as
-    ///
-    ///   resolve_from should find the project policy: No such file or
-    ///   directory (os error 2)
-    ///
-    /// which reads like a missing policy and is really a torn directory.
-    /// It went red on macOS first only because that runner lost the race first.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    /// Take the lock for a test that touches process-global state. Poison is
-    /// deliberately ignored: if one test panics while holding it, the others
-    /// should report their own verdicts rather than all fail as collateral.
-    fn env_guard() -> std::sync::MutexGuard<'static, ()> {
-        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
-    }
+    use crate::testutil::TestEnv;
 
     #[test]
     fn hash_key_stable_across_path_representations() {
@@ -319,22 +300,9 @@ mod tests {
 
     #[test]
     fn resolve_from_uses_given_root_not_process_cwd() {
-        use std::fs;
-        let _lock = env_guard();
-        // Build a temp project with a policy, in a dir that is NOT the process cwd.
-        let base = std::env::temp_dir().join(format!("tmx-cwdtest-{}", std::process::id()));
-        let proj = base.join("proj");
-        fs::create_dir_all(proj.join(".termaxa")).unwrap();
-        fs::write(
-            proj.join(".termaxa").join("policy.yaml"),
-            "version: 1\ndefault: ask\nrules: []\n",
-        )
-        .unwrap();
-        // Point at this test's own tree. Without it the state dir lands in the
-        // developer's real ~/.termaxa (verified: the run creates
-        // ~/.termaxa/projects/proj-<hash>/logs there), or in a sibling test's
-        // temp tree if one has already exported the variable.
-        std::env::set_var("TERMAXA_HOME", base.join("home"));
+        let env = TestEnv::new("cwdtest");
+        // A project with a policy, in a dir that is NOT the process cwd.
+        let proj = env.project("proj");
 
         // Resolve FROM the project dir explicitly (simulating payload.cwd),
         // while the actual process cwd is elsewhere.
@@ -353,12 +321,10 @@ mod tests {
         // tree and this fails the same way every run, instead of failing once
         // in a hundred on whichever runner happens to lose the race.
         assert!(
-            paths.state_dir.starts_with(&base),
+            paths.state_dir.starts_with(env.home()),
             "state must resolve under this test's own TERMAXA_HOME, got {}",
             paths.state_dir.display()
         );
-
-        let _ = fs::remove_dir_all(&base);
     }
 
     #[test]
@@ -378,24 +344,16 @@ mod tests {
         // Regression: a hook spawned from the WRONG directory must still find the
         // project's policy via the explicit start dir (the agent's payload cwd).
         // This is the exact Cursor failure mode: process cwd != project dir.
-        use std::fs;
-        let _lock = env_guard();
-        let tmp = std::env::temp_dir().join(format!("tmx-cwd-test-{}", std::process::id()));
-        let proj = tmp.join("proj");
+        let mut env = TestEnv::new("cwd-test");
+        let proj = env.project("proj");
         let aegis = proj.join(".termaxa");
-        fs::create_dir_all(&aegis).unwrap();
-        fs::write(
-            aegis.join("policy.yaml"),
-            "version: 1\ndefault: ask\nrules: []\n",
-        )
-        .unwrap();
-        std::env::set_var("TERMAXA_HOME", tmp.join("home"));
 
-        // Simulate the agent spawning us from somewhere unrelated:
-        let elsewhere = tmp.join("elsewhere");
-        fs::create_dir_all(&elsewhere).unwrap();
-        let previous_cwd = std::env::current_dir().ok();
-        std::env::set_current_dir(&elsewhere).unwrap();
+        // Simulate the agent spawning us from somewhere unrelated. The guard
+        // remembers where the process was and steps back out before it deletes
+        // the tree, so nothing after this test inherits a deleted cwd.
+        let elsewhere = env.root().join("elsewhere");
+        std::fs::create_dir_all(&elsewhere).unwrap();
+        env.chdir(&elsewhere);
 
         // resolve() (process cwd = elsewhere) must FAIL to find the policy...
         assert!(
@@ -409,14 +367,6 @@ mod tests {
             "explicit resolve_from(project cwd) must find the policy"
         );
         assert_eq!(r.unwrap().policy_file(), aegis.join("policy.yaml"));
-
-        // Step out before deleting the tree. Leaving the process cwd inside a
-        // directory that no longer exists is a landmine for every test that
-        // runs after this one: on Unix `getcwd` then fails outright.
-        if let Some(cwd) = previous_cwd {
-            let _ = std::env::set_current_dir(cwd);
-        }
-        let _ = fs::remove_dir_all(&tmp);
     }
 
     #[test]
@@ -425,17 +375,8 @@ mod tests {
         // `termaxa doctor` runs on projects that have never executed anything;
         // if resolving created logs/ and backups/, the report would describe
         // directories it had just invented.
-        use std::fs;
-        let _lock = env_guard();
-        let tmp = std::env::temp_dir().join(format!("tmx-ro-{}", std::process::id()));
-        let proj = tmp.join("proj");
-        fs::create_dir_all(proj.join(".termaxa")).unwrap();
-        fs::write(
-            proj.join(".termaxa").join("policy.yaml"),
-            "version: 1\ndefault: ask\nrules: []\n",
-        )
-        .unwrap();
-        std::env::set_var("TERMAXA_HOME", tmp.join("home"));
+        let env = TestEnv::new("ro");
+        let proj = env.project("proj");
 
         let p = resolve_readonly(&proj).expect("must resolve without creating anything");
         assert!(
@@ -451,8 +392,6 @@ mod tests {
         let p2 = resolve_from(&proj).expect("resolve_from must succeed");
         assert!(p2.state_dir.join("logs").is_dir());
         assert!(p2.state_dir.join("backups").is_dir());
-
-        let _ = fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -1,0 +1,303 @@
+//! Test-only isolation for the process-global state this suite reaches into.
+//!
+//! `TERMAXA_HOME` and the working directory belong to the PROCESS, and cargo
+//! runs tests as threads inside one process. Three tests in `paths.rs` used to
+//! set them by hand and delete the trees they pointed at, which produced a
+//! flake that read as a missing policy (#17) and, on every green run in
+//! between, quietly wrote state into the developer's real `~/.termaxa`.
+//!
+//! Both halves of that came from the same thing: setting up a test correctly
+//! took knowledge the test itself did not carry. So the safe path is the only
+//! path here. `TestEnv::new` takes the lock, points `TERMAXA_HOME` at a tree
+//! this test alone owns, and on drop puts the cwd and the variable back,
+//! removes the tree, and fails the test if state landed anywhere else.
+//!
+//! ```ignore
+//! let env = TestEnv::new("my-case");
+//! let proj = env.project("proj");        // <root>/proj/.termaxa/policy.yaml
+//! let paths = crate::paths::resolve_from(&proj)?;
+//! ```
+//!
+//! One guard per test. `std::sync::Mutex` is not reentrant, so a second
+//! `TestEnv::new` while one is alive deadlocks rather than failing.
+
+use std::collections::BTreeSet;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Mutex, MutexGuard};
+
+static GLOBAL_ENV: Mutex<()> = Mutex::new(());
+static SEQ: AtomicUsize = AtomicUsize::new(0);
+
+/// Take the lock, tolerating poisoning: if a test panicked while holding it,
+/// the rest should report their own verdicts instead of failing as collateral
+/// and hiding which one actually broke.
+fn lock() -> MutexGuard<'static, ()> {
+    GLOBAL_ENV.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// The real `~/.termaxa/projects`, ignoring any `TERMAXA_HOME` override.
+///
+/// Deliberately not `paths::home_base()`: this has to name the directory the
+/// override is protecting, which is exactly the one `home_base` stops
+/// returning the moment the guard does its job.
+fn real_state_root() -> Option<PathBuf> {
+    let home = std::env::var_os("USERPROFILE").or_else(|| std::env::var_os("HOME"))?;
+    Some(PathBuf::from(home).join(".termaxa").join("projects"))
+}
+
+fn listing(dir: &Path) -> BTreeSet<OsString> {
+    match std::fs::read_dir(dir) {
+        Ok(entries) => entries.flatten().map(|e| e.file_name()).collect(),
+        // Absent reads as empty on purpose: a directory that does not exist
+        // yet and one that is empty are the same starting point, and the
+        // comparison at drop is what has to notice the difference.
+        Err(_) => BTreeSet::new(),
+    }
+}
+
+/// Names present at drop that were not present at construction.
+fn arrivals(before: &BTreeSet<OsString>, after: &BTreeSet<OsString>) -> Vec<OsString> {
+    after.difference(before).cloned().collect()
+}
+
+pub struct TestEnv {
+    /// `None` only for the tests in this module that already hold the lock in
+    /// order to observe the guard without racing it.
+    _lock: Option<MutexGuard<'static, ()>>,
+    root: PathBuf,
+    previous_home: Option<OsString>,
+    previous_cwd: Option<PathBuf>,
+    watch: Option<(PathBuf, BTreeSet<OsString>)>,
+}
+
+impl TestEnv {
+    /// Serialise against every other `TestEnv`, then claim a fresh tree.
+    ///
+    /// `label` only has to be readable in `/tmp` while a test is running; the
+    /// pid and a counter make the path unique, so two tests sharing a label
+    /// still get separate trees.
+    pub fn new(label: &str) -> Self {
+        Self::build(Some(lock()), label)
+    }
+
+    fn build(guard: Option<MutexGuard<'static, ()>>, label: &str) -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "tmx-{}-{}-{}",
+            label,
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("test root must be creatable");
+
+        let previous_home = std::env::var_os("TERMAXA_HOME");
+        std::env::set_var("TERMAXA_HOME", root.join("home"));
+
+        let watch = real_state_root().map(|dir| {
+            let before = listing(&dir);
+            (dir, before)
+        });
+
+        Self {
+            _lock: guard,
+            root,
+            previous_home,
+            previous_cwd: None,
+            watch,
+        }
+    }
+
+    /// The tree this test owns. Everything it writes belongs under here.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Where `TERMAXA_HOME` points for the life of this guard.
+    pub fn home(&self) -> PathBuf {
+        self.root.join("home")
+    }
+
+    /// A project directory with a minimal policy, ready for `resolve_from`.
+    pub fn project(&self, name: &str) -> PathBuf {
+        let proj = self.root.join(name);
+        std::fs::create_dir_all(proj.join(".termaxa")).expect("project dir must be creatable");
+        std::fs::write(
+            proj.join(".termaxa").join("policy.yaml"),
+            "version: 1\ndefault: ask\nrules: []\n",
+        )
+        .expect("policy must be writable");
+        proj
+    }
+
+    /// Move the process into `dir`, remembering where it came from.
+    ///
+    /// The original is captured once, so a test may step through several
+    /// directories and still land back where it started.
+    pub fn chdir(&mut self, dir: &Path) {
+        if self.previous_cwd.is_none() {
+            self.previous_cwd = std::env::current_dir().ok();
+        }
+        std::env::set_current_dir(dir).expect("cwd must be settable");
+    }
+
+    /// Watch a stand-in directory instead of the real one, so the check at
+    /// drop can be tested without writing to anybody's home.
+    #[cfg(test)]
+    fn watch_instead(&mut self, dir: PathBuf) {
+        let before = listing(&dir);
+        self.watch = Some((dir, before));
+    }
+}
+
+impl Drop for TestEnv {
+    fn drop(&mut self) {
+        // Step out before deleting: leaving the process in a directory that no
+        // longer exists breaks `getcwd` for everything scheduled after it.
+        if let Some(cwd) = self.previous_cwd.take() {
+            let _ = std::env::set_current_dir(cwd);
+        }
+        match self.previous_home.take() {
+            Some(previous) => std::env::set_var("TERMAXA_HOME", previous),
+            // Restoring absence matters as much as restoring a value: a
+            // variable left pointing at a deleted tree is the original bug.
+            None => std::env::remove_var("TERMAXA_HOME"),
+        }
+
+        let strays = self.watch.take().map(|(dir, before)| {
+            let found = arrivals(&before, &listing(&dir));
+            (dir, found)
+        });
+        let _ = std::fs::remove_dir_all(&self.root);
+
+        // Never assert into an unwind: a panicking Drop during a panic aborts
+        // the process, and the test's own failure is the one worth reading.
+        if std::thread::panicking() {
+            return;
+        }
+        if let Some((dir, found)) = strays {
+            assert!(
+                found.is_empty(),
+                "state landed outside this test's tree, in {}: {:?}\n\
+                 The suite must not write where the product writes. If this is \
+                 a new code path, route it through TERMAXA_HOME rather than \
+                 widening this check.",
+                dir.display(),
+                found
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The anti-rot test. If `TestEnv` ever stops exporting `TERMAXA_HOME`,
+    /// every test that trusts it keeps passing while writing to the real home
+    /// again, which is precisely how the pollution went unnoticed for months.
+    /// This is the one assertion that fails when the helper becomes a no-op.
+    #[test]
+    fn the_guard_actually_redirects_state() {
+        let env = TestEnv::new("isolates");
+        let paths = crate::paths::resolve_from(&env.project("proj")).expect("must resolve");
+        assert!(
+            paths.state_dir.starts_with(env.home()),
+            "state must land under the guard's home, got {}",
+            paths.state_dir.display()
+        );
+        assert!(paths.state_dir.join("logs").is_dir());
+    }
+
+    #[test]
+    fn the_guard_puts_everything_back() {
+        // Hold the lock across the whole test, so nothing else can move the
+        // cwd or the variable between the guard dropping and the assertions.
+        // The inner guard is built without taking it again, since a std Mutex
+        // is not reentrant.
+        let _outer = lock();
+        let home_before = std::env::var_os("TERMAXA_HOME");
+        let cwd_before = std::env::current_dir().expect("a cwd to return to");
+
+        let root = {
+            let mut env = TestEnv::build(None, "restores");
+            let proj = env.project("proj");
+            env.chdir(&proj);
+            assert_ne!(
+                std::env::current_dir().ok(),
+                Some(cwd_before.clone()),
+                "chdir must actually move the process"
+            );
+            assert_eq!(
+                std::env::var_os("TERMAXA_HOME"),
+                Some(env.home().into_os_string()),
+                "the guard must export its own home while it is alive"
+            );
+            env.root().to_path_buf()
+        };
+
+        assert!(!root.exists(), "the guard must remove its own tree");
+        assert_eq!(std::env::var_os("TERMAXA_HOME"), home_before);
+        assert_eq!(std::env::current_dir().ok(), Some(cwd_before));
+    }
+
+    #[test]
+    fn the_guard_fails_loudly_when_state_lands_outside_its_tree() {
+        let _outer = lock();
+        let decoy = std::env::temp_dir().join(format!("tmx-decoy-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&decoy);
+        std::fs::create_dir_all(&decoy).expect("decoy must be creatable");
+
+        // The guard reports by panicking, so the expected failure would print
+        // a backtrace-looking wall of text on a passing run. Silence just this
+        // one, and put the real hook back.
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let outcome = std::panic::catch_unwind({
+            let decoy = decoy.clone();
+            move || {
+                let mut env = TestEnv::build(None, "stray");
+                env.watch_instead(decoy.clone());
+                // Stand in for a test resolving into the real ~/.termaxa.
+                std::fs::create_dir_all(decoy.join("proj-deadbeef")).unwrap();
+                drop(env);
+            }
+        });
+        std::panic::set_hook(hook);
+
+        let _ = std::fs::remove_dir_all(&decoy);
+        assert!(
+            outcome.is_err(),
+            "a test that writes outside its own tree must fail, not pass quietly"
+        );
+    }
+
+    #[test]
+    fn the_check_only_reports_what_arrived() {
+        let names =
+            |xs: &[&str]| -> BTreeSet<OsString> { xs.iter().map(|s| OsString::from(*s)).collect() };
+        // Pre-existing entries are somebody else's, and a test that removes
+        // one is doing something worse than the check is looking for, but it
+        // is not what this check is for.
+        assert!(arrivals(&names(&["a", "b"]), &names(&["a", "b"])).is_empty());
+        assert!(arrivals(&names(&["a", "b"]), &names(&["a"])).is_empty());
+        assert_eq!(
+            arrivals(&names(&["a"]), &names(&["a", "proj-deadbeef"])),
+            vec![OsString::from("proj-deadbeef")]
+        );
+    }
+
+    #[test]
+    fn each_guard_gets_a_tree_of_its_own() {
+        let first = TestEnv::new("unique");
+        let first_root = first.root().to_path_buf();
+        drop(first);
+        let second = TestEnv::new("unique");
+        assert_ne!(
+            first_root,
+            second.root(),
+            "two guards sharing a label must not share a tree"
+        );
+    }
+}


### PR DESCRIPTION
Follow-up to #17, off `de322b2`. All three points of the shape, plus the stray check you asked for.

`TestEnv` takes the lock, points `TERMAXA_HOME` at a tree it alone owns, and on drop restores the cwd, restores `TERMAXA_HOME` to its previous value **or to absent**, removes the tree, and fails the test if state landed anywhere else. The three `paths.rs` tests are rewritten onto it and lose their setup entirely:

```rust
let env = TestEnv::new("ro");
let proj = env.project("proj");
let p = resolve_readonly(&proj).expect("must resolve without creating anything");
```

That is the whole of it now. No temp path, no `set_var`, no cleanup, no lock to remember.

## The stray check, verified against the real home

Your addition is the part I spent the most time on, because a decoy directory proves the mechanism and not the thing it is for. So I checked it end to end: removed the `set_var` from the guard and ran the suite.

```
state landed outside this test's tree, in /root/.termaxa/projects: ["proj-296e3b9d"]
state landed outside this test's tree, in /root/.termaxa/projects: ["proj-dec8077b"]
```

The one worth pointing at is `resolve_from_uses_explicit_dir_not_process_cwd`. It asserts nothing about home, has no `starts_with` guard of its own, and would have passed. The guard caught it alone. That is exactly the case that went unnoticed for months, and it now fails the same way every run.

## Both claims checked by breaking them

A helper that rots into a no-op is worse than no helper, as you said, so neither claim rests on reading the code:

| mutation | what fails |
| --- | --- |
| drop the `set_var` from the guard | `the_guard_actually_redirects_state`, naming the real path it fell back to |
| silence the check in `Drop` | `the_guard_fails_loudly_when_state_lands_outside_its_tree` |

## Four details that are deliberate

- **`Drop` returns early while the thread is panicking.** A panicking `Drop` during a panic aborts the process, and the test's own failure is the one worth reading, not the guard's opinion about it.
- **`TERMAXA_HOME` is restored to absent when it was absent**, not just overwritten. A variable left pointing at a deleted tree is the #17 bug, and restoring only non-empty values would rebuild it.
- **Poison is ignored on the lock.** Same reason as before.
- **Two tests build the guard without taking the lock**, because they hold it themselves to watch the guard work without racing it. A std `Mutex` is not reentrant, so a second `TestEnv::new` inside one would deadlock rather than fail; that is called out in the module docs.

## Something I found while measuring, not in this PR

Checking that the guard cleans up after itself, I cleared `/tmp` and ran the suite once. The guard leaves nothing. Nine other things remain:

```
tmx-intent-test-<pid>-ThreadId(49..64)/     7 directories
tmx-intent-pol-<pid>-ThreadId(51).yaml      2 files
```

All from `intent.rs`, which builds temp paths by hand and does not remove them. Across the 300-run stress that had accumulated 8,000+ directories. It is only `/tmp`, so it is untidiness rather than the `~/.termaxa` problem, and nothing there resolves through `TERMAXA_HOME`, which is why the guard has nothing to say about it today.

Nine test modules build temp dirs by hand right now. Moving them onto the guard would make it the one obvious way for real, and would let the drop check grow to "did this test leave anything anywhere". I did not do it here because it touches tests I have not studied and this PR is already the interesting change. Happy to take it as a third PR if you want it, or leave it.

Verified: 116 pass, `fmt --check` and `clippy -D warnings` silent, 300 full-suite runs at 16 threads with no failures, nothing in `~/.termaxa`, nothing left in `/tmp` by the guard. Release build clean, and the module is `#[cfg(test)]` so it does not ship.

## On the errno

Your `os error 17` against my `os error 2`, same harness, same race, different filesystem: agreed that it is worth recording and agreed it changes nothing about the fix. It also makes the `other errors` column the more useful half of that harness, which was luck on my part rather than foresight. If it ever matters, the thing to vary is the filesystem rather than the iteration count.
