### PR TITLE
Sweep the hand-rolled temp paths onto the guard

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -488,14 +488,16 @@ fn git_out(args: &[&str]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::TempTree;
 
-    /// A real temp directory containing one file.
-    fn scratch(tag: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("tmx-bk-{}-{}", tag, std::process::id()));
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).unwrap();
-        fs::write(dir.join("f.txt"), "x").unwrap();
-        dir
+    /// A real temp directory containing one file. The guard is returned with
+    /// it: dropping it removes the tree, so the caller has to keep it alive
+    /// for as long as the path is used.
+    fn scratch(tag: &str) -> (TempTree, PathBuf) {
+        let tmp = TempTree::new(&format!("bk-{tag}"));
+        tmp.file("f.txt", "x");
+        let dir = tmp.path().to_path_buf();
+        (tmp, dir)
     }
 
     #[test]
@@ -503,7 +505,7 @@ mod tests {
         // The v0.14 bug: `/c/Users/x/Desktop` got no backup while the
         // identical target written `C:\Users\x\Desktop` did. The case where
         // insurance mattered most was the one silently without it.
-        let dir = scratch("syntax");
+        let (_tmp, dir) = scratch("syntax");
         let win = dir.display().to_string();
         let planned_win = plan(&format!("rm -rf {}", win)).is_some();
         assert!(planned_win, "an existing path must be insurable: {win}");
@@ -526,7 +528,7 @@ mod tests {
     fn powershell_and_cmd_deletes_are_insurable_too() {
         // Previously only `rm` was matched, so every PowerShell and cmd delete
         // ran uninsured even though policy and the classifier both gate them.
-        let dir = scratch("shells");
+        let (_tmp, dir) = scratch("shells");
         let p = dir.display().to_string();
 
         assert!(plan(&format!("Remove-Item -Recurse -Force {}", p)).is_some());

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -586,6 +586,7 @@ fn short(p: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::TempTree;
 
     /// Schipper review, finding 2. Sweeps every length across non-ASCII
     /// prefixes so the truncation point lands mid-codepoint; the old byte
@@ -807,9 +808,9 @@ mod tests {
 
     #[test]
     fn budgeted_scan_counts_and_reports_capping_honestly() {
-        let dir = std::env::temp_dir().join(format!("tmx-scan-{}", std::process::id()));
-        let sub = dir.join("nested");
-        std::fs::create_dir_all(&sub).unwrap();
+        let tmp = TempTree::new("scan");
+        let dir = tmp.path().to_path_buf();
+        let sub = tmp.dir("nested");
         for i in 0..12 {
             std::fs::write(dir.join(format!("f{i}.txt")), "x").unwrap();
         }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -338,15 +338,16 @@ fn hook_configured(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::TempTree;
     use std::io::Write;
 
     #[test]
     fn count_log_reads_without_creating_and_tolerates_junk() {
-        let dir = std::env::temp_dir().join(format!("tmx-doc-log-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
+        let tmp = TempTree::new("doc-log");
+        let dir = tmp.path().to_path_buf();
 
         // Missing file: zero, and nothing created.
-        let missing = dir.join("nope.jsonl");
+        let missing = tmp.absent("nope.jsonl");
         assert_eq!(count_log(&missing), (0, 0));
         assert!(!missing.exists(), "count_log must not create the log file");
 
@@ -362,18 +363,13 @@ mod tests {
         let (total, hooks) = count_log(&f);
         assert_eq!(total, 3, "junk lines still count as entries that happened");
         assert_eq!(hooks, 1);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn a_policy_edited_behind_the_gate_becomes_a_reported_problem() {
-        let dir = std::env::temp_dir().join(format!("tmx-doc-fp-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        let state = dir.join("state");
-        std::fs::create_dir_all(&state).unwrap();
-        let policy = dir.join("policy.yaml");
-        std::fs::write(&policy, "version: 1\ndefault: ask\nrules: []\n").unwrap();
+        let tmp = TempTree::new("doc-fp");
+        let state = tmp.dir("state");
+        let policy = tmp.file("policy.yaml", "version: 1\ndefault: ask\nrules: []\n");
 
         // 1. No baseline: say so, and do NOT quietly create one — a
         //    diagnostic that records the value it checks always reports
@@ -404,14 +400,12 @@ mod tests {
             "the problem must name what happened: {}",
             problems[0]
         );
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn hook_configured_detects_plain_and_absolute_forms() {
-        let dir = std::env::temp_dir().join(format!("tmx-doctor-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
+        let tmp = TempTree::new("doctor");
+        let dir = tmp.path().to_path_buf();
 
         let plain = dir.join("plain.json");
         let mut f = std::fs::File::create(&plain).unwrap();
@@ -437,6 +431,5 @@ mod tests {
         assert!(!hook_configured(&empty));
 
         assert!(!hook_configured(&dir.join("does-not-exist.json")));
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -155,6 +155,7 @@ pub fn sha256_hex(data: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::TempTree;
 
     #[test]
     fn sha256_matches_the_published_vectors() {
@@ -192,9 +193,8 @@ mod tests {
 
     #[test]
     fn baseline_roundtrips_through_the_state_dir() {
-        let dir = std::env::temp_dir().join(format!("tmx-fp-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
+        let tmp = TempTree::new("fp");
+        let dir = tmp.path().to_path_buf();
 
         assert!(
             read_baseline(&dir).is_none(),
@@ -225,8 +225,8 @@ mod tests {
 
     #[test]
     fn of_file_reports_absence_rather_than_guessing() {
-        let missing = std::env::temp_dir().join("tmx-fp-definitely-not-here.yaml");
-        let _ = std::fs::remove_file(&missing);
+        let tmp = TempTree::new("fp-absent");
+        let missing = tmp.absent("definitely-not-here.yaml");
         assert!(of_file(&missing).is_none());
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -500,6 +500,7 @@ pub(crate) fn which(bin: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::TempTree;
 
     /// `examples/policy.yaml` is the file people copy. It had drifted to 28
     /// rules against the starter's 44 — missing every broad delete deny and
@@ -555,14 +556,9 @@ mod tests {
 
     #[test]
     fn init_records_a_baseline_the_policy_directory_cannot_erase() {
-        let dir = std::env::temp_dir().join(format!("tmx-init-fp-{}", std::process::id()));
-        let _ = fs::remove_dir_all(&dir);
-        let project = dir.join("proj");
-        let state = dir.join("home").join("projects").join("proj-abc12345");
-        fs::create_dir_all(project.join(".termaxa")).unwrap();
-        fs::create_dir_all(&state).unwrap();
-        let policy = project.join(".termaxa").join("policy.yaml");
-        fs::write(&policy, STARTER_POLICY).unwrap();
+        let tmp = TempTree::new("init-fp");
+        let state = tmp.dir("home/projects/proj-abc12345");
+        let policy = tmp.file("proj/.termaxa/policy.yaml", STARTER_POLICY);
 
         let short = record_fingerprint(&state, &policy)
             .unwrap()
@@ -574,7 +570,7 @@ mod tests {
         let baseline = crate::fingerprint::baseline_file(&state);
         assert!(baseline.is_file());
         assert!(
-            !baseline.starts_with(&project),
+            !baseline.starts_with(policy.parent().unwrap()),
             "baseline must not live in the project: {}",
             baseline.display()
         );
@@ -582,8 +578,6 @@ mod tests {
         // Re-running init on an unchanged policy records the same hash.
         let again = record_fingerprint(&state, &policy).unwrap().unwrap();
         assert_eq!(short, again);
-
-        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -407,7 +407,7 @@ fn tokens(segment: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
+    use crate::testutil::TempTree;
 
     // --- classification ---
 
@@ -581,19 +581,15 @@ mod tests {
 
     // --- counting + breaker ---
 
-    fn write_log(lines: &[serde_json::Value]) -> std::path::PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "tmx-intent-test-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("audit.jsonl");
-        let mut f = std::fs::File::create(&path).unwrap();
+    /// The tree must outlive the path it hands back, so the caller holds it.
+    /// Before the guard existed this wrote to a pid+thread path that nothing
+    /// ever removed, which is where most of the /tmp litter came from.
+    fn write_log(tmp: &TempTree, lines: &[serde_json::Value]) -> std::path::PathBuf {
+        let mut body = String::new();
         for l in lines {
-            writeln!(f, "{}", l).unwrap();
+            body.push_str(&format!("{}\n", l));
         }
-        path
+        tmp.file("audit.jsonl", &body)
     }
 
     fn entry(session: &str, decision: &str, intent: &str, command: &str) -> serde_json::Value {
@@ -609,11 +605,15 @@ mod tests {
 
     #[test]
     fn counts_asks_and_denies_for_same_session_and_intent() {
-        let log = write_log(&[
-            entry("s1", "ask", "file-delete", "rm -rf ."),
-            entry("s1", "ask", "file-delete", "Remove-Item -Recurse -Force ."),
-            entry("s1", "allow", "file-delete", "rm -rf /tmp/scratch"),
-        ]);
+        let tmp = TempTree::new("intent");
+        let log = write_log(
+            &tmp,
+            &[
+                entry("s1", "ask", "file-delete", "rm -rf ."),
+                entry("s1", "ask", "file-delete", "Remove-Item -Recurse -Force ."),
+                entry("s1", "allow", "file-delete", "rm -rf /tmp/scratch"),
+            ],
+        );
         assert_eq!(
             recent_intent_count(&log, "s1", Intent::FileDelete, 64 * 1024),
             2
@@ -622,10 +622,14 @@ mod tests {
 
     #[test]
     fn session_isolation() {
-        let log = write_log(&[
-            entry("s1", "ask", "file-delete", "rm -rf ."),
-            entry("s1", "deny", "file-delete", "del /s /q ."),
-        ]);
+        let tmp = TempTree::new("intent");
+        let log = write_log(
+            &tmp,
+            &[
+                entry("s1", "ask", "file-delete", "rm -rf ."),
+                entry("s1", "deny", "file-delete", "del /s /q ."),
+            ],
+        );
         assert_eq!(
             recent_intent_count(&log, "s2", Intent::FileDelete, 64 * 1024),
             0
@@ -634,10 +638,14 @@ mod tests {
 
     #[test]
     fn intent_isolation() {
-        let log = write_log(&[
-            entry("s1", "ask", "file-delete", "rm -rf ."),
-            entry("s1", "ask", "file-delete", "del /s /q ."),
-        ]);
+        let tmp = TempTree::new("intent");
+        let log = write_log(
+            &tmp,
+            &[
+                entry("s1", "ask", "file-delete", "rm -rf ."),
+                entry("s1", "ask", "file-delete", "del /s /q ."),
+            ],
+        );
         assert_eq!(
             recent_intent_count(&log, "s1", Intent::GitDestructive, 64 * 1024),
             0
@@ -647,10 +655,14 @@ mod tests {
     #[test]
     fn approved_ask_is_excluded() {
         // ask -> human approved -> post execution record exists
-        let log = write_log(&[
-            entry("s1", "ask", "file-delete", "rm -rf ./node_modules"),
-            entry("s1", "executed", "file-delete", "rm -rf ./node_modules"),
-        ]);
+        let tmp = TempTree::new("intent");
+        let log = write_log(
+            &tmp,
+            &[
+                entry("s1", "ask", "file-delete", "rm -rf ./node_modules"),
+                entry("s1", "executed", "file-delete", "rm -rf ./node_modules"),
+            ],
+        );
         // patch the second entry's source to "post"
         let text = std::fs::read_to_string(&log).unwrap();
         let patched: Vec<String> = text
@@ -673,14 +685,18 @@ mod tests {
 
     #[test]
     fn old_log_lines_without_intent_are_ignored_not_fatal() {
-        let log = write_log(&[
-            serde_json::json!({
-                "ts": "2026-01-01T00:00:00Z", "source": "hook",
-                "session": "s1", "decision": "ask", "command": "rm -rf ."
-                // no "intent" field — pre-v0.11 line
-            }),
-            entry("s1", "ask", "file-delete", "del /s /q ."),
-        ]);
+        let tmp = TempTree::new("intent");
+        let log = write_log(
+            &tmp,
+            &[
+                serde_json::json!({
+                    "ts": "2026-01-01T00:00:00Z", "source": "hook",
+                    "session": "s1", "decision": "ask", "command": "rm -rf ."
+                    // no "intent" field — pre-v0.11 line
+                }),
+                entry("s1", "ask", "file-delete", "del /s /q ."),
+            ],
+        );
         assert_eq!(
             recent_intent_count(&log, "s1", Intent::FileDelete, 64 * 1024),
             1
@@ -689,7 +705,8 @@ mod tests {
 
     #[test]
     fn missing_log_fails_open() {
-        let ghost = std::env::temp_dir().join("tmx-intent-no-such-dir/audit.jsonl");
+        let tmp = TempTree::new("intent-ghost");
+        let ghost = tmp.absent("no-such-dir/audit.jsonl");
         assert_eq!(
             recent_intent_count(&ghost, "s1", Intent::FileDelete, 64 * 1024),
             0
@@ -699,16 +716,15 @@ mod tests {
     #[test]
     fn breaker_trips_on_third_variant() {
         // the money test: the live Cursor whack-a-mole scenario
-        let log = write_log(&[
-            entry("s1", "ask", "file-delete", "rm -rf ."),
-            entry("s1", "ask", "file-delete", "Remove-Item -Recurse -Force ."),
-        ]);
-        let policy = std::env::temp_dir().join(format!(
-            "tmx-intent-pol-{}-{:?}.yaml",
-            std::process::id(),
-            std::thread::current().id()
-        ));
-        std::fs::write(&policy, "version: 1\ndefault: ask\nrules: []\n").unwrap();
+        let tmp = TempTree::new("intent");
+        let log = write_log(
+            &tmp,
+            &[
+                entry("s1", "ask", "file-delete", "rm -rf ."),
+                entry("s1", "ask", "file-delete", "Remove-Item -Recurse -Force ."),
+            ],
+        );
+        let policy = tmp.file("policy.yaml", "version: 1\ndefault: ask\nrules: []\n");
 
         let tripped = maybe_trip(&policy, &log, Some("s1"), "del /s /q .");
         assert!(
@@ -728,21 +744,19 @@ mod tests {
 
     #[test]
     fn breaker_respects_config() {
-        let log = write_log(&[
-            entry("s1", "ask", "file-delete", "rm -rf ."),
-            entry("s1", "ask", "file-delete", "del /s /q ."),
-        ]);
-        let policy = std::env::temp_dir().join(format!(
-            "tmx-intent-pol-off-{}-{:?}.yaml",
-            std::process::id(),
-            std::thread::current().id()
-        ));
+        let tmp = TempTree::new("intent");
+        let log = write_log(
+            &tmp,
+            &[
+                entry("s1", "ask", "file-delete", "rm -rf ."),
+                entry("s1", "ask", "file-delete", "del /s /q ."),
+            ],
+        );
         // disabled
-        std::fs::write(
-            &policy,
+        let policy = tmp.file(
+            "policy.yaml",
             "version: 1\ndefault: ask\nrules: []\ncircuit_breaker:\n  enabled: false\n",
-        )
-        .unwrap();
+        );
         assert!(maybe_trip(&policy, &log, Some("s1"), "rd /s /q .").is_none());
 
         // higher threshold
@@ -756,8 +770,8 @@ mod tests {
 
     #[test]
     fn config_defaults_when_block_missing_or_file_absent() {
-        let policy = std::env::temp_dir().join("tmx-intent-nopolicy.yaml");
-        let _ = std::fs::remove_file(&policy);
+        let tmp = TempTree::new("intent-nopolicy");
+        let policy = tmp.absent("policy.yaml");
         let c = breaker_config(&policy);
         assert!(c.enabled);
         assert_eq!(c.threshold, 2);

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -8,18 +8,35 @@
 //!
 //! Both halves of that came from the same thing: setting up a test correctly
 //! took knowledge the test itself did not carry. So the safe path is the only
-//! path here. `TestEnv::new` takes the lock, points `TERMAXA_HOME` at a tree
-//! this test alone owns, and on drop puts the cwd and the variable back,
-//! removes the tree, and fails the test if state landed anywhere else.
+//! path here.
+//!
+//! Two guards, because the costs differ:
+//!
+//! - [`TempTree`] is a scratch directory that removes itself. It touches
+//!   nothing process-global, takes no lock, and tests using only it still run
+//!   in parallel. Most tests want this one.
+//! - [`TestEnv`] is a `TempTree` plus the lock, `TERMAXA_HOME` pointed into
+//!   the tree, and the cwd restored on the way out. Only tests that need the
+//!   environment redirected should pay for the serialisation.
 //!
 //! ```ignore
-//! let env = TestEnv::new("my-case");
+//! let tmp = TempTree::new("my-case");
+//! let log = tmp.file("audit.jsonl", "{}\n");
+//!
+//! let env = TestEnv::new("my-case");     // when TERMAXA_HOME matters
 //! let proj = env.project("proj");        // <root>/proj/.termaxa/policy.yaml
-//! let paths = crate::paths::resolve_from(&proj)?;
 //! ```
 //!
-//! One guard per test. `std::sync::Mutex` is not reentrant, so a second
-//! `TestEnv::new` while one is alive deadlocks rather than failing.
+//! Both fail the test that leaves something behind: every guard asserts its
+//! own tree is gone, and `TestEnv` additionally watches the real `~/.termaxa`.
+//! A helper nobody is obliged to use stops being used, so
+//! `no_module_builds_a_temp_path_by_hand` reads the source and fails on a
+//! `temp_dir()` call outside this module. That is what keeps this the only
+//! obvious way rather than merely an available one.
+//!
+//! One `TestEnv` per test. `std::sync::Mutex` is not reentrant, so a second
+//! `TestEnv::new` while one is alive deadlocks rather than failing. `TempTree`
+//! takes no lock and nests freely.
 
 use std::collections::BTreeSet;
 use std::ffi::OsString;
@@ -35,6 +52,82 @@ static SEQ: AtomicUsize = AtomicUsize::new(0);
 /// and hiding which one actually broke.
 fn lock() -> MutexGuard<'static, ()> {
     GLOBAL_ENV.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Claim a fresh tree. The pid keeps two concurrent `cargo test` runs apart
+/// and the counter keeps two guards sharing a label apart.
+fn claim(label: &str) -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "tmx-{}-{}-{}",
+        label,
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("test root must be creatable");
+    root
+}
+
+/// Remove a tree, reporting whether it is actually gone.
+///
+/// A cleanup that silently failed is how litter accumulates in the first
+/// place, so the guard says so rather than shrugging.
+fn release(root: &Path) -> bool {
+    let _ = std::fs::remove_dir_all(root);
+    !root.exists()
+}
+
+/// A scratch directory that removes itself, with no lock and no environment
+/// changes. The default way to get a path to write to in a test.
+pub struct TempTree {
+    root: PathBuf,
+}
+
+impl TempTree {
+    pub fn new(label: &str) -> Self {
+        Self { root: claim(label) }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.root
+    }
+
+    /// A subdirectory, created.
+    pub fn dir(&self, name: &str) -> PathBuf {
+        let dir = self.root.join(name);
+        std::fs::create_dir_all(&dir).expect("scratch dir must be creatable");
+        dir
+    }
+
+    /// A file with `contents`, parents created. `name` may be nested.
+    pub fn file(&self, name: &str, contents: &str) -> PathBuf {
+        let path = self.root.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("scratch parent must be creatable");
+        }
+        std::fs::write(&path, contents).expect("scratch file must be writable");
+        path
+    }
+
+    /// A path inside the tree that deliberately does NOT exist, for the tests
+    /// that check a missing file is reported rather than guessed at.
+    pub fn absent(&self, name: &str) -> PathBuf {
+        self.root.join(name)
+    }
+}
+
+impl Drop for TempTree {
+    fn drop(&mut self) {
+        let gone = release(&self.root);
+        if std::thread::panicking() {
+            return;
+        }
+        assert!(
+            gone,
+            "the guard failed to remove {} — the tree it owns must not outlive it",
+            self.root.display()
+        );
+    }
 }
 
 /// The real `~/.termaxa/projects`, ignoring any `TERMAXA_HOME` override.
@@ -66,7 +159,10 @@ pub struct TestEnv {
     /// `None` only for the tests in this module that already hold the lock in
     /// order to observe the guard without racing it.
     _lock: Option<MutexGuard<'static, ()>>,
-    root: PathBuf,
+    /// The tree and its cleanup. Dropped after this struct's own `Drop` runs,
+    /// so the environment is already back to normal by the time the directory
+    /// goes.
+    tree: TempTree,
     previous_home: Option<OsString>,
     previous_cwd: Option<PathBuf>,
     watch: Option<(PathBuf, BTreeSet<OsString>)>,
@@ -83,17 +179,10 @@ impl TestEnv {
     }
 
     fn build(guard: Option<MutexGuard<'static, ()>>, label: &str) -> Self {
-        let root = std::env::temp_dir().join(format!(
-            "tmx-{}-{}-{}",
-            label,
-            std::process::id(),
-            SEQ.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
-        std::fs::create_dir_all(&root).expect("test root must be creatable");
+        let tree = TempTree::new(label);
 
         let previous_home = std::env::var_os("TERMAXA_HOME");
-        std::env::set_var("TERMAXA_HOME", root.join("home"));
+        std::env::set_var("TERMAXA_HOME", tree.path().join("home"));
 
         let watch = real_state_root().map(|dir| {
             let before = listing(&dir);
@@ -102,7 +191,7 @@ impl TestEnv {
 
         Self {
             _lock: guard,
-            root,
+            tree,
             previous_home,
             previous_cwd: None,
             watch,
@@ -111,17 +200,17 @@ impl TestEnv {
 
     /// The tree this test owns. Everything it writes belongs under here.
     pub fn root(&self) -> &Path {
-        &self.root
+        self.tree.path()
     }
 
     /// Where `TERMAXA_HOME` points for the life of this guard.
     pub fn home(&self) -> PathBuf {
-        self.root.join("home")
+        self.tree.path().join("home")
     }
 
     /// A project directory with a minimal policy, ready for `resolve_from`.
     pub fn project(&self, name: &str) -> PathBuf {
-        let proj = self.root.join(name);
+        let proj = self.tree.path().join(name);
         std::fs::create_dir_all(proj.join(".termaxa")).expect("project dir must be creatable");
         std::fs::write(
             proj.join(".termaxa").join("policy.yaml"),
@@ -169,7 +258,8 @@ impl Drop for TestEnv {
             let found = arrivals(&before, &listing(&dir));
             (dir, found)
         });
-        let _ = std::fs::remove_dir_all(&self.root);
+        // The tree itself goes with `self.tree`'s own Drop, immediately
+        // after this one.
 
         // Never assert into an unwind: a panicking Drop during a panic aborts
         // the process, and the test's own failure is the one worth reading.
@@ -242,19 +332,28 @@ mod tests {
         assert_eq!(std::env::current_dir().ok(), Some(cwd_before));
     }
 
+    /// Run `f` with panic output silenced, and report whether it panicked.
+    ///
+    /// The guard reports by panicking, so a test that proves the guard works
+    /// would otherwise print a wall of backtrace-looking text on a PASSING
+    /// run, which is how people learn to ignore their own test output.
+    fn panics_quietly(f: impl FnOnce() + std::panic::UnwindSafe) -> bool {
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let outcome = std::panic::catch_unwind(f);
+        std::panic::set_hook(hook);
+        outcome.is_err()
+    }
+
     #[test]
     fn the_guard_fails_loudly_when_state_lands_outside_its_tree() {
         let _outer = lock();
-        let decoy = std::env::temp_dir().join(format!("tmx-decoy-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&decoy);
-        std::fs::create_dir_all(&decoy).expect("decoy must be creatable");
+        // The stand-in lives inside a guard of its own, so proving the check
+        // works does not itself leave anything behind.
+        let holder = TempTree::new("decoy-holder");
+        let decoy = holder.dir("home-projects");
 
-        // The guard reports by panicking, so the expected failure would print
-        // a backtrace-looking wall of text on a passing run. Silence just this
-        // one, and put the real hook back.
-        let hook = std::panic::take_hook();
-        std::panic::set_hook(Box::new(|_| {}));
-        let outcome = std::panic::catch_unwind({
+        let caught = panics_quietly({
             let decoy = decoy.clone();
             move || {
                 let mut env = TestEnv::build(None, "stray");
@@ -264,12 +363,65 @@ mod tests {
                 drop(env);
             }
         });
-        std::panic::set_hook(hook);
 
-        let _ = std::fs::remove_dir_all(&decoy);
         assert!(
-            outcome.is_err(),
+            caught,
             "a test that writes outside its own tree must fail, not pass quietly"
+        );
+    }
+
+    /// The check that keeps this the only obvious way.
+    ///
+    /// A guard that merely exists gets ignored: the six modules swept up in
+    /// this PR each built temp paths by hand, and the pile in /tmp was the
+    /// result. This fails at the moment somebody writes the line, naming the
+    /// file, instead of months later when a stranger counts the directories.
+    ///
+    /// The earlier version of this check scanned the temp directory at every
+    /// guard drop. It worked, and it cost 46ms per scan on a machine with
+    /// 250k entries in /tmp: two seconds on a suite that otherwise runs in
+    /// 0.06, paid only by developers, since CI runners start with an empty
+    /// /tmp. Reading the source costs nothing and catches it earlier.
+    #[test]
+    fn no_module_builds_a_temp_path_by_hand() {
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut offenders: Vec<String> = Vec::new();
+        // Recursive, because a check that only reads the top level passes
+        // silently the day src/ grows a subdirectory, and passing silently is
+        // the failure mode this whole module exists to end.
+        let mut queue = vec![src.clone()];
+        while let Some(dir) = queue.pop() {
+            for entry in std::fs::read_dir(&dir)
+                .unwrap_or_else(|e| panic!("{} must be readable: {e}", dir.display()))
+                .flatten()
+            {
+                let path = entry.path();
+                if path.is_dir() {
+                    queue.push(path);
+                    continue;
+                }
+                if path.file_name() == Some(std::ffi::OsStr::new("testutil.rs"))
+                    || path.extension() != Some(std::ffi::OsStr::new("rs"))
+                {
+                    continue;
+                }
+                let body = std::fs::read_to_string(&path).expect("source must be readable");
+                for (i, line) in body.lines().enumerate() {
+                    if line.contains("temp_dir()") {
+                        let shown = path.strip_prefix(&src).unwrap_or(&path);
+                        offenders.push(format!("{}:{}", shown.display(), i + 1));
+                    }
+                }
+            }
+        }
+        offenders.sort();
+        assert!(
+            offenders.is_empty(),
+            "these build a temp path by hand: {:?}\n\
+             Use TempTree (or TestEnv, when TERMAXA_HOME matters) instead. \
+             They clean up on their own, and a path nobody removes is how \
+             /tmp filled up with 8,000 directories.",
+            offenders
         );
     }
 


### PR DESCRIPTION
The third of the three, off v0.14.2.

Thirteen sites across `backup`, `delete`, `doctor`, `fingerprint`, `init` and `intent` now take a guard. Most of them wanted scratch space rather than a redirected environment, so there is a second, cheaper guard:

| guard | gives you | cost |
| --- | --- | --- |
| `TempTree` | a tree that removes itself | no lock, tests stay parallel |
| `TestEnv` | that, plus the lock, `TERMAXA_HOME` and the cwd | serialised |

Only the tests that need serialising pay for it now. `intent.rs` was the whole of the `/tmp` litter: `write_log` built a pid-and-thread-named directory that nothing ever removed. It takes the tree as an argument, so the caller owns the lifetime.

## What enforces it

A guard that merely exists gets ignored, which is how the pile got there in the first place. So `no_module_builds_a_temp_path_by_hand` reads the source and fails on `std::env::temp_dir()` outside `testutil`:

```
these build a temp path by hand: ["delete.rs:811"]
Use TempTree (or TestEnv, when TERMAXA_HOME matters) instead. They clean up on
their own, and a path nobody removes is how /tmp filled up with 8,000 directories.
```

It walks `src/` recursively. A check that reads only the top level passes silently the day `src/` grows a subdirectory, and passing silently is the failure mode this module exists to end. Verified both ways: putting the line back reports `delete.rs:811`, and a file at `src/nested/probe.rs` reports `nested/probe.rs:4`.

## An approach I tried and threw away

The check was originally a filesystem sweep at every guard drop, with a live-root registry so a guard's own tree would not count against it. It worked, and I am not shipping it, for two measured reasons.

**It was slow in exactly the place nobody would notice.** `read_dir` of `/tmp` costs 46ms on this box, which has 250,760 entries. Times the guard drops in a run, that is two seconds on a suite that otherwise finishes in 0.06. CI runners start with an empty `/tmp`, so the bill goes to developers only, and quietly.

**It was self-defeating under parallelism.** The test proving the sweep worked had to create real litter, and every sibling guard dropping at that moment saw it and failed. Three unrelated tests went red. That is the same cross-test interference as #17, reintroduced by the tool meant to prevent it, and it only showed up because the suite runs in parallel: serially it passed clean.

Reading the source costs nothing, cannot be perturbed by a sibling, and catches the mistake when the line is written rather than after it has run.

## Verified

- 121 pass, `fmt --check` and `clippy -D warnings` silent
- 200 full-suite runs at 16 threads, no failures
- nothing left in `/tmp`, nothing in `~/.termaxa`, before and after
- release build clean, zero `testutil` symbols in the binary

The directories this suite had already scattered are deleted rather than counted as somebody else's problem.

## One thing I checked and did not change

`/tmp` appears as a literal in `preview.rs`, `intent.rs`, `delete.rs` and `policy.rs`, but every one is a command string being classified, not a path being written. Extending the check to flag literals would fail those tests for saying `rm -rf /tmp/x` out loud, so it looks only for `temp_dir()`. Worth knowing as a limit: a test that invents its own absolute path still slips through, and the answer there is the same helper rather than a wider grep.
