### PR TITLE
test: mutation-testing pass over the whole suite (189 -> 379 tests), four findings, one fix

### DIFF
--- a/.chaos-mcp/suppressions.json
+++ b/.chaos-mcp/suppressions.json
@@ -103,6 +103,22 @@
         "reason": "equivalent: idx < bi and idx <= bi differ only at idx == bi, and that means the same index into self.rules — so both arms of the if produce the identical (index, rule) pair and `best` is unchanged either way",
         "fingerprint": "26f79d8eac41"
       }
+    ],
+    "src/hook.rs": [
+      {
+        "line": 521,
+        "mutator": "replace && with || in run",
+        "addedAt": 1786731671137,
+        "reason": "unreachable: this is a duplicate of the `if input.is_post` block above it, which returns Ok(()) for every post input, so nothing here executes. Not equivalent — dead. The block should be deleted; the suppression goes away with it",
+        "fingerprint": "c7754d516339"
+      },
+      {
+        "line": 521,
+        "mutator": "delete ! in run",
+        "addedAt": 1786731671137,
+        "reason": "unreachable: this is a duplicate of the `if input.is_post` block above it, which returns Ok(()) for every post input, so nothing here executes. Not equivalent — dead. The block should be deleted; the suppression goes away with it",
+        "fingerprint": "c7754d516339"
+      }
     ]
   }
 }

--- a/.chaos-mcp/suppressions.json
+++ b/.chaos-mcp/suppressions.json
@@ -24,15 +24,52 @@
         "line": 131,
         "mutator": "replace ^ with | in sha256_hex",
         "addedAt": 1786705435998,
-        "reason": "equivalent: SHA-256 `ch` is (e&f)^(!e&g), whose terms are masked by e and !e and so are disjoint \u2014 XOR and OR agree on every bit pattern (verified over all 8)",
+        "reason": "equivalent: SHA-256 `ch` is (e&f)^(!e&g), whose terms are masked by e and !e and so are disjoint — XOR and OR agree on every bit pattern (verified over all 8)",
         "fingerprint": "fe05454fb5c0"
       },
       {
         "line": 138,
         "mutator": "replace ^ with | in sha256_hex",
         "addedAt": 1786705435998,
-        "reason": "equivalent: SHA-256 `maj` is the majority function, identical in XOR and OR form \u2014 both single-operator swaps match maj on all 8 bit patterns under Rust's & > ^ > | precedence",
+        "reason": "equivalent: SHA-256 `maj` is the majority function, identical in XOR and OR form — both single-operator swaps match maj on all 8 bit patterns under Rust's & > ^ > | precedence",
         "fingerprint": "735600a52303"
+      }
+    ],
+    "src/ui.rs": [
+      {
+        "line": 49,
+        "mutator": "replace is_tty -> bool with true",
+        "addedAt": 1786706277919,
+        "reason": "platform-gated: this is the #[cfg(windows)] is_tty, not compiled on Linux, so no test run on this target can observe the change — audit on Windows to score it",
+        "fingerprint": "dda202a6fe45"
+      },
+      {
+        "line": 49,
+        "mutator": "replace is_tty -> bool with false",
+        "addedAt": 1786706277919,
+        "reason": "platform-gated: this is the #[cfg(windows)] is_tty, not compiled on Linux, so no test run on this target can observe the change — audit on Windows to score it",
+        "fingerprint": "dda202a6fe45"
+      },
+      {
+        "line": 50,
+        "mutator": "delete - in is_tty",
+        "addedAt": 1786706277919,
+        "reason": "platform-gated: STD_OUTPUT_HANDLE in the #[cfg(windows)] is_tty, not compiled on Linux — audit on Windows to score it",
+        "fingerprint": "1cc2dfc8f009"
+      },
+      {
+        "line": 61,
+        "mutator": "replace != with == in is_tty",
+        "addedAt": 1786706277919,
+        "reason": "platform-gated: the GetConsoleMode check in the #[cfg(windows)] is_tty, not compiled on Linux — audit on Windows to score it",
+        "fingerprint": "2cd1cbb6d021"
+      },
+      {
+        "line": 69,
+        "mutator": "replace is_tty -> bool with true",
+        "addedAt": 1786706277919,
+        "reason": "platform-gated: the #[cfg(not(any(unix, windows)))] fallback, compiled on neither of the targets this project ships — unreachable from any test here",
+        "fingerprint": "fcbcf165908d"
       }
     ]
   }

--- a/.chaos-mcp/suppressions.json
+++ b/.chaos-mcp/suppressions.json
@@ -9,6 +9,15 @@
         "reason": "fire-and-forget notifier: the wrapper only guards and delegates, and the doctrine is that it must never affect enforcement",
         "fingerprint": "fb29c8070b2b"
       }
+    ],
+    "src/audit.rs": [
+      {
+        "line": 83,
+        "mutator": "replace > with >= in AuditLog::read_last",
+        "addedAt": 1786698460251,
+        "reason": "equivalent: the only input that separates > from >= is len == n, and there the guarded body drains 0..0, which is a no-op either way",
+        "fingerprint": "bbeea8530188"
+      }
     ]
   }
 }

--- a/.chaos-mcp/suppressions.json
+++ b/.chaos-mcp/suppressions.json
@@ -87,6 +87,22 @@
         "reason": "equivalent: they differ only at exactly one --stat line, which cannot reach here — git() returns None for empty output, so the block runs only with per-file lines plus the totals line, i.e. two or more",
         "fingerprint": "a840fd70ac75"
       }
+    ],
+    "src/policy.rs": [
+      {
+        "line": 312,
+        "mutator": "replace + with * in wildcard_match",
+        "addedAt": 1786720071482,
+        "reason": "equivalent: after the mutated backtrack (pi = star) the next iteration re-enters the star branch and sets star = pi, mark = ti, pi = star + 1 — exactly the state the real branch produces, so the two reconverge before anything is observable. Checked exhaustively over 30,276 pattern/text pairs from {a, b, *} (patterns and texts up to length 6): no input distinguishes them",
+        "fingerprint": "2590c17b32bd"
+      },
+      {
+        "line": 214,
+        "mutator": "replace < with <= in Policy::evaluate",
+        "addedAt": 1786720710037,
+        "reason": "equivalent: idx < bi and idx <= bi differ only at idx == bi, and that means the same index into self.rules — so both arms of the if produce the identical (index, rule) pair and `best` is unchanged either way",
+        "fingerprint": "26f79d8eac41"
+      }
     ]
   }
 }

--- a/.chaos-mcp/suppressions.json
+++ b/.chaos-mcp/suppressions.json
@@ -1,0 +1,14 @@
+{
+  "version": 3,
+  "entries": {
+    "src/notify.rs": [
+      {
+        "line": 10,
+        "mutator": "replace maybe_send with ()",
+        "addedAt": 1786658772553,
+        "reason": "fire-and-forget notifier: the wrapper only guards and delegates, and the doctrine is that it must never affect enforcement",
+        "fingerprint": "fb29c8070b2b"
+      }
+    ]
+  }
+}

--- a/.chaos-mcp/suppressions.json
+++ b/.chaos-mcp/suppressions.json
@@ -119,6 +119,22 @@
         "reason": "unreachable: this is a duplicate of the `if input.is_post` block above it, which returns Ok(()) for every post input, so nothing here executes. Not equivalent — dead. The block should be deleted; the suppression goes away with it",
         "fingerprint": "c7754d516339"
       }
+    ],
+    "src/delete.rs": [
+      {
+        "line": 224,
+        "mutator": "delete match arm \"rm\" | \"unlink\" in is_flag",
+        "addedAt": 1786732519506,
+        "reason": "equivalent: the arm's body is byte-identical to the `_` default arm (token.starts_with('-')), so deleting it changes no behaviour. It exists to document that a leading slash is a PATH for POSIX deletes, which is what keeps `rm -rf /c` a target",
+        "fingerprint": "9566f08c4f6b"
+      },
+      {
+        "line": 226,
+        "mutator": "delete match arm \"remove-item\" | \"ri\" in is_flag",
+        "addedAt": 1786732519506,
+        "reason": "equivalent: the arm's body is byte-identical to the `_` default arm (token.starts_with('-')), so deleting it changes no behaviour. It exists to document that PowerShell never uses a leading slash for switches",
+        "fingerprint": "5b4c79689c91"
+      }
     ]
   }
 }

--- a/.chaos-mcp/suppressions.json
+++ b/.chaos-mcp/suppressions.json
@@ -71,6 +71,22 @@
         "reason": "platform-gated: the #[cfg(not(any(unix, windows)))] fallback, compiled on neither of the targets this project ships — unreachable from any test here",
         "fingerprint": "fcbcf165908d"
       }
+    ],
+    "src/preview.rs": [
+      {
+        "line": 54,
+        "mutator": "replace > with >= in generate",
+        "addedAt": 1786713336077,
+        "reason": "equivalent: the two differ only at one segment, and there find_map over that single segment calls generate_one with the same text — normalize trims the whitespace, and a dropped trailing separator is an inert token to every downstream parser (pg tokenizes, git matches a prefix)",
+        "fingerprint": "b573b51bf054"
+      },
+      {
+        "line": 168,
+        "mutator": "replace > with >= in git_push_preview",
+        "addedAt": 1786713336077,
+        "reason": "equivalent: they differ only at exactly one --stat line, which cannot reach here — git() returns None for empty output, so the block runs only with per-file lines plus the totals line, i.e. two or more",
+        "fingerprint": "a840fd70ac75"
+      }
     ]
   }
 }

--- a/.chaos-mcp/suppressions.json
+++ b/.chaos-mcp/suppressions.json
@@ -172,6 +172,22 @@
         "reason": "equivalent: i = j lands on the '&' itself, which the next iteration matches with the default arm and steps over, arriving at the same position as i = j + 1",
         "fingerprint": "507d53aa5804"
       }
+    ],
+    "src/pg.rs": [
+      {
+        "line": 472,
+        "mutator": "replace += with *= in parse_one",
+        "addedAt": 1786741147106,
+        "reason": "equivalent: i is 2 at this point (DROP TABLE consumed), and 2 += 2 and 2 *= 2 both give 4. The only value reaching this line makes the two operators identical",
+        "fingerprint": "3f4e5968e63f"
+      },
+      {
+        "line": 538,
+        "mutator": "replace += with *= in read_table_list",
+        "addedAt": 1786742128600,
+        "reason": "equivalent: i *= 1 leaves the standalone comma token to be re-read at the top of the loop, where clean_ident rejects it (trimming the commas leaves an empty string) and nothing is pushed. The loop advances past it on the next pass and converges on the same table list",
+        "fingerprint": "48eb3131a719"
+      }
     ]
   }
 }

--- a/.chaos-mcp/suppressions.json
+++ b/.chaos-mcp/suppressions.json
@@ -135,6 +135,43 @@
         "reason": "equivalent: the arm's body is byte-identical to the `_` default arm (token.starts_with('-')), so deleting it changes no behaviour. It exists to document that PowerShell never uses a leading slash for switches",
         "fingerprint": "5b4c79689c91"
       }
+    ],
+    "src/shell.rs": [
+      {
+        "line": 59,
+        "mutator": "replace < with > in split_segments",
+        "addedAt": 1786737505742,
+        "reason": "equivalent: not consuming the second `|` is unobservable. The unconsumed character is handled by the same `|` arm on the next iteration, which flushes an empty buffer, and flush() drops empties. Both paths produce identical segments",
+        "fingerprint": "555f7e722b0a"
+      },
+      {
+        "line": 60,
+        "mutator": "replace += with *= in split_segments",
+        "addedAt": 1786737505742,
+        "reason": "equivalent: i *= 1 leaves i unchanged, which is the same as not consuming the second `|`, and an unconsumed `|` only flushes an empty buffer, which flush() drops",
+        "fingerprint": "0d1ba708993c"
+      },
+      {
+        "line": 135,
+        "mutator": "replace < with <= in redirect_targets",
+        "addedAt": 1786737505742,
+        "reason": "equivalent: the bound differs only at a trailing backslash (i + 1 == len). There the real guard falls to the default arm and the mutant skips one position; both then leave the loop with nothing pushed",
+        "fingerprint": "f6a2746dc86a"
+      },
+      {
+        "line": 135,
+        "mutator": "replace + with * in redirect_targets",
+        "addedAt": 1786737505742,
+        "reason": "equivalent: i * 1 < len is i < len, which is always true inside the loop, so the guard reduces to !in_single. It differs only at a trailing backslash, where both paths end the loop having pushed nothing",
+        "fingerprint": "f6a2746dc86a"
+      },
+      {
+        "line": 155,
+        "mutator": "replace + with * in redirect_targets",
+        "addedAt": 1786737505742,
+        "reason": "equivalent: i = j lands on the '&' itself, which the next iteration matches with the default arm and steps over, arriving at the same position as i = j + 1",
+        "fingerprint": "507d53aa5804"
+      }
     ]
   }
 }

--- a/.chaos-mcp/suppressions.json
+++ b/.chaos-mcp/suppressions.json
@@ -18,6 +18,22 @@
         "reason": "equivalent: the only input that separates > from >= is len == n, and there the guarded body drains 0..0, which is a no-op either way",
         "fingerprint": "bbeea8530188"
       }
+    ],
+    "src/fingerprint.rs": [
+      {
+        "line": 131,
+        "mutator": "replace ^ with | in sha256_hex",
+        "addedAt": 1786705435998,
+        "reason": "equivalent: SHA-256 `ch` is (e&f)^(!e&g), whose terms are masked by e and !e and so are disjoint \u2014 XOR and OR agree on every bit pattern (verified over all 8)",
+        "fingerprint": "fe05454fb5c0"
+      },
+      {
+        "line": 138,
+        "mutator": "replace ^ with | in sha256_hex",
+        "addedAt": 1786705435998,
+        "reason": "equivalent: SHA-256 `maj` is the majority function, identical in XOR and OR form \u2014 both single-operator swaps match maj on all 8 bit patterns under Rust's & > ^ > | precedence",
+        "fingerprint": "735600a52303"
+      }
     ]
   }
 }

--- a/.chaos-mcp/suppressions.json
+++ b/.chaos-mcp/suppressions.json
@@ -1,15 +1,6 @@
 {
   "version": 3,
   "entries": {
-    "src/notify.rs": [
-      {
-        "line": 10,
-        "mutator": "replace maybe_send with ()",
-        "addedAt": 1786658772553,
-        "reason": "fire-and-forget notifier: the wrapper only guards and delegates, and the doctrine is that it must never affect enforcement",
-        "fingerprint": "fb29c8070b2b"
-      }
-    ],
     "src/audit.rs": [
       {
         "line": 83,

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -97,3 +97,137 @@ pub fn now() -> (u128, String) {
         chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::testutil::TempTree;
+
+    fn entry(command: &str) -> AuditEntry {
+        let (ts_ms, ts) = now();
+        AuditEntry {
+            ts_ms,
+            ts,
+            source: "test".into(),
+            command: command.into(),
+            decision: "allow".into(),
+            matched_rule: None,
+            reason: "because".into(),
+            signals: Vec::new(),
+            escalated: false,
+            session: None,
+            backup: None,
+            preview: None,
+            intent: None,
+            approved: None,
+            exit_code: None,
+            cwd: "/work".into(),
+        }
+    }
+
+    fn log_in(tmp: &TempTree) -> AuditLog {
+        AuditLog::new(&tmp.dir("state")).expect("the log directory must be creatable")
+    }
+
+    #[test]
+    fn new_puts_the_log_under_the_state_dir_and_creates_it() {
+        let tmp = TempTree::new("audit-new");
+        let state = tmp.dir("state");
+        let log = AuditLog::new(&state).expect("the log directory must be creatable");
+
+        assert_eq!(log.path, state.join("logs").join("audit.jsonl"));
+        assert!(
+            state.join("logs").is_dir(),
+            "the directory is created up front so appends never fail on a missing parent"
+        );
+    }
+
+    #[test]
+    fn read_last_on_a_log_that_was_never_written_is_empty() {
+        let tmp = TempTree::new("audit-missing");
+        let log = log_in(&tmp);
+
+        let entries = log
+            .read_last(10)
+            .expect("no log yet is a fresh project, not a failure");
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn read_last_returns_exactly_the_tail_in_order() {
+        let tmp = TempTree::new("audit-tail");
+        let log = log_in(&tmp);
+        for command in ["one", "two", "three", "four", "five"] {
+            log.append(&entry(command)).expect("append must succeed");
+        }
+
+        let tail = log.read_last(2).expect("read must succeed");
+        let commands: Vec<&str> = tail.iter().map(|e| e.command.as_str()).collect();
+        // Exactly two, oldest first: reports read the tail as a timeline.
+        assert_eq!(commands, ["four", "five"]);
+    }
+
+    #[test]
+    fn read_last_asking_for_more_than_exists_returns_everything() {
+        let tmp = TempTree::new("audit-short");
+        let log = log_in(&tmp);
+        for command in ["one", "two", "three"] {
+            log.append(&entry(command)).expect("append must succeed");
+        }
+
+        // The boundary: asking for exactly the number held, and for more.
+        let all = log.read_last(3).expect("read must succeed");
+        assert_eq!(
+            all.iter().map(|e| e.command.as_str()).collect::<Vec<_>>(),
+            ["one", "two", "three"]
+        );
+        let more = log.read_last(99).expect("read must succeed");
+        assert_eq!(more.len(), 3, "asking for more cannot invent entries");
+    }
+
+    #[test]
+    fn read_last_skips_a_line_it_cannot_parse() {
+        let tmp = TempTree::new("audit-corrupt");
+        let log = log_in(&tmp);
+        log.append(&entry("first")).expect("append must succeed");
+        // A truncated write (a killed process mid-append) must not make the
+        // whole history unreadable.
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&log.path)
+            .expect("log must be open-able");
+        writeln!(f, "{{\"ts_ms\": 1, oh no").expect("write must succeed");
+        drop(f);
+        log.append(&entry("second")).expect("append must succeed");
+
+        let entries = log.read_last(10).expect("read must succeed");
+        assert_eq!(
+            entries
+                .iter()
+                .map(|e| e.command.as_str())
+                .collect::<Vec<_>>(),
+            ["first", "second"]
+        );
+    }
+
+    #[test]
+    fn now_reports_the_same_instant_in_both_forms() {
+        let (ms, ts) = now();
+
+        // A stubbed clock (0, or 1) would sit in 1970.
+        assert!(
+            ms > 1_735_689_600_000,
+            "epoch milliseconds should be recent, got {}",
+            ms
+        );
+        let parsed = chrono::DateTime::parse_from_rfc3339(&ts)
+            .unwrap_or_else(|e| panic!("`{}` must be RFC3339 UTC: {}", ts, e));
+        let skew = (ms as i64 - parsed.timestamp_millis()).abs();
+        assert!(
+            skew < 2_000,
+            "the two halves must describe one instant, {} ms apart",
+            skew
+        );
+    }
+}

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -655,7 +655,10 @@ mod tests {
 
     #[test]
     fn only_git_push_itself_is_a_forced_push() {
-        assert_eq!(git_force_push_target(&tokens_of("git commit --force")), None);
+        assert_eq!(
+            git_force_push_target(&tokens_of("git commit --force")),
+            None
+        );
         assert_eq!(
             git_force_push_target(&tokens_of("hub push --force origin main")),
             None
@@ -669,8 +672,8 @@ mod tests {
         assert_eq!(tables, ["users"]);
         assert!(data_only, "the table survives a truncate; only its rows go");
 
-        let (tables, data_only) =
-            pg_backup_targets(r#"psql -d shop -c "DROP TABLE users""#).expect("a drop is insurable");
+        let (tables, data_only) = pg_backup_targets(r#"psql -d shop -c "DROP TABLE users""#)
+            .expect("a drop is insurable");
         assert_eq!(tables, ["users"]);
         assert!(
             !data_only,
@@ -805,7 +808,12 @@ mod tests {
         );
         git_run(
             &work,
-            &["remote", "add", "origin", remote.to_str().expect("utf-8 path")],
+            &[
+                "remote",
+                "add",
+                "origin",
+                remote.to_str().expect("utf-8 path"),
+            ],
         );
         std::fs::write(work.join("seed.txt"), "seed\n").expect("file must be writable");
         git_run(&work, &["add", "-A"]);
@@ -942,7 +950,9 @@ mod tests {
             .expect("a truncate is insurable");
 
         assert_eq!(record.kind, "pg-dump");
-        let file = record.data["file"].as_str().expect("the record names a file");
+        let file = record.data["file"]
+            .as_str()
+            .expect("the record names a file");
         assert!(
             Path::new(file).is_file(),
             "the record must name a dump that exists: {file}"

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -611,4 +611,410 @@ mod tests {
         // not produce a plan merely because a switch was present.
         assert!(plan("del /s /q C:\\definitely-not-here-xyz-9f2").is_none());
     }
+
+    // -----------------------------------------------------------------------
+    // What the command says: the parsing that decides whether insurance
+    // applies at all, and to what.
+    // -----------------------------------------------------------------------
+
+    use crate::testutil::TestEnv;
+
+    fn tokens_of(command: &str) -> Vec<String> {
+        crate::pg::shell_tokens(command)
+    }
+
+    #[test]
+    fn a_forced_push_names_the_ref_it_would_overwrite() {
+        assert_eq!(
+            git_force_push_target(&tokens_of("git push --force origin main")),
+            Some(("origin".to_string(), "main".to_string()))
+        );
+        // Flags are not positional arguments: reading them as one would pin
+        // `--force-with-lease` instead of the branch about to be lost.
+        assert_eq!(
+            git_force_push_target(&tokens_of("git push origin main --force-with-lease")),
+            Some(("origin".to_string(), "main".to_string()))
+        );
+    }
+
+    #[test]
+    fn every_spelling_of_force_counts_and_an_ordinary_push_does_not() {
+        for flag in ["--force", "-f", "--force-with-lease"] {
+            assert!(
+                git_force_push_target(&tokens_of(&format!("git push {flag} origin main")))
+                    .is_some(),
+                "{flag} is a force push"
+            );
+        }
+        // An ordinary push only adds commits; there is nothing to insure.
+        assert_eq!(
+            git_force_push_target(&tokens_of("git push origin main")),
+            None
+        );
+    }
+
+    #[test]
+    fn only_git_push_itself_is_a_forced_push() {
+        assert_eq!(git_force_push_target(&tokens_of("git commit --force")), None);
+        assert_eq!(
+            git_force_push_target(&tokens_of("hub push --force origin main")),
+            None
+        );
+    }
+
+    #[test]
+    fn a_truncate_is_insured_with_data_only_and_a_drop_with_the_schema() {
+        let (tables, data_only) = pg_backup_targets(r#"psql -d shop -c "TRUNCATE users""#)
+            .expect("a truncate is insurable");
+        assert_eq!(tables, ["users"]);
+        assert!(data_only, "the table survives a truncate; only its rows go");
+
+        let (tables, data_only) =
+            pg_backup_targets(r#"psql -d shop -c "DROP TABLE users""#).expect("a drop is insurable");
+        assert_eq!(tables, ["users"]);
+        assert!(
+            !data_only,
+            "a drop takes the table itself, so the schema has to be in the dump"
+        );
+    }
+
+    #[test]
+    fn insurance_needs_a_psql_command_carrying_a_destructive_statement() {
+        assert!(
+            pg_backup_targets(r#"mysql -e "DROP TABLE users""#).is_none(),
+            "another client is not psql"
+        );
+        assert!(
+            pg_backup_targets("psql -d shop").is_none(),
+            "no statement, nothing to insure against"
+        );
+        assert!(
+            pg_backup_targets(r#"psql -d shop -c "SELECT 1""#).is_none(),
+            "a read destroys nothing"
+        );
+        assert!(
+            pg_backup_targets(r#"psql -d shop --command "TRUNCATE users""#).is_some(),
+            "the long spelling is the same flag"
+        );
+    }
+
+    #[test]
+    fn local_terraform_state_is_insured_only_for_apply_and_destroy() {
+        let mut env = TestEnv::new("bk-tfstate");
+        let stack = env.root().join("stack");
+        std::fs::create_dir_all(&stack).expect("stack dir must be creatable");
+        std::fs::write(stack.join("terraform.tfstate"), "{}").expect("state must be writable");
+        env.chdir(&stack);
+
+        for bin in ["terraform", "tofu"] {
+            for verb in ["apply", "destroy"] {
+                assert!(
+                    tf_state_target(&tokens_of(&format!("{bin} {verb}"))).is_some(),
+                    "{bin} {verb} rewrites state"
+                );
+            }
+            assert_eq!(
+                tf_state_target(&tokens_of(&format!("{bin} plan"))),
+                None,
+                "a plan changes nothing"
+            );
+        }
+        assert_eq!(
+            tf_state_target(&tokens_of("ansible apply")),
+            None,
+            "another tool's apply is not terraform's"
+        );
+
+        // Remote state is versioned by its own backend and out of scope: with
+        // no local file there is nothing here to copy.
+        let empty = env.root().join("remote-backend");
+        std::fs::create_dir_all(&empty).expect("dir must be creatable");
+        env.chdir(&empty);
+        assert_eq!(tf_state_target(&tokens_of("terraform destroy")), None);
+    }
+
+    #[test]
+    fn a_compound_command_is_planned_by_its_insurable_segment() {
+        // The first segment insures nothing, which must not make the whole
+        // command read as uninsurable.
+        let planned = plan(r#"echo hi && psql -d shop -c "TRUNCATE users""#)
+            .expect("the insurable segment must be found");
+        assert!(planned.contains("pg_dump"), "{planned}");
+    }
+
+    #[test]
+    fn take_insures_the_first_insurable_segment_of_a_compound() {
+        let tmp = TempTree::new("bk-compound");
+        let state = tmp.dir("state");
+        let doomed = tmp.file("doomed.txt", "precious");
+
+        let record = take(&state, &format!("echo hi && rm -rf {}", doomed.display()))
+            .expect("taking a backup must not fail")
+            .expect("the delete segment is insurable");
+
+        assert_eq!(record.kind, "files");
+        assert!(
+            state.join("backups").join("manifest.jsonl").is_file(),
+            "an insured operation leaves a record behind"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // git-ref insurance, against a real repository. `git_out` reads whatever
+    // repo the PROCESS is in, so these move into one.
+    // -----------------------------------------------------------------------
+
+    fn git_run(dir: &Path, args: &[&str]) -> String {
+        let out = Command::new("git")
+            .current_dir(dir)
+            .args([
+                "-c",
+                "user.email=tests@termaxa.invalid",
+                "-c",
+                "user.name=termaxa tests",
+                "-c",
+                "commit.gpgsign=false",
+            ])
+            .args(args)
+            .output()
+            .expect("git must be available: this is git insurance");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    /// A working copy on `branch`, with an `origin` that already has it.
+    fn repo_with_remote(env: &TestEnv, branch: &str) -> PathBuf {
+        let root = env.root().to_path_buf();
+        let remote = root.join("remote.git");
+        git_run(
+            &root,
+            &["init", "--bare", "-q", remote.to_str().expect("utf-8 path")],
+        );
+
+        let work = root.join("work");
+        std::fs::create_dir_all(&work).expect("work dir must be creatable");
+        git_run(&work, &["init", "-q"]);
+        git_run(
+            &work,
+            &["symbolic-ref", "HEAD", &format!("refs/heads/{branch}")],
+        );
+        git_run(
+            &work,
+            &["remote", "add", "origin", remote.to_str().expect("utf-8 path")],
+        );
+        std::fs::write(work.join("seed.txt"), "seed\n").expect("file must be writable");
+        git_run(&work, &["add", "-A"]);
+        git_run(&work, &["commit", "-q", "-m", "seed"]);
+        git_run(&work, &["push", "-q", "-u", "origin", branch]);
+        work
+    }
+
+    #[test]
+    fn the_branch_defaults_to_the_one_the_repository_is_on() {
+        let mut env = TestEnv::new("bk-branch");
+        let work = repo_with_remote(&env, "release/7");
+        env.chdir(&work);
+
+        assert_eq!(current_branch(), Some("release/7".to_string()));
+        // A force push that names no branch insures the branch you are on,
+        // not a guessed `main`.
+        assert_eq!(
+            git_force_push_target(&tokens_of("git push --force")),
+            Some(("origin".to_string(), "release/7".to_string()))
+        );
+    }
+
+    #[test]
+    fn a_forced_push_is_insured_by_pinning_the_remote_ref() {
+        let mut env = TestEnv::new("bk-gitref");
+        let work = repo_with_remote(&env, "main");
+        env.chdir(&work);
+
+        let record = backup_git_ref(
+            "b-1",
+            "2026-01-01T00:00:00Z",
+            "git push --force origin main",
+            "origin",
+            "main",
+        )
+        .expect("the remote ref must be pinnable");
+
+        assert_eq!(record.kind, "git-ref");
+        // The snapshot has to be a real ref, or the record promises a restore
+        // that cannot happen.
+        let pinned = record.data["branch"]
+            .as_str()
+            .expect("the record names its branch");
+        assert_eq!(pinned, "termaxa/backup/b-1");
+        assert_eq!(
+            git_run(&work, &["rev-parse", pinned]),
+            git_run(&work, &["rev-parse", "origin/main"]),
+            "the backup branch must point at what the remote had"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // The postgres paths, driven by stub binaries. Neither pg_dump nor psql is
+    // a reasonable test dependency, and what matters here is what the gate
+    // does with their EXIT STATUS — which a script can produce exactly.
+    // -----------------------------------------------------------------------
+
+    /// Put `name` on PATH as a script exiting with `code`, for the life of the
+    /// returned guard. PATH is process-global, so every caller holds `TestEnv`.
+    #[cfg(unix)]
+    fn stub_on_path(env: &TestEnv, name: &str, code: i32) -> PathGuard {
+        use std::os::unix::fs::PermissionsExt as _;
+        let bin_dir = env.root().join("stub-bin");
+        std::fs::create_dir_all(&bin_dir).expect("stub dir must be creatable");
+        let path = bin_dir.join(name);
+        // Write the -f target if asked for one, so a "successful" dump leaves
+        // the file its record will name.
+        std::fs::write(
+            &path,
+            "#!/bin/sh\nwhile [ $# -gt 0 ]; do\n  if [ \"$1\" = \"-f\" ]; then : > \"$2\"; fi\n  \
+             shift\ndone\necho 'stub' >&2\n"
+                .to_string()
+                + &format!("exit {code}\n"),
+        )
+        .expect("stub must be writable");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("stub must be executable");
+
+        let previous = std::env::var_os("PATH");
+        let combined = match &previous {
+            Some(p) => format!("{}:{}", bin_dir.display(), p.to_string_lossy()),
+            None => bin_dir.display().to_string(),
+        };
+        std::env::set_var("PATH", combined);
+        PathGuard { previous }
+    }
+
+    /// Restores PATH on drop, so a failing assertion cannot leave a stub
+    /// binary in front of the real one for the rest of the process.
+    #[cfg(unix)]
+    struct PathGuard {
+        previous: Option<std::ffi::OsString>,
+    }
+
+    #[cfg(unix)]
+    impl Drop for PathGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(p) => std::env::set_var("PATH", p),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_dump_that_failed_is_not_recorded_as_insurance() {
+        // The one lie insurance must never tell. `hook` ignores an Err from
+        // `take` and proceeds, so the error is what keeps a phantom record
+        // out of the manifest.
+        let env = TestEnv::new("bk-pg-fail");
+        let _guard = stub_on_path(&env, "pg_dump", 1);
+        let state = env.root().join("state");
+
+        let err = take(&state, r#"psql -d shop -c "TRUNCATE users""#)
+            .expect_err("a dump that did not run is not a backup");
+        assert!(err.to_string().contains("pg_dump failed"), "{err}");
+        assert!(
+            !state.join("backups").join("manifest.jsonl").exists(),
+            "nothing may be recorded for a dump that failed"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_successful_dump_is_recorded_with_the_file_it_wrote() {
+        let env = TestEnv::new("bk-pg-ok");
+        let _guard = stub_on_path(&env, "pg_dump", 0);
+        let state = env.root().join("state");
+
+        let record = take(&state, r#"psql -d shop -c "TRUNCATE users""#)
+            .expect("the dump must succeed")
+            .expect("a truncate is insurable");
+
+        assert_eq!(record.kind, "pg-dump");
+        let file = record.data["file"].as_str().expect("the record names a file");
+        assert!(
+            Path::new(file).is_file(),
+            "the record must name a dump that exists: {file}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_restore_that_failed_is_reported_rather_than_claimed() {
+        let env = TestEnv::new("bk-restore-fail");
+        let state = env.root().join("state");
+        {
+            // Take a real record first, with a dump that works.
+            let _guard = stub_on_path(&env, "pg_dump", 0);
+            take(&state, r#"psql -d shop -c "TRUNCATE users""#)
+                .expect("the dump must succeed")
+                .expect("a truncate is insurable");
+        }
+
+        // Then fail the restore: reporting success here would leave someone
+        // believing their data came back.
+        let _guard = stub_on_path(&env, "psql", 1);
+        let id = list(&state).expect("the manifest must read")[0].id.clone();
+        let err = restore(&state, &id).expect_err("a failed restore is not a restore");
+        assert!(err.to_string().contains("psql restore failed"), "{err}");
+    }
+
+    #[test]
+    fn a_restore_push_that_failed_is_reported_rather_than_claimed() {
+        // Restoring a git ref means force-pushing the pinned sha back. If
+        // that push does not land, the remote still holds the overwritten
+        // history — saying "restored" would send someone away believing the
+        // opposite of what happened.
+        let mut env = TestEnv::new("bk-restore-push");
+        let work = repo_with_remote(&env, "main");
+        env.chdir(&work);
+        let state = env.root().join("state");
+
+        let record = backup_git_ref(
+            "b-1",
+            "2026-01-01T00:00:00Z",
+            "git push --force origin main",
+            "origin",
+            "main",
+        )
+        .expect("the remote ref must be pinnable");
+        append_manifest(&state, &record).expect("the record must be writable");
+
+        // Take the remote away, so the restore push cannot succeed.
+        std::fs::remove_dir_all(env.root().join("remote.git")).expect("remote must be removable");
+
+        let err = restore(&state, "b-1").expect_err("a push that failed is not a restore");
+        assert!(err.to_string().contains("restore push failed"), "{err}");
+    }
+
+    #[test]
+    fn a_branch_that_cannot_be_created_is_reported_not_recorded() {
+        // Recording a snapshot that was never taken tells the user they are
+        // insured when they are not — the one lie insurance must not tell.
+        let mut env = TestEnv::new("bk-gitref-fail");
+        let work = repo_with_remote(&env, "main");
+        env.chdir(&work);
+        git_run(&work, &["branch", "termaxa/backup/b-collide", "HEAD"]);
+
+        let err = backup_git_ref(
+            "b-collide",
+            "2026-01-01T00:00:00Z",
+            "git push --force origin main",
+            "origin",
+            "main",
+        )
+        .expect_err("a branch that cannot be created is not a backup");
+        assert!(err.to_string().contains("git branch failed"), "{err}");
+    }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -97,6 +97,22 @@ pub fn apply(decision: Decision, signals: &[Signal]) -> (Decision, bool) {
     (decision, false)
 }
 
+fn current_git_branch() -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let branch = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if branch.is_empty() {
+        None
+    } else {
+        Some(branch)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -173,7 +189,10 @@ mod tests {
 
         let signal = branch_signal(&gather("git push origin main"));
         assert_eq!(signal.label, "current branch: main");
-        assert!(signal.escalate, "a push to main is the case this exists for");
+        assert!(
+            signal.escalate,
+            "a push to main is the case this exists for"
+        );
     }
 
     #[test]
@@ -295,21 +314,5 @@ mod tests {
         assert_eq!(out.action, Action::Allow);
         assert!(!escalated);
         assert_eq!(out.reason, "base", "an untouched decision keeps its reason");
-    }
-}
-
-fn current_git_branch() -> Option<String> {
-    let out = Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let branch = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if branch.is_empty() {
-        None
-    } else {
-        Some(branch)
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -97,6 +97,207 @@ pub fn apply(decision: Decision, signals: &[Signal]) -> (Decision, bool) {
     (decision, false)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::testutil::TestEnv;
+    use std::path::{Path, PathBuf};
+
+    fn git(dir: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("git must be available: branch awareness is what is under test");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// A repo with one commit, sitting on `branch`, with the process moved
+    /// into it — `current_git_branch` reads the cwd, so the branch has to be
+    /// real rather than mocked.
+    fn repo_on_branch(env: &mut TestEnv, branch: &str) -> PathBuf {
+        let dir = env.root().join("repo");
+        std::fs::create_dir_all(&dir).expect("repo dir must be creatable");
+        git(&dir, &["init", "-q"]);
+        git(
+            &dir,
+            &[
+                "-c",
+                "user.email=tests@termaxa.invalid",
+                "-c",
+                "user.name=termaxa tests",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--allow-empty",
+                "-q",
+                "-m",
+                "root",
+            ],
+        );
+        git(&dir, &["checkout", "-q", "-B", branch]);
+        env.chdir(&dir);
+        dir
+    }
+
+    fn branch_signal(signals: &[Signal]) -> Signal {
+        signals
+            .iter()
+            .find(|s| s.label.starts_with("current branch:"))
+            .cloned()
+            .expect("a git command in a repo should report the branch it is on")
+    }
+
+    #[test]
+    fn committing_reports_the_branch_without_escalating() {
+        let mut env = TestEnv::new("ctx-commit");
+        repo_on_branch(&mut env, "main");
+
+        let signal = branch_signal(&gather("git commit -m wip"));
+        assert_eq!(signal.label, "current branch: main");
+        // Being on main is worth showing; a commit is local and reversible,
+        // so it is not worth stopping for.
+        assert!(!signal.escalate, "a commit on main must not escalate");
+    }
+
+    #[test]
+    fn pushing_to_a_protected_branch_escalates() {
+        let mut env = TestEnv::new("ctx-push-main");
+        repo_on_branch(&mut env, "main");
+
+        let signal = branch_signal(&gather("git push origin main"));
+        assert_eq!(signal.label, "current branch: main");
+        assert!(signal.escalate, "a push to main is the case this exists for");
+    }
+
+    #[test]
+    fn pushing_from_a_feature_branch_does_not_escalate() {
+        let mut env = TestEnv::new("ctx-push-feature");
+        repo_on_branch(&mut env, "feature/widgets");
+
+        let signal = branch_signal(&gather("git push origin feature/widgets"));
+        assert_eq!(signal.label, "current branch: feature/widgets");
+        assert!(
+            !signal.escalate,
+            "only the protected branches make a push notable"
+        );
+    }
+
+    #[test]
+    fn a_production_marker_is_flagged_on_a_non_git_command() {
+        let signals = gather("psql -h prod-db.internal -c 'select 1'");
+        let prod = signals
+            .iter()
+            .find(|s| s.label.contains("possible production target"))
+            .expect("`prod` in a connection string is the whole point of this check");
+        assert!(prod.escalate);
+    }
+
+    #[test]
+    fn git_commands_are_exempt_from_the_production_marker() {
+        // Branch and remote names carry `production` constantly; flagging
+        // every one of them would train the human to click through.
+        let signals = gather("git push origin production");
+        assert!(
+            !signals
+                .iter()
+                .any(|s| s.label.contains("possible production target")),
+            "a git ref named production is not a production target"
+        );
+    }
+
+    #[test]
+    fn an_ordinary_command_produces_no_signals_at_all() {
+        assert!(
+            gather("ls -la").is_empty(),
+            "a listing is not worth a signal"
+        );
+    }
+
+    #[test]
+    fn destructive_sql_and_flags_are_flagged() {
+        let signals = gather("psql -c \"TRUNCATE users\"");
+        assert!(signals
+            .iter()
+            .any(|s| s.label.contains("destructive SQL") && s.escalate));
+
+        let signals = gather("rm -rf build");
+        assert!(signals
+            .iter()
+            .any(|s| s.label.contains("destructive flag") && s.escalate));
+    }
+
+    #[test]
+    fn command_substitution_is_flagged_because_it_cannot_be_read() {
+        let signals = gather("echo $(cat /etc/passwd)");
+        assert!(signals
+            .iter()
+            .any(|s| s.label.contains("command substitution") && s.escalate));
+    }
+
+    fn decision(action: Action) -> Decision {
+        Decision {
+            action,
+            matched_rule: Some("rule".into()),
+            reason: "base".into(),
+        }
+    }
+
+    fn escalating() -> Vec<Signal> {
+        vec![Signal {
+            label: "destructive flag detected: --force".into(),
+            escalate: true,
+        }]
+    }
+
+    #[test]
+    fn context_escalates_allow_to_ask_and_says_why() {
+        let (out, escalated) = apply(decision(Action::Allow), &escalating());
+        assert_eq!(out.action, Action::Ask);
+        assert!(escalated);
+        assert!(
+            out.reason.contains("base") && out.reason.contains("--force"),
+            "the reason must keep the rule's own words and add the signal: {}",
+            out.reason
+        );
+        assert_eq!(
+            out.matched_rule,
+            Some("rule".into()),
+            "escalation does not change which rule matched"
+        );
+    }
+
+    #[test]
+    fn context_never_downgrades_a_decision() {
+        // A deny that a signal could soften would be a gate with a bypass.
+        let (out, escalated) = apply(decision(Action::Deny), &escalating());
+        assert_eq!(out.action, Action::Deny);
+        assert!(!escalated);
+
+        let (out, escalated) = apply(decision(Action::Ask), &escalating());
+        assert_eq!(out.action, Action::Ask);
+        assert!(!escalated);
+    }
+
+    #[test]
+    fn a_non_escalating_signal_leaves_allow_alone() {
+        let noted = vec![Signal {
+            label: "current branch: main".into(),
+            escalate: false,
+        }];
+        let (out, escalated) = apply(decision(Action::Allow), &noted);
+        assert_eq!(out.action, Action::Allow);
+        assert!(!escalated);
+        assert_eq!(out.reason, "base", "an untouched decision keeps its reason");
+    }
+}
+
 fn current_git_branch() -> Option<String> {
     let out = Command::new("git")
         .args(["rev-parse", "--abbrev-ref", "HEAD"])

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -970,6 +970,33 @@ mod tests {
     }
 
     #[test]
+    fn a_delete_too_large_to_copy_says_that_rather_than_naming_insurance() {
+        // "Not recoverable" is ambiguous on its own: it could mean no backup
+        // engine covers the command, or that the target is simply too big to
+        // copy. Two different facts get two different sentences, and reaching
+        // this one needs a scan that actually caps.
+        let tmp = TempTree::new("del-too-large");
+        let dir = tmp.dir("huge");
+        for i in 0..(MAX_FILES + 100) {
+            std::fs::write(dir.join(format!("f{i}")), "").expect("file must be writable");
+        }
+
+        let lines = preview_lines(&format!("rm -rf {}", dir.display()), None);
+        assert!(
+            has_line(&lines, "too large to copy"),
+            "an insurable command over budget must say which fact applies: {lines:?}"
+        );
+        assert!(
+            !has_line(&lines, "insurance   :"),
+            "it cannot both promise insurance and say it is out of reach: {lines:?}"
+        );
+        assert!(
+            has_line(&lines, "+ files (stopped counting)"),
+            "the count says it stopped: {lines:?}"
+        );
+    }
+
+    #[test]
     fn a_cmd_switch_is_matched_by_shape_not_by_its_leading_slash() {
         for switch in ["/s", "/q", "/f", "/a:h", "/a:"] {
             assert!(is_cmd_switch(switch), "{switch} is a cmd switch");

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -1090,7 +1090,11 @@ mod tests {
         // make something a profile, or every third-level directory on the
         // machine becomes one.
         let same_depth_elsewhere = env.root().join("srv").join("bob");
-        assert!(!is_user_profile(&same_depth_elsewhere), "{}", same_depth_elsewhere.display());
+        assert!(
+            !is_user_profile(&same_depth_elsewhere),
+            "{}",
+            same_depth_elsewhere.display()
+        );
     }
 
     #[test]

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -831,4 +831,230 @@ mod tests {
         assert_eq!(fmt_num(1000), "1,000");
         assert_eq!(fmt_num(0), "0");
     }
+
+    // -----------------------------------------------------------------------
+    // What the preview says, and what it declines to say. Every line here is
+    // read by a human deciding whether to approve a deletion.
+    // -----------------------------------------------------------------------
+
+    use crate::testutil::TestEnv;
+
+    fn preview_lines(command: &str, root: Option<&Path>) -> Vec<String> {
+        preview_for(command, root)
+            .map(|p| p.lines)
+            .unwrap_or_default()
+    }
+
+    fn has_line(lines: &[String], needle: &str) -> bool {
+        lines.iter().any(|l| l.contains(needle))
+    }
+
+    #[test]
+    fn the_as_written_line_appears_only_when_resolution_changed_something() {
+        let tmp = TempTree::new("del-written");
+        let dir = tmp.dir("target");
+
+        // An absolute path resolves to itself, and echoing it back twice is
+        // noise that trains people to skip the block.
+        let lines = preview_lines(&format!("rm -rf {}", dir.display()), None);
+        assert!(!has_line(&lines, "as written"), "{lines:?}");
+
+        // `./x` beside its absolute form is the same path to a reader.
+        let lines = preview_lines("rm -rf ./some-relative-target", None);
+        assert!(!has_line(&lines, "as written"), "{lines:?}");
+
+        // A `~` expansion genuinely changes what is about to be deleted.
+        let lines = preview_lines("rm -rf ~/some-home-target", None);
+        assert!(
+            has_line(&lines, "as written"),
+            "an expansion the reader would miss has to be shown: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn a_target_outside_the_project_root_is_called_out() {
+        let tmp = TempTree::new("del-outside");
+        let root = tmp.dir("project");
+        let inside = tmp.dir("project/build");
+        let outside = tmp.dir("elsewhere");
+
+        let lines = preview_lines(&format!("rm -rf {}", outside.display()), Some(&root));
+        assert!(has_line(&lines, "OUTSIDE the project root"), "{lines:?}");
+
+        let lines = preview_lines(&format!("rm -rf {}", inside.display()), Some(&root));
+        assert!(
+            !has_line(&lines, "OUTSIDE the project root"),
+            "a warning that fires on ordinary work is one nobody reads: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn a_target_that_does_not_exist_says_so_instead_of_counting() {
+        let tmp = TempTree::new("del-absent");
+        let missing = tmp.absent("not-here");
+        let present = tmp.dir("here");
+
+        let lines = preview_lines(&format!("rm -rf {}", missing.display()), None);
+        assert!(has_line(&lines, "does not exist"), "{lines:?}");
+        // Nothing is counted, because there is nothing there to count. (The
+        // absence is reported on the same `contains` line, so the assertion
+        // is on the count itself.)
+        assert!(!has_line(&lines, "files across"), "{lines:?}");
+
+        let lines = preview_lines(&format!("rm -rf {}", present.display()), None);
+        assert!(!has_line(&lines, "does not exist"), "{lines:?}");
+        assert!(has_line(&lines, "files across"), "{lines:?}");
+    }
+
+    #[test]
+    fn an_insurable_delete_within_budget_reports_its_insurance() {
+        let tmp = TempTree::new("del-insurance");
+        let dir = tmp.dir("small");
+        std::fs::write(dir.join("a.txt"), "a").expect("file must be writable");
+
+        let lines = preview_lines(&format!("rm -rf {}", dir.display()), None);
+        assert!(
+            has_line(&lines, "insurance   :"),
+            "a small delete is recoverable and should say so: {lines:?}"
+        );
+        assert!(
+            !has_line(&lines, "too large to copy"),
+            "nothing here is too large: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn a_cmd_switch_is_matched_by_shape_not_by_its_leading_slash() {
+        for switch in ["/s", "/q", "/f", "/a:h", "/a:"] {
+            assert!(is_cmd_switch(switch), "{switch} is a cmd switch");
+        }
+        // Four characters and a leading slash, but a path: `del /s /q /tmp`
+        // must keep its target.
+        for path in ["/tmp", "/usr", "/c/Users", "/a:hidden", "notaswitch"] {
+            assert!(!is_cmd_switch(path), "{path} is a path");
+        }
+    }
+
+    #[test]
+    fn a_drive_letter_is_split_only_when_it_really_is_one() {
+        assert_eq!(split_drive("c/Users/x"), Some(("c", "Users/x")));
+        assert_eq!(split_drive("c"), Some(("c", "")));
+        // `/usr/local/lib` must not resolve to `C:/usr/local/lib`.
+        assert_eq!(split_drive("usr/local/lib"), None);
+        assert_eq!(split_drive("1/x"), None);
+    }
+
+    #[test]
+    fn a_tilde_is_expanded_to_the_home_it_names() {
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .expect("a home directory must be set");
+        let home = PathBuf::from(home);
+
+        assert_eq!(resolve_path("~"), home);
+        assert_eq!(resolve_path("~/projects"), home.join("projects"));
+        // A path that merely starts with the character is not an expansion.
+        assert_ne!(resolve_path("~notauser"), home.join("notauser"));
+    }
+
+    /// Sets HOME/USERPROFILE for the life of the guard. Process-global, so
+    /// every caller holds `TestEnv`'s lock.
+    struct HomeGuard {
+        home: Option<std::ffi::OsString>,
+        profile: Option<std::ffi::OsString>,
+    }
+
+    impl HomeGuard {
+        fn set(home: Option<&Path>) -> Self {
+            let guard = HomeGuard {
+                home: std::env::var_os("HOME"),
+                profile: std::env::var_os("USERPROFILE"),
+            };
+            std::env::remove_var("USERPROFILE");
+            match home {
+                Some(p) => std::env::set_var("HOME", p),
+                None => std::env::remove_var("HOME"),
+            }
+            guard
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match self.home.take() {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match self.profile.take() {
+                Some(v) => std::env::set_var("USERPROFILE", v),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+    }
+
+    #[test]
+    fn a_home_and_its_siblings_are_recognised_as_profiles() {
+        let env = TestEnv::new("del-profile");
+        let users = env.root().join("home");
+        let alice = users.join("alice");
+        std::fs::create_dir_all(&alice).expect("home must be creatable");
+        let _guard = HomeGuard::set(Some(&alice));
+
+        assert!(is_user_profile(&alice), "the home itself");
+        assert!(
+            is_user_profile(&users.join("bob")),
+            "a sibling profile: an agent on a mistyped path lands here"
+        );
+        assert!(
+            !is_user_profile(&alice.join("projects")),
+            "something inside a profile is not the profile"
+        );
+        assert!(
+            !is_user_profile(&env.root().join("etc")),
+            "a different parent is a different thing"
+        );
+        // Same depth as the home, different parent. Depth alone must not
+        // make something a profile, or every third-level directory on the
+        // machine becomes one.
+        let same_depth_elsewhere = env.root().join("srv").join("bob");
+        assert!(!is_user_profile(&same_depth_elsewhere), "{}", same_depth_elsewhere.display());
+    }
+
+    #[test]
+    fn the_profile_shapes_are_recognised_even_with_no_home_set() {
+        let _env = TestEnv::new("del-profile-fallback");
+        let _guard = HomeGuard::set(None);
+
+        assert!(is_user_profile(Path::new("/home/alice")));
+        assert!(is_user_profile(Path::new("/Users/alice")));
+        assert!(is_user_profile(Path::new("C:\\Users\\alice")));
+        assert!(!is_user_profile(Path::new("/home/alice/projects")));
+        assert!(!is_user_profile(Path::new("/etc")));
+    }
+
+    #[test]
+    fn sensitive_children_are_named_whatever_their_casing() {
+        let tmp = TempTree::new("del-sensitive");
+        let dir = tmp.dir("home");
+        std::fs::create_dir_all(dir.join(".SSH")).expect("dir must be creatable");
+        std::fs::write(dir.join(".env"), "SECRET=1").expect("file must be writable");
+        std::fs::write(dir.join("notes.txt"), "hello").expect("file must be writable");
+
+        let found = sensitive_children(&dir);
+        let names: Vec<&str> = found.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(
+            names.contains(&".SSH"),
+            "an upper-case spelling holds the same keys: {names:?}"
+        );
+        assert!(names.contains(&".env"), "{names:?}");
+        assert_eq!(
+            found.len(),
+            2,
+            "two different sensitive entries are two findings: {names:?}"
+        );
+        assert!(
+            !names.contains(&"notes.txt"),
+            "ordinary files are not findings: {names:?}"
+        );
+    }
 }

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -519,6 +519,7 @@ pub fn scan_budgeted(root: &Path) -> Scan {
     }
 
     while let Some(dir) = stack.pop() {
+        // Budget check at the pop bounds long runs of small directories…
         if files >= MAX_FILES || start.elapsed() > MAX_TIME {
             return Scan {
                 files,
@@ -531,6 +532,26 @@ pub fn scan_budgeted(root: &Path) -> Scan {
         };
         dirs += 1;
         for e in entries.flatten() {
+            // …and the check HERE bounds one large directory. Until v0.16 the
+            // budget was only consulted between directories, so a single big
+            // dir ran to completion: thousands of symlink_metadata calls with
+            // no way to stop. On a filesystem where each stat costs
+            // milliseconds — WSL2 with Windows drives mounted was the field
+            // case — that turned a 300ms budget into 5.8–7.1 measured seconds,
+            // blew the doctor probe's 2s timeout, and a correctly gated setup
+            // reported "registered but NOT firing". hook_configured inverted:
+            // red over a gated session. It also let a flat directory of 6,000
+            // files overrun MAX_FILES and return capped:false. Reported by
+            // Tim Schipper. The residue, stated: a budget can only act BETWEEN
+            // syscalls — one genuinely hung stat (dead network mount) is the
+            // OS's to interrupt, not ours.
+            if files >= MAX_FILES || start.elapsed() > MAX_TIME {
+                return Scan {
+                    files,
+                    dirs,
+                    capped: true,
+                };
+            }
             // symlink_metadata: do NOT follow links. Following them would both
             // inflate the count and risk walking out of the target entirely
             // (see the junction-traversal issue).
@@ -821,6 +842,31 @@ mod tests {
         assert_eq!(scan.files, 17, "must count files recursively");
         assert_eq!(scan.dirs, 2);
         assert!(!scan.capped, "17 files is well under the budget");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The field case, made deterministic: the budget must bind INSIDE one
+    /// directory, not just between directories. Before the fix this returned
+    /// files=5500, capped=false — over budget and misreported. (The time
+    /// half of the same check can't be pinned without a slow filesystem;
+    /// it is the same line of code, so this count test holds both.)
+    #[test]
+    fn a_single_large_directory_cannot_blow_the_budget() {
+        let tmp = TempTree::new("scan-flat");
+        let dir = tmp.path().to_path_buf();
+        for i in 0..(MAX_FILES + 500) {
+            std::fs::write(dir.join(format!("f{i}")), "").unwrap();
+        }
+        let scan = scan_budgeted(&dir);
+        assert!(
+            scan.capped,
+            "a flat directory larger than the budget must report capped"
+        );
+        assert!(
+            scan.files <= MAX_FILES,
+            "the count must stop at the budget, not at the directory's end: {}",
+            scan.files
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -957,4 +957,264 @@ mod tests {
         assert!(c.enabled);
         assert_eq!(c.threshold, 2);
     }
+
+    // -----------------------------------------------------------------------
+    // Spellings. Every predicate below decides whether a command presses the
+    // circuit breaker, so a flag it fails to recognise is a command that
+    // accumulates no pressure at all.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn the_most_severe_intent_in_a_compound_is_the_one_reported() {
+        // Ordered worst-first on purpose: a ranking that returned a constant
+        // would still pick the last one and look correct.
+        assert_eq!(
+            classify_command(r#"psql -c "DROP TABLE users" && rm -rf ./build"#),
+            Some(Intent::DbDestroy)
+        );
+    }
+
+    #[test]
+    fn a_delete_counts_when_it_is_recursive_or_forced_in_any_dialect() {
+        for command in [
+            "rm -r ./dir",
+            "rm -f notes.txt",
+            "rm -rf ./dir",
+            "rm --force notes.txt",
+            "del /s C:\\tmp",
+            "del /q C:\\tmp",
+            "Remove-Item -Recurse ./dir",
+            "Remove-Item -Force notes.txt",
+        ] {
+            assert_eq!(
+                classify_command(command),
+                Some(Intent::FileDelete),
+                "{command}"
+            );
+        }
+        // A single-file delete with no force and no recursion is ordinary work.
+        assert_eq!(classify_command("rm notes.txt"), None);
+    }
+
+    #[test]
+    fn a_long_flag_that_merely_contains_the_letter_is_not_the_short_flag() {
+        // `-r` and `-f` are read out of bundled short flags, so the letter
+        // test must not reach into long options that happen to spell one.
+        // All three are real rm options: the first two carry an `r`, and
+        // `--one-file-system` carries an `f`.
+        assert_eq!(classify_command("rm --verbose notes.txt"), None);
+        assert_eq!(classify_command("rm --preserve-root notes.txt"), None);
+        assert_eq!(classify_command("rm --one-file-system ./dir"), None);
+    }
+
+    #[test]
+    fn find_and_xargs_count_only_when_they_invoke_a_delete() {
+        for command in [
+            "find . -delete",
+            "find . -mindepth 1 -exec rm -rf {} +",
+            "find . -execdir unlink {} ;",
+            "xargs rm -rf",
+        ] {
+            assert_eq!(
+                classify_command(command),
+                Some(Intent::FileDelete),
+                "{command}"
+            );
+        }
+        // An -exec that runs something harmless is not a delete.
+        assert_eq!(classify_command("find . -exec ls {} +"), None);
+        assert_eq!(classify_command("xargs ls -la"), None);
+    }
+
+    #[test]
+    fn shred_counts_only_when_it_also_removes() {
+        assert_eq!(
+            classify_command("shred -u secrets.txt"),
+            Some(Intent::FileDelete)
+        );
+        assert_eq!(
+            classify_command("shred --remove secrets.txt"),
+            Some(Intent::FileDelete)
+        );
+        // Overwriting in place leaves the file there.
+        assert_eq!(classify_command("shred secrets.txt"), None);
+        // And the flag belongs to shred, not to whatever else spells it.
+        assert_eq!(classify_command("ls -u"), None);
+    }
+
+    #[test]
+    fn every_git_spelling_that_destroys_history_is_recognised() {
+        for command in [
+            "git push --force origin main",
+            "git push -f origin main",
+            "git push --force-with-lease origin main",
+            "git push origin +main",
+            "git reset --hard HEAD~3",
+            "git branch -D feature",
+        ] {
+            assert_eq!(
+                classify_command(command),
+                Some(Intent::GitDestructive),
+                "{command}"
+            );
+        }
+        for benign in [
+            "git push origin main",
+            "git reset --soft HEAD~1",
+            "git branch -d merged-feature",
+        ] {
+            assert_eq!(classify_command(benign), None, "{benign}");
+        }
+    }
+
+    /// KNOWN GAP, pinned so a fix flips it deliberately rather than by
+    /// accident: `git clean -f` is classified and `git clean --force` is not.
+    /// The two spellings delete the same untracked files. The rm predicate a
+    /// few lines above handles its own long form by listing `--force`
+    /// explicitly; this one only reads bundled short flags, so the long
+    /// spelling presses nothing toward the breaker and shows no intent in the
+    /// report.
+    #[test]
+    fn git_clean_recognises_only_the_short_force_flag() {
+        assert_eq!(
+            classify_command("git clean -f"),
+            Some(Intent::GitDestructive)
+        );
+        assert_eq!(
+            classify_command("git clean -fd"),
+            Some(Intent::GitDestructive)
+        );
+        assert_eq!(
+            classify_command("git clean --force"),
+            None,
+            "if this ever starts classifying, the gap was fixed and this test \
+             should be inverted rather than deleted"
+        );
+        // A dry run destroys nothing either way.
+        assert_eq!(classify_command("git clean -n"), None);
+    }
+
+    #[test]
+    fn destructive_sql_is_recognised_through_a_db_client() {
+        for sql in [
+            "DROP TABLE users",
+            "DROP DATABASE shop",
+            "DROP SCHEMA public CASCADE",
+            "TRUNCATE users",
+            "DELETE FROM users",
+        ] {
+            assert_eq!(
+                classify_command(&format!(r#"psql -d shop -c "{sql}""#)),
+                Some(Intent::DbDestroy),
+                "{sql}"
+            );
+        }
+        // A bounded delete is ordinary work, and a read is not destruction.
+        assert_eq!(
+            classify_command(r#"psql -d shop -c "DELETE FROM users WHERE id = 1""#),
+            None
+        );
+        assert_eq!(classify_command(r#"psql -d shop -c "SELECT 1""#), None);
+    }
+
+    #[test]
+    fn infrastructure_teardown_is_recognised_by_its_verb() {
+        for command in ["terraform destroy", "tofu destroy", "kubectl delete pod web"] {
+            assert_eq!(
+                classify_command(command),
+                Some(Intent::InfraDestroy),
+                "{command}"
+            );
+        }
+        for benign in ["terraform plan", "kubectl get pods"] {
+            assert_eq!(classify_command(benign), None, "{benign}");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // The tail read. The breaker only sees what this window returns, so its
+    // size and its boundary decide whether repeated attempts accumulate.
+    // -----------------------------------------------------------------------
+
+    /// A log of `n` entries, every line padded to exactly `LINE` bytes so the
+    /// read window can be aligned on a line boundary on purpose.
+    fn padded_log(dir: &std::path::Path, n: usize) -> std::path::PathBuf {
+        const LINE: usize = 1024;
+        let path = dir.join("audit.jsonl");
+        let mut out = String::new();
+        for i in 0..n {
+            let mut entry = serde_json::json!({
+                "session": "sess-1",
+                "source": "hook",
+                "command": format!("rm -rf ./dir{i}"),
+                "decision": "deny",
+                "intent": Intent::FileDelete.label(),
+                "pad": "",
+            });
+            let base = serde_json::to_string(&entry).expect("entry must serialize");
+            // -1 for the newline this line will carry.
+            let pad = LINE - 1 - base.len();
+            entry["pad"] = serde_json::Value::String("x".repeat(pad));
+            let line = serde_json::to_string(&entry).expect("entry must serialize");
+            assert_eq!(line.len(), LINE - 1, "every line must be exactly {LINE} bytes");
+            out.push_str(&line);
+            out.push('\n');
+        }
+        std::fs::write(&path, out).expect("log must be writable");
+        path
+    }
+
+    #[test]
+    fn the_window_reads_back_the_bytes_it_promises() {
+        let tmp = TempTree::new("intent-window");
+        // 128 KiB of log: twice the window, so the count is decided by the
+        // window size rather than by how much was written.
+        let log = padded_log(tmp.path(), 128);
+
+        let counted = recent_intent_count(&log, "sess-1", Intent::FileDelete, 64 * 1024);
+        assert_eq!(
+            counted, 63,
+            "64 KiB holds 64 lines, and the one the window lands on top of is \
+             dropped as possibly partial"
+        );
+
+        // A smaller window sees proportionally less, which is what makes the
+        // constant load-bearing.
+        let counted = recent_intent_count(&log, "sess-1", Intent::FileDelete, 8 * 1024);
+        assert_eq!(counted, 7);
+    }
+
+    #[test]
+    fn the_breaker_looks_back_further_than_a_line_or_two() {
+        // The window is the whole reason repeated attempts accumulate.
+        // Shrink it and a session that is plainly flailing reads as a first
+        // offence, which is the failure mode the breaker exists to prevent.
+        let tmp = TempTree::new("intent-trip-window");
+        let log = padded_log(tmp.path(), 128);
+        let policy = tmp.file(
+            "policy.yaml",
+            "version: 1\ndefault: ask\nrules: []\ncircuit_breaker:\n  enabled: true\n  threshold: 5\n",
+        );
+
+        let (intent, prior, _reason) = maybe_trip(&policy, &log, Some("sess-1"), "rm -rf ./another")
+            .expect("dozens of prior denied attempts is well past a threshold of 5");
+        assert_eq!(intent, Intent::FileDelete);
+        assert!(
+            prior >= 60,
+            "the window must reach back across the whole log, counted {prior}"
+        );
+    }
+
+    #[test]
+    fn a_log_smaller_than_the_window_is_read_whole() {
+        // start == 0, so there is no partial first line to drop, and dropping
+        // one anyway would lose a real attempt.
+        let tmp = TempTree::new("intent-whole");
+        let log = padded_log(tmp.path(), 4);
+
+        assert_eq!(
+            recent_intent_count(&log, "sess-1", Intent::FileDelete, 64 * 1024),
+            4
+        );
+    }
 }

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -1119,7 +1119,11 @@ mod tests {
 
     #[test]
     fn infrastructure_teardown_is_recognised_by_its_verb() {
-        for command in ["terraform destroy", "tofu destroy", "kubectl delete pod web"] {
+        for command in [
+            "terraform destroy",
+            "tofu destroy",
+            "kubectl delete pod web",
+        ] {
             assert_eq!(
                 classify_command(command),
                 Some(Intent::InfraDestroy),
@@ -1156,7 +1160,11 @@ mod tests {
             let pad = LINE - 1 - base.len();
             entry["pad"] = serde_json::Value::String("x".repeat(pad));
             let line = serde_json::to_string(&entry).expect("entry must serialize");
-            assert_eq!(line.len(), LINE - 1, "every line must be exactly {LINE} bytes");
+            assert_eq!(
+                line.len(),
+                LINE - 1,
+                "every line must be exactly {LINE} bytes"
+            );
             out.push_str(&line);
             out.push('\n');
         }
@@ -1196,8 +1204,9 @@ mod tests {
             "version: 1\ndefault: ask\nrules: []\ncircuit_breaker:\n  enabled: true\n  threshold: 5\n",
         );
 
-        let (intent, prior, _reason) = maybe_trip(&policy, &log, Some("sess-1"), "rm -rf ./another")
-            .expect("dozens of prior denied attempts is well past a threshold of 5");
+        let (intent, prior, _reason) =
+            maybe_trip(&policy, &log, Some("sess-1"), "rm -rf ./another")
+                .expect("dozens of prior denied attempts is well past a threshold of 5");
         assert_eq!(intent, Intent::FileDelete);
         assert!(
             prior >= 60,

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -88,3 +88,140 @@ pub fn test(policy: &Policy) -> anyhow::Result<i32> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read as _, Write as _};
+    use std::net::TcpListener;
+
+    /// A listener that answers one request and hands back what it received.
+    /// The webhook is fire-and-forget, so the only way to know what was sent
+    /// is to be the thing receiving it.
+    fn capture<F: FnOnce(String)>(status: &str, body_of: F) -> Option<String> {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("a local port must be bindable");
+        let port = listener.local_addr().expect("the port must be readable").port();
+        let status = status.to_string();
+
+        let handle = std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().ok()?;
+            sock.set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                .ok()?;
+            // The body follows the headers in its own packet, so one read
+            // returns the request line and nothing that was sent.
+            let mut raw = Vec::new();
+            let mut chunk = [0u8; 1024];
+            loop {
+                match sock.read(&mut chunk) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => raw.extend_from_slice(&chunk[..n]),
+                }
+                let text = String::from_utf8_lossy(&raw);
+                let Some((head, body)) = text.split_once("\r\n\r\n") else {
+                    continue;
+                };
+                let want: usize = head
+                    .lines()
+                    .find_map(|l| l.strip_prefix("Content-Length: "))
+                    .and_then(|v| v.trim().parse().ok())
+                    .unwrap_or(0);
+                if body.len() >= want {
+                    break;
+                }
+            }
+            let _ = sock.write_all(
+                format!("HTTP/1.1 {status}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                    .as_bytes(),
+            );
+            Some(String::from_utf8_lossy(&raw).into_owned())
+        });
+
+        body_of(format!("http://127.0.0.1:{port}/hook"));
+        handle.join().ok().flatten()
+    }
+
+    fn policy_with(webhook: String, on: Vec<&str>) -> Policy {
+        let yaml = format!(
+            "version: 1\ndefault: ask\nrules: []\nnotify:\n  webhook: {}\n  on: [{}]\n",
+            webhook,
+            on.join(", ")
+        );
+        serde_yaml::from_str(&yaml).expect("policy must parse")
+    }
+
+    #[test]
+    fn each_decision_carries_its_own_mark() {
+        // The mark is the first thing a reader sees in the channel, and it is
+        // the only part of the message that distinguishes a block from an
+        // approval at a glance.
+        for (decision, mark) in [("deny", "🛑"), ("ask", "⚠️"), ("allow", "✅")] {
+            let got = capture("200 OK", |url| {
+                let policy = policy_with(url, vec![decision]);
+                maybe_send(&policy, decision, "rm -rf /", "matched a rule", "hook");
+            })
+            .unwrap_or_default();
+            assert!(
+                got.contains(mark),
+                "a {decision} should be marked {mark}: {got:?}"
+            );
+            assert!(got.contains(&decision.to_uppercase()), "{got:?}");
+        }
+    }
+
+    #[test]
+    fn only_the_decisions_the_policy_asked_for_are_sent() {
+        // `on: [deny]` is the default, and a webhook that fires on every
+        // decision is one people mute.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("a port must be bindable");
+        let port = listener.local_addr().expect("readable").port();
+        listener.set_nonblocking(true).expect("non-blocking");
+        let policy = policy_with(format!("http://127.0.0.1:{port}/hook"), vec!["deny"]);
+
+        maybe_send(&policy, "allow", "ls", "no rule matched", "hook");
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        assert!(
+            listener.accept().is_err(),
+            "an allow must not reach a deny-only webhook"
+        );
+    }
+
+    #[test]
+    fn the_probe_reports_what_the_endpoint_actually_said() {
+        // The normal path is fire-and-forget, which means a misconfigured
+        // webhook fails silently. This command is the counterweight, so its
+        // exit code has to distinguish delivered from rejected.
+        let code = capture("200 OK", |url| {
+            let policy = policy_with(url, vec!["deny"]);
+            assert_eq!(test(&policy).expect("the probe must not error"), 0);
+        });
+        assert!(
+            code.unwrap_or_default().contains("termaxa notify --test"),
+            "the probe says which command sent it"
+        );
+
+        let sent = capture("500 Internal Server Error", |url| {
+            let policy = policy_with(url, vec!["deny"]);
+            assert_eq!(
+                test(&policy).expect("a rejection is reported, not raised"),
+                1,
+                "an endpoint that rejects the probe is not a working webhook"
+            );
+        });
+        assert!(sent.is_some(), "the endpoint was reached");
+    }
+
+    #[test]
+    fn a_policy_with_no_notify_section_has_nothing_to_test() {
+        let policy: Policy = serde_yaml::from_str("version: 1\ndefault: ask\nrules: []\n")
+            .expect("policy must parse");
+        assert_eq!(
+            test(&policy).expect("a missing section is not an error"),
+            1,
+            "there is nothing to report on, and saying so is not success"
+        );
+        // And nothing is sent, which is why this cannot be asserted by a
+        // listener: there is no request to observe.
+        maybe_send(&policy, "deny", "rm -rf /", "matched", "hook");
+    }
+}
+

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -100,7 +100,10 @@ mod tests {
     /// is to be the thing receiving it.
     fn capture<F: FnOnce(String)>(status: &str, body_of: F) -> Option<String> {
         let listener = TcpListener::bind("127.0.0.1:0").expect("a local port must be bindable");
-        let port = listener.local_addr().expect("the port must be readable").port();
+        let port = listener
+            .local_addr()
+            .expect("the port must be readable")
+            .port();
         let status = status.to_string();
 
         let handle = std::thread::spawn(move || {
@@ -224,4 +227,3 @@ mod tests {
         maybe_send(&policy, "deny", "rm -rf /", "matched", "hook");
     }
 }
-

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -287,7 +287,7 @@ fn copy_recursive(src: &Path, dst: &Path) -> Result<()> {
 mod tests {
     use super::*;
 
-    use crate::testutil::TestEnv;
+    use crate::testutil::{TempTree, TestEnv};
 
     #[test]
     fn hash_key_stable_across_path_representations() {
@@ -324,6 +324,138 @@ mod tests {
             paths.state_dir.starts_with(env.home()),
             "state must resolve under this test's own TERMAXA_HOME, got {}",
             paths.state_dir.display()
+        );
+    }
+
+    #[test]
+    fn only_a_drive_letter_is_case_folded() {
+        // The lowercasing exists for `C:` vs `c:`. A directory name that
+        // merely starts with a letter must keep its case, or two different
+        // projects can share a state directory.
+        assert_eq!(hash_key("Users/x/proj"), "Users/x/proj");
+        assert_ne!(hash_key("Users/x/proj"), hash_key("users/x/proj"));
+    }
+
+    #[test]
+    fn the_root_path_survives_both_guards() {
+        // One character: the trailing-slash strip must not eat the only
+        // thing there is, and the drive-letter check must not read a second
+        // byte that does not exist.
+        assert_eq!(hash_key("/"), "/");
+        assert_eq!(hash_key("/a/"), "/a");
+        assert_eq!(hash_key("/a///"), "/a");
+    }
+
+    #[test]
+    fn the_hash_is_the_published_algorithm_not_merely_a_stable_one() {
+        // Golden values. Any other mixing step still produces hashes that are
+        // stable and distinct, so only a known answer pins FNV-1a itself —
+        // and the state directory a project resolves to depends on it.
+        assert_eq!(fnv1a_hex8("abc"), "e25ef552");
+        assert_eq!(fnv1a_hex8("/home/u/proj"), "430add1b");
+    }
+
+    #[test]
+    fn demo_state_dir_sits_under_the_home_and_is_ready_to_write() {
+        let env = TestEnv::new("demo-state");
+        let dir = demo_state_dir().expect("demo state must resolve");
+
+        assert!(
+            dir.starts_with(env.home()),
+            "demo state belongs under TERMAXA_HOME, got {}",
+            dir.display()
+        );
+        assert!(dir.ends_with("demo"));
+        // A zero-setup check writes immediately; the directories have to be
+        // there before it does.
+        assert!(dir.join("logs").is_dir());
+        assert!(dir.join("backups").is_dir());
+    }
+
+    #[test]
+    fn legacy_in_repo_state_is_moved_and_its_recorded_paths_rewritten() {
+        let env = TestEnv::new("migrate");
+        let proj = env.project("legacy");
+        let in_repo = proj.join(".termaxa");
+
+        // The pre-v0.8 layout: logs and backups inside the repository.
+        std::fs::create_dir_all(in_repo.join("logs")).expect("legacy logs must be creatable");
+        std::fs::write(
+            in_repo.join("logs").join("audit.jsonl"),
+            "{\"command\":\"legacy entry\"}\n",
+        )
+        .expect("legacy log must be writable");
+
+        let old_backups = in_repo.join("backups");
+        std::fs::create_dir_all(&old_backups).expect("legacy backups must be creatable");
+        let payload = old_backups.join("payload.sql");
+        std::fs::write(&payload, "-- dump\n").expect("payload must be writable");
+        let record = serde_json::json!({
+            "id": "b1",
+            "data": { "file": payload.display().to_string() },
+        });
+        std::fs::write(
+            old_backups.join("manifest.jsonl"),
+            format!("{}\n", record),
+        )
+        .expect("legacy manifest must be writable");
+
+        let paths = resolve_from(&proj).expect("resolve must migrate on the way past");
+
+        // Nothing is left behind in the repository.
+        assert!(!in_repo.join("logs").join("audit.jsonl").exists());
+        assert!(!payload.exists());
+
+        // The payload moved, or `rollback` would point at nothing.
+        let new_backups = paths.state_dir.join("backups");
+        assert!(
+            new_backups.join("payload.sql").is_file(),
+            "the payload must arrive at {}",
+            new_backups.display()
+        );
+
+        // The old log is appended to the home log rather than replacing it.
+        let log = std::fs::read_to_string(paths.log_file()).expect("the log must be readable");
+        assert!(log.contains("legacy entry"), "{log:?}");
+
+        // And every recorded path is rewritten, which is the whole reason the
+        // manifest is handled apart from the payloads it names.
+        let manifest = std::fs::read_to_string(new_backups.join("manifest.jsonl"))
+            .expect("the manifest must be readable");
+        assert!(
+            manifest.contains(&new_backups.join("payload.sql").display().to_string()),
+            "the record must name the payload's new home: {manifest:?}"
+        );
+        assert!(
+            !manifest.contains(&old_backups.display().to_string()),
+            "no record may still point into the repository: {manifest:?}"
+        );
+    }
+
+    #[test]
+    fn copy_recursive_reproduces_a_whole_tree() {
+        // `move_path` only reaches this when `rename` fails, i.e. across a
+        // filesystem — and then it is the only thing between a backup and a
+        // lost payload.
+        let tmp = TempTree::new("copy-tree");
+        let src = tmp.dir("src");
+        std::fs::create_dir_all(src.join("nested").join("deeper"))
+            .expect("tree must be creatable");
+        std::fs::write(src.join("top.txt"), "top").expect("file must be writable");
+        std::fs::write(src.join("nested").join("deeper").join("leaf.txt"), "leaf")
+            .expect("file must be writable");
+
+        let dst = tmp.absent("dst");
+        copy_recursive(&src, &dst).expect("the tree must copy");
+
+        assert_eq!(
+            std::fs::read_to_string(dst.join("top.txt")).expect("top must arrive"),
+            "top"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dst.join("nested").join("deeper").join("leaf.txt"))
+                .expect("the nested leaf must arrive"),
+            "leaf"
         );
     }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -394,11 +394,8 @@ mod tests {
             "id": "b1",
             "data": { "file": payload.display().to_string() },
         });
-        std::fs::write(
-            old_backups.join("manifest.jsonl"),
-            format!("{}\n", record),
-        )
-        .expect("legacy manifest must be writable");
+        std::fs::write(old_backups.join("manifest.jsonl"), format!("{}\n", record))
+            .expect("legacy manifest must be writable");
 
         let paths = resolve_from(&proj).expect("resolve must migrate on the way past");
 
@@ -439,8 +436,7 @@ mod tests {
         // lost payload.
         let tmp = TempTree::new("copy-tree");
         let src = tmp.dir("src");
-        std::fs::create_dir_all(src.join("nested").join("deeper"))
-            .expect("tree must be creatable");
+        std::fs::create_dir_all(src.join("nested").join("deeper")).expect("tree must be creatable");
         std::fs::write(src.join("top.txt"), "top").expect("file must be writable");
         std::fs::write(src.join("nested").join("deeper").join("leaf.txt"), "leaf")
             .expect("file must be writable");

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -417,15 +417,27 @@ mod tests {
 
         // And every recorded path is rewritten, which is the whole reason the
         // manifest is handled apart from the payloads it names.
+        //
+        // Compared as a PATH rather than as text: the manifest is JSON, so on
+        // Windows every separator in it is an escaped backslash and a raw path
+        // never appears literally. Matching the rendering rather than the
+        // value passed on both other platforms and failed only where the
+        // escaping exists.
         let manifest = std::fs::read_to_string(new_backups.join("manifest.jsonl"))
             .expect("the manifest must be readable");
-        assert!(
-            manifest.contains(&new_backups.join("payload.sql").display().to_string()),
-            "the record must name the payload's new home: {manifest:?}"
+        let record: serde_json::Value =
+            serde_json::from_str(manifest.trim()).expect("the record must still be JSON");
+        let recorded = record["data"]["file"]
+            .as_str()
+            .expect("the record names its payload");
+        assert_eq!(
+            Path::new(recorded),
+            new_backups.join("payload.sql"),
+            "the record must name the payload's new home"
         );
         assert!(
-            !manifest.contains(&old_backups.display().to_string()),
-            "no record may still point into the repository: {manifest:?}"
+            !Path::new(recorded).starts_with(&old_backups),
+            "no record may still point into the repository: {recorded}"
         );
     }
 

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -791,7 +791,10 @@ mod tests {
         let (tables, _) = truncate_of("TRUNCATE ONLY users");
         assert_eq!(tables, ["users"]);
 
-        match parse_destructive("DELETE FROM ONLY users").into_iter().next() {
+        match parse_destructive("DELETE FROM ONLY users")
+            .into_iter()
+            .next()
+        {
             Some(Destructive::DeleteFrom { table, has_where }) => {
                 assert_eq!(table, "users");
                 assert!(!has_where);
@@ -881,7 +884,12 @@ mod tests {
         let args = connection_args(&shell_tokens(
             "psql -h db.internal -p 5433 -U app -d shop -c \"TRUNCATE users\"",
         ));
-        for pair in [["-h", "db.internal"], ["-p", "5433"], ["-U", "app"], ["-d", "shop"]] {
+        for pair in [
+            ["-h", "db.internal"],
+            ["-p", "5433"],
+            ["-U", "app"],
+            ["-d", "shop"],
+        ] {
             assert!(
                 args.windows(2).any(|w| w == pair),
                 "{pair:?} must survive: {args:?}"
@@ -1038,7 +1046,11 @@ mod tests {
             "{:?}",
             p.lines
         );
-        assert!(p.lines.iter().any(|l| l.contains("TRUNCATE users")), "{:?}", p.lines);
+        assert!(
+            p.lines.iter().any(|l| l.contains("TRUNCATE users")),
+            "{:?}",
+            p.lines
+        );
     }
 
     #[test]

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -716,4 +716,336 @@ mod tests {
         );
         assert_eq!(psql_program(&shell_tokens("evilpsql -c 'x'")), None);
     }
+
+    use crate::testutil::TempTree;
+
+    // -----------------------------------------------------------------------
+    // The grammar, at the places it decides how much is destroyed.
+    // -----------------------------------------------------------------------
+
+    fn truncate_of(sql: &str) -> (Vec<String>, bool) {
+        match parse_destructive(sql).into_iter().next() {
+            Some(Destructive::Truncate { tables, cascade }) => (tables, cascade),
+            other => panic!("expected a TRUNCATE, got {other:?} for {sql:?}"),
+        }
+    }
+
+    #[test]
+    fn a_table_list_ends_at_cascade_rather_than_swallowing_it() {
+        // CASCADE is a modifier, not a table. Reading it as one both invents a
+        // table and loses the fact that dependents will be emptied too.
+        let (tables, cascade) = truncate_of("TRUNCATE users CASCADE");
+        assert_eq!(tables, ["users"]);
+        assert!(cascade);
+
+        let (tables, cascade) = truncate_of("TRUNCATE users RESTRICT");
+        assert_eq!(tables, ["users"]);
+        assert!(!cascade, "RESTRICT is the opposite of CASCADE");
+    }
+
+    #[test]
+    fn a_comma_separated_list_is_read_in_either_spelling() {
+        for sql in ["TRUNCATE a, b", "TRUNCATE a , b", "TRUNCATE TABLE a, b"] {
+            let (tables, _) = truncate_of(sql);
+            assert_eq!(tables, ["a", "b"], "{sql}");
+        }
+        // A trailing comma runs the list to the very end of the statement,
+        // which is where the loop bound is the only thing left to stop it.
+        let (tables, _) = truncate_of("TRUNCATE a, b,");
+        assert_eq!(tables, ["a", "b"]);
+    }
+
+    /// KNOWN GAP, pinned so a fix flips it deliberately rather than by
+    /// accident. A comma with no space after it is valid SQL and this parser
+    /// does not read it: `clean_ident` refuses `a,b` because the comma is
+    /// interior rather than trailing, so the table list comes back empty and
+    /// the statement is classified as nothing.
+    ///
+    /// The consequence is not a missing preview. `backup::pg_backup_targets`
+    /// reads the same parse, so the command runs with NO pg_dump behind it:
+    ///
+    ///   TRUNCATE a, b   parsed, insurance planned
+    ///   TRUNCATE a,b    not parsed, NO insurance
+    ///
+    /// The intent classifier still sees it (it matches on the text), so policy
+    /// and the breaker still gate the command. It is only the safety net that
+    /// is decided by whitespace, which is the same class as the v0.14 path bug
+    /// in delete.rs: "path syntax must never decide whether a safety net
+    /// exists". Here it is comma spacing.
+    #[test]
+    fn a_comma_without_a_space_is_a_known_gap_with_no_insurance_beneath() {
+        assert!(
+            parse_destructive("TRUNCATE a,b").is_empty(),
+            "if this starts parsing, the gap closed and this test should be \
+             inverted rather than deleted"
+        );
+        assert!(parse_destructive("DROP TABLE a,b").is_empty());
+
+        // The spaced spelling of the same statement is read in full, which is
+        // what makes the difference a spelling rather than a limitation.
+        assert_eq!(truncate_of("TRUNCATE a, b").0, ["a", "b"]);
+    }
+
+    #[test]
+    fn only_is_stepped_over_rather_than_taken_as_the_table() {
+        let (tables, _) = truncate_of("TRUNCATE ONLY users");
+        assert_eq!(tables, ["users"]);
+
+        match parse_destructive("DELETE FROM ONLY users").into_iter().next() {
+            Some(Destructive::DeleteFrom { table, has_where }) => {
+                assert_eq!(table, "users");
+                assert!(!has_where);
+            }
+            other => panic!("expected a DELETE, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn delete_needs_both_of_its_keywords() {
+        // `DELETE ONLY users` is not a statement postgres accepts, and
+        // classifying it would be inventing a destruction that cannot happen.
+        assert!(parse_destructive("DELETE ONLY users").is_empty());
+        assert!(parse_destructive("FROM users").is_empty());
+    }
+
+    #[test]
+    fn a_malformed_if_exists_does_not_make_a_drop_invisible() {
+        // Both halves have to be present for the clause to be consumed. If
+        // only `IF` is checked, the parser steps past two words that are not
+        // there and loses the table list, and a DROP goes unclassified.
+        let found = parse_destructive("DROP TABLE IF users");
+        assert!(
+            !found.is_empty(),
+            "a DROP with a broken IF EXISTS is still a DROP"
+        );
+    }
+
+    #[test]
+    fn an_identifier_may_be_schema_qualified_or_carry_the_allowed_symbols() {
+        for (sql, want) in [
+            ("TRUNCATE public.users", "public.users"),
+            ("TRUNCATE _private", "_private"),
+            ("TRUNCATE tab$le", "tab$le"),
+            ("TRUNCATE \"users\"", "users"),
+        ] {
+            let (tables, _) = truncate_of(sql);
+            assert_eq!(tables, [want], "{sql}");
+        }
+        // And junk is refused rather than guessed at.
+        assert!(parse_destructive("TRUNCATE (select 1)").is_empty());
+    }
+
+    #[test]
+    fn the_tokenizer_keeps_each_quote_kind_to_itself() {
+        // A `"` inside single quotes is data, and a `'` inside double quotes
+        // is data. Reading either as a delimiter re-splits the SQL that
+        // follows it, and the statement the gate examines stops being the
+        // statement that will run.
+        assert_eq!(
+            shell_tokens("psql -c 'it\"s fine'"),
+            ["psql", "-c", "it\"s fine"]
+        );
+        assert_eq!(
+            shell_tokens("psql -c \"it's fine\""),
+            ["psql", "-c", "it's fine"]
+        );
+    }
+
+    #[test]
+    fn a_backslash_escapes_only_inside_double_quotes() {
+        // Inside double quotes it protects the next character, so the string
+        // does not end early. Outside them psql sees a literal backslash, and
+        // consuming the next character there would drop it from the command.
+        assert_eq!(
+            shell_tokens("psql -c \"a\\\"b\""),
+            ["psql", "-c", "a\"b"],
+            "the escaped quote belongs to the string, not to its end"
+        );
+        assert_eq!(shell_tokens("psql a\\b"), ["psql", "a\\b"]);
+    }
+
+    #[test]
+    fn a_psql_invocation_without_a_statement_has_nothing_to_preview() {
+        // extract_sql walks to the end of the token list here, and the bound
+        // on that walk is all that separates it from an index panic.
+        assert!(preview_for("psql -d shop", false).is_none());
+        assert!(preview_for("psql -d shop -U app -tAX", false).is_none());
+    }
+
+    #[test]
+    fn every_connection_parameter_survives_the_rebuild() {
+        // The argv is rebuilt from an allowlist rather than filtered, so a
+        // parameter missing from that list is one the preview silently
+        // connects without: a port dropped here sends the catalog query to
+        // 5432 and reports on whichever database answers there.
+        let args = connection_args(&shell_tokens(
+            "psql -h db.internal -p 5433 -U app -d shop -c \"TRUNCATE users\"",
+        ));
+        for pair in [["-h", "db.internal"], ["-p", "5433"], ["-U", "app"], ["-d", "shop"]] {
+            assert!(
+                args.windows(2).any(|w| w == pair),
+                "{pair:?} must survive: {args:?}"
+            );
+        }
+        // And the statement itself must not.
+        assert!(!args.iter().any(|a| a.contains("TRUNCATE")), "{args:?}");
+    }
+
+    #[test]
+    fn a_lone_dash_is_a_positional_not_a_flag_cluster() {
+        // `-` on its own carries no flag letters. Treating it as a cluster
+        // would silently drop it instead of letting it fall through to the
+        // positional handling psql itself applies.
+        let args = connection_args(&shell_tokens("psql -"));
+        assert!(args.windows(2).any(|w| w == ["-d", "-"]), "{args:?}");
+    }
+
+    #[test]
+    fn a_table_list_that_reaches_cascade_after_a_comma_still_stops() {
+        // The comma keeps the list open, so CASCADE arrives at the top of the
+        // loop rather than at its tail. It is a modifier either way.
+        let (tables, cascade) = truncate_of("TRUNCATE a, CASCADE");
+        assert_eq!(tables, ["a"]);
+        assert!(cascade);
+    }
+
+    #[test]
+    fn two_tables_without_a_comma_are_not_a_list() {
+        // `TRUNCATE a b` is not valid SQL, and reading it as two tables would
+        // mean insuring, previewing and reporting a table nobody named.
+        let (tables, _) = truncate_of("TRUNCATE a b");
+        assert_eq!(tables, ["a"]);
+    }
+
+    #[test]
+    fn thousands_are_grouped_at_every_boundary() {
+        assert_eq!(group_thousands(0), "0");
+        assert_eq!(group_thousands(999), "999");
+        assert_eq!(group_thousands(1000), "1,000");
+        assert_eq!(group_thousands(100), "100");
+        assert_eq!(group_thousands(1234567), "1,234,567");
+        assert_eq!(group_thousands(-1000), "-1,000");
+    }
+
+    #[test]
+    fn a_row_count_that_was_never_analyzed_says_so() {
+        // -1 is postgres saying "I have never counted", which is a different
+        // fact from zero rows and must not be printed as one.
+        let unknown = TableInfo {
+            rows: -1,
+            dependents: vec![],
+        };
+        assert_eq!(unknown.rows_display(), "unknown (never analyzed)");
+
+        let counted = TableInfo {
+            rows: 0,
+            dependents: vec![],
+        };
+        assert_eq!(counted.rows_display(), "0");
+    }
+
+    // -----------------------------------------------------------------------
+    // Introspection, against a stub psql.
+    //
+    // The stub is reached by ABSOLUTE PATH, taken from the command itself, so
+    // nothing here touches the process environment: psql_program accepts any
+    // path whose file stem is psql.
+    // -----------------------------------------------------------------------
+
+    #[cfg(unix)]
+    fn stub_psql(dir: &std::path::Path, body: &str, code: i32) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt as _;
+        let path = dir.join("psql");
+        std::fs::write(
+            &path,
+            format!("#!/bin/sh\nprintf '%s\\n' \"{body}\"\nexit {code}\n"),
+        )
+        .expect("stub must be writable");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("stub must be executable");
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn introspection_reads_the_row_count_and_the_dependents() {
+        let tmp = TempTree::new("pg-introspect");
+        // SET lines and blanks are noise from the session setup, not data.
+        let psql = stub_psql(tmp.path(), "SET\n\n120000\norders,invoices\n", 0);
+        let command = format!("{} -d shop -c \"TRUNCATE users\"", psql.display());
+
+        assert_eq!(
+            fk_dependents(&command, "users"),
+            ["orders", "invoices"],
+            "the dependents decide what a CASCADE would also empty"
+        );
+
+        let p = preview_for(&command, true).expect("a truncate is previewable");
+        assert!(
+            p.lines.iter().any(|l| l.contains("120,000")),
+            "the row estimate is the blast radius: {:?}",
+            p.lines
+        );
+        assert!(
+            p.lines
+                .iter()
+                .any(|l| l.contains("without CASCADE") && l.contains("orders")),
+            "a truncate with dependents and no CASCADE will fail, and saying so \
+             is the difference between a preview and a guess: {:?}",
+            p.lines
+        );
+        assert!(
+            !p.lines.iter().any(|l| l.contains("database unreachable")),
+            "the database answered: {:?}",
+            p.lines
+        );
+
+        // With CASCADE the dependents are emptied on purpose, so the warning
+        // that the statement will FAIL without it must not appear.
+        let with_cascade = format!("{} -d shop -c \"TRUNCATE users CASCADE\"", psql.display());
+        let p = preview_for(&with_cascade, true).expect("a truncate is previewable");
+        assert!(
+            !p.lines.iter().any(|l| l.contains("without CASCADE")),
+            "CASCADE was given: {:?}",
+            p.lines
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_empty_dependent_list_is_not_a_dependent() {
+        let tmp = TempTree::new("pg-deps");
+        let psql = stub_psql(tmp.path(), "SET\n7\norders,,invoices\n", 0);
+        let command = format!("{} -d shop -c \"TRUNCATE users\"", psql.display());
+
+        assert_eq!(fk_dependents(&command, "users"), ["orders", "invoices"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_database_that_refuses_degrades_to_static_analysis() {
+        // Wrong table, no permission, database down: all the same answer, and
+        // it must be a quieter preview rather than a missing one.
+        let tmp = TempTree::new("pg-refused");
+        let psql = stub_psql(tmp.path(), "FATAL: no", 1);
+        let command = format!("{} -d shop -c \"TRUNCATE users\"", psql.display());
+
+        assert!(fk_dependents(&command, "users").is_empty());
+
+        let p = preview_for(&command, true).expect("static analysis still applies");
+        assert!(
+            p.lines.iter().any(|l| l.contains("database unreachable")),
+            "{:?}",
+            p.lines
+        );
+        assert!(p.lines.iter().any(|l| l.contains("TRUNCATE users")), "{:?}", p.lines);
+    }
+
+    #[test]
+    fn a_client_that_is_not_psql_is_not_previewed() {
+        assert!(preview_for("mysql -e \"DROP TABLE users\"", false).is_none());
+        assert!(preview_for("psqlx -c \"DROP TABLE users\"", false).is_none());
+        // An absolute path to the real client still is one.
+        assert!(preview_for("/usr/bin/psql -c \"DROP TABLE users\"", false).is_some());
+    }
 }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -323,6 +323,150 @@ pub fn wildcard_match(pattern: &str, text: &str) -> bool {
 }
 
 #[cfg(test)]
+mod schema_and_severity_tests {
+    use super::*;
+
+    fn policy_from(yaml: &str) -> Policy {
+        serde_yaml::from_str(yaml).expect("policy must parse")
+    }
+
+    #[test]
+    fn an_omitted_field_gets_the_documented_default() {
+        let minimal = policy_from("default: ask\nrules: []\n");
+        assert_eq!(minimal.version, 1, "version 1 is the current schema");
+
+        let notifying = policy_from(
+            "default: ask\nrules: []\nnotify:\n  webhook: https://example.invalid/hook\n",
+        );
+        assert_eq!(
+            notifying.notify.expect("the notify block must parse").on,
+            ["deny"],
+            "notifying on every decision trains the reader to ignore them"
+        );
+    }
+
+    #[test]
+    fn case_sensitivity_is_written_out_only_when_it_was_asked_for() {
+        let plain = Rule {
+            r#match: "ls*".into(),
+            action: Action::Allow,
+            reason: None,
+            case_sensitive: false,
+        };
+        let json = serde_json::to_string(&plain).expect("a rule must serialize");
+        assert!(
+            !json.contains("case_sensitive"),
+            "the default must not clutter every rule: {json}"
+        );
+
+        let strict = Rule {
+            r#match: "git branch -D*".into(),
+            action: Action::Deny,
+            reason: None,
+            case_sensitive: true,
+        };
+        let json = serde_json::to_string(&strict).expect("a rule must serialize");
+        assert!(
+            json.contains("case_sensitive"),
+            "an opt-in has to survive the round trip: {json}"
+        );
+    }
+
+    #[test]
+    fn the_readings_include_the_tokenized_form_a_quote_would_hide() {
+        let views = readings(r#""rm" -rf /"#);
+        assert!(
+            views.contains(&r#""rm" -rf /"#.to_string()),
+            "the raw reading is still there: {views:?}"
+        );
+        assert!(
+            views.contains(&"rm -rf /".to_string()),
+            "quotes must not hide a command from its rule: {views:?}"
+        );
+    }
+
+    #[test]
+    fn an_ordinary_command_is_not_read_twice() {
+        // Nothing to strip and nothing to lower: one reading is enough, and a
+        // duplicate would just be work.
+        assert_eq!(readings("git status"), ["git status"]);
+    }
+
+    #[test]
+    fn the_earliest_of_two_equally_severe_rules_is_the_one_reported() {
+        // The quoted spelling matches rule 1; the tokenized reading matches
+        // rule 2. Same severity, so first-match-wins has to survive there
+        // being several readings.
+        let p = policy_from(
+            "default: allow\nrules:\n  - match: '\"rm\"*'\n    action: deny\n  \
+             - match: \"rm -rf*\"\n    action: deny\n",
+        );
+        let d = p.evaluate(r#""rm" -rf /"#);
+        assert_eq!(d.action, Action::Deny);
+        assert_eq!(d.matched_rule.as_deref(), Some("\"rm\"*"));
+    }
+
+    #[test]
+    fn the_earliest_rule_still_wins_when_the_order_is_reversed() {
+        // The mirror image, so "earliest" cannot be satisfied by accident of
+        // which reading happens to be examined first.
+        let p = policy_from(
+            "default: allow\nrules:\n  - match: \"rm -rf*\"\n    action: deny\n  \
+             - match: '\"rm\"*'\n    action: deny\n",
+        );
+        let d = p.evaluate(r#""rm" -rf /"#);
+        assert_eq!(d.matched_rule.as_deref(), Some("rm -rf*"));
+    }
+
+    #[test]
+    fn a_spelling_only_one_reading_recognises_gets_the_worse_verdict() {
+        // The documented cost of severity-across-readings: the raw reading
+        // matches the allow, the tokenized reading matches the deny, and the
+        // deny governs. This case fails CLOSED on purpose.
+        let p = policy_from(
+            "default: allow\nrules:\n  - match: '\"cat\"*'\n    action: allow\n  \
+             - match: \"cat .termaxa*\"\n    action: deny\n",
+        );
+        let d = p.evaluate(r#""cat" .termaxa/policy.yaml"#);
+        assert_eq!(
+            d.action,
+            Action::Deny,
+            "a spelling only some readings recognise must not reach the exception: {}",
+            d.reason
+        );
+    }
+
+    #[test]
+    fn the_first_of_two_equally_dangerous_segments_is_the_one_named() {
+        // Naming the later one would point the reader at the second-worst
+        // thing in the command.
+        let p = policy_from(
+            "default: allow\nrules:\n  - match: \"rm -rf*\"\n    action: deny\n  \
+             - match: \"drop table*\"\n    action: deny\n",
+        );
+        let d = p.evaluate_command("rm -rf /tmp/x && drop table users");
+        assert_eq!(d.action, Action::Deny);
+        assert_eq!(d.matched_rule.as_deref(), Some("rm -rf*"));
+        assert!(d.reason.contains("segment 1/2"), "{}", d.reason);
+    }
+
+    #[test]
+    fn an_explicit_allow_never_outranks_a_more_dangerous_default() {
+        // Segment 1 falls through to the `ask` default; segment 2 matches an
+        // explicit allow. A matched rule breaks TIES between equally severe
+        // segments — it does not lower the verdict.
+        let p = policy_from("default: ask\nrules:\n  - match: \"ls*\"\n    action: allow\n");
+        let d = p.evaluate_command("curl https://example.invalid/x | ls");
+        assert_eq!(
+            d.action,
+            Action::Ask,
+            "the most dangerous segment governs: {}",
+            d.reason
+        );
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -614,8 +614,16 @@ mod terraform_stub_tests {
     fn stub(dir: &Path, name: &str, plan: &str, code: i32) -> PathBuf {
         std::fs::create_dir_all(dir).expect("stub dir must be creatable");
         let path = dir.join(name);
-        std::fs::write(&path, format!("#!/bin/sh\ncat <<'PLAN'\n{plan}\nPLAN\nexit {code}\n"))
-            .expect("stub must be writable");
+        // printf rather than a heredoc through `cat`: `cat` is an external
+        // command, so the stub would depend on PATH resolving it, and PATH is
+        // exactly what the neighbouring test in this module rewrites while
+        // this one may be running. printf is a builtin and needs nothing
+        // found on disk.
+        std::fs::write(
+            &path,
+            format!("#!/bin/sh\nprintf '%s\\n' \"{plan}\"\nexit {code}\n"),
+        )
+        .expect("stub must be writable");
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
             .expect("stub must be executable");
         path

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -288,9 +288,411 @@ Plan: 2 to add, 0 to change, 1 to destroy.
     }
 
     #[test]
+    fn a_resource_line_needs_both_halves_of_its_shape() {
+        // Plan output is full of `#` comments, and prose elsewhere says "will
+        // be" constantly. A resource line is the intersection, not either one.
+        let out = "\
+  # this is a note about the plan
+  Terraform will be reading state
+  # aws_instance.old will be destroyed
+
+Plan: 0 to add, 0 to change, 1 to destroy.
+";
+        let (_, _, _, resources) = parse_tf_plan(out).unwrap();
+        assert_eq!(resources, ["aws_instance.old will be destroyed"]);
+    }
+
+    #[test]
     fn no_changes_is_zeroes() {
         let (a, c, d, _) = parse_tf_plan("No changes. Your infrastructure matches.").unwrap();
         assert_eq!((a, c, d), (0, 0, 0));
+    }
+}
+
+/// The live push preview, against real repositories.
+///
+/// `git()` runs wherever the PROCESS is, so every test here moves into a
+/// purpose-built repo — which is also why they take `TestEnv` and its lock
+/// rather than a bare scratch tree.
+#[cfg(test)]
+mod push_preview_tests {
+    use super::*;
+
+    use crate::testutil::TestEnv;
+    use std::path::{Path, PathBuf};
+
+    fn git_run(dir: &Path, args: &[&str]) -> String {
+        let out = Command::new("git")
+            .current_dir(dir)
+            .args([
+                "-c",
+                "user.email=tests@termaxa.invalid",
+                "-c",
+                "user.name=termaxa tests",
+                "-c",
+                "commit.gpgsign=false",
+            ])
+            .args(args)
+            .output()
+            .expect("git must be available: the preview under test is git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    fn commit_files(dir: &Path, names: &[String], message: &str) {
+        for name in names {
+            std::fs::write(dir.join(name), format!("{message}\n")).expect("file must be writable");
+        }
+        git_run(dir, &["add", "-A"]);
+        git_run(dir, &["commit", "-q", "-m", message]);
+    }
+
+    fn commit_one(dir: &Path, name: &str, message: &str) {
+        commit_files(dir, &[name.to_string()], message);
+    }
+
+    /// A working copy with `origin` beside it, one commit pushed and upstream
+    /// tracking set — case 1 of the three the preview distinguishes.
+    fn repo_with_remote(env: &mut TestEnv) -> PathBuf {
+        let root = env.root().to_path_buf();
+        let remote = root.join("remote.git");
+        git_run(
+            &root,
+            &["init", "--bare", "-q", remote.to_str().expect("utf-8 path")],
+        );
+
+        let work = root.join("work");
+        std::fs::create_dir_all(&work).expect("work dir must be creatable");
+        git_run(&work, &["init", "-q"]);
+        // Name the unborn branch rather than checking one out: `checkout -B`
+        // has no commit to stand on yet.
+        git_run(&work, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+        git_run(
+            &work,
+            &["remote", "add", "origin", remote.to_str().expect("utf-8 path")],
+        );
+        commit_one(&work, "seed.txt", "seed");
+        git_run(&work, &["push", "-q", "-u", "origin", "main"]);
+        // A bare repo's HEAD still names whatever `init` defaulted to, so a
+        // clone of it would land on an unborn branch of that name instead of
+        // the one branch that exists.
+        git_run(&remote, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+        env.chdir(&work);
+        work
+    }
+
+    /// Put a commit on the remote that the local branch does not have, so a
+    /// force push would destroy it.
+    fn advance_the_remote(root: &Path, remote: &Path) {
+        let other = root.join("other");
+        git_run(
+            root,
+            &[
+                "clone",
+                "-q",
+                remote.to_str().expect("utf-8 path"),
+                other.to_str().expect("utf-8 path"),
+            ],
+        );
+        commit_one(&other, "remote-only.txt", "only on the remote");
+        git_run(&other, &["push", "-q", "origin", "main"]);
+    }
+
+    fn preview_of(command: &str) -> Preview {
+        generate(command, None, true).expect("a live push preview should exist in a repo")
+    }
+
+    #[test]
+    fn a_branch_the_remote_has_never_seen_is_entirely_new() {
+        let mut env = TestEnv::new("preview-new-branch");
+        let work = repo_with_remote(&mut env);
+        git_run(&work, &["checkout", "-q", "-b", "feature/widgets"]);
+        commit_one(&work, "widget.txt", "widget");
+
+        let p = preview_of("git push origin feature/widgets");
+        assert_eq!(
+            p.summary, "new branch, 2 commit(s)",
+            "with no upstream and no origin/<branch>, everything is new"
+        );
+        assert!(p.title.contains("new remote branch"), "{}", p.title);
+    }
+
+    #[test]
+    fn nothing_to_push_is_said_plainly() {
+        let mut env = TestEnv::new("preview-current");
+        repo_with_remote(&mut env);
+
+        let p = preview_of("git push origin main");
+        assert_eq!(p.summary, "nothing to push");
+    }
+
+    #[test]
+    fn the_commit_list_is_capped_and_says_how_many_it_hid() {
+        let mut env = TestEnv::new("preview-ahead");
+        let work = repo_with_remote(&mut env);
+        for i in 0..7 {
+            commit_one(&work, &format!("f{i}.txt"), &format!("commit {i}"));
+        }
+
+        let p = preview_of("git push origin main");
+        assert!(
+            p.summary.starts_with("7 commit(s);"),
+            "the count leads the summary: {}",
+            p.summary
+        );
+        let listed = p.lines.iter().filter(|l| l.contains("commit ")).count();
+        assert_eq!(listed, 5, "five commits are listed, then a tally: {:?}", p.lines);
+        assert!(
+            p.lines.iter().any(|l| l.contains("... and 2 more")),
+            "the hidden ones are counted, not dropped: {:?}",
+            p.lines
+        );
+        assert!(
+            !p.summary.contains("LOSES"),
+            "an ordinary push loses nothing: {}",
+            p.summary
+        );
+        assert!(
+            !p.lines.iter().any(|l| l.contains("LOSE")),
+            "and says nothing about loss: {:?}",
+            p.lines
+        );
+    }
+
+    #[test]
+    fn a_forced_push_that_destroys_nothing_claims_no_losses() {
+        // The boundary the `> 0` guards sit on: forced, with a range to
+        // examine, but nothing on the remote to lose.
+        let mut env = TestEnv::new("preview-force-clean");
+        let work = repo_with_remote(&mut env);
+        commit_one(&work, "ahead.txt", "ahead");
+
+        let p = preview_of("git push -f origin main");
+        assert!(
+            !p.summary.contains("LOSES"),
+            "nothing is lost, so nothing is claimed: {}",
+            p.summary
+        );
+        assert!(
+            !p.lines.iter().any(|l| l.contains("LOSE")),
+            "{:?}",
+            p.lines
+        );
+    }
+
+    #[test]
+    fn a_forced_push_reports_what_the_remote_would_lose() {
+        // The v0.6.0 incident: the preview said "nothing to push" while a
+        // force push destroyed a commit. Gain and loss are different
+        // directions, and only the loss direction is the damage.
+        let mut env = TestEnv::new("preview-force-loss");
+        let work = repo_with_remote(&mut env);
+        let remote = env.root().join("remote.git");
+        advance_the_remote(&env.root().to_path_buf(), &remote);
+        git_run(&work, &["fetch", "-q", "origin"]);
+
+        // `-f` alone, not `--force`: both spellings must count as force.
+        let forced = preview_of("git push -f origin main");
+        assert!(
+            forced.summary.starts_with("remote LOSES 1 commit(s);"),
+            "the loss leads the summary: {}",
+            forced.summary
+        );
+        assert!(
+            forced
+                .lines
+                .iter()
+                .any(|l| l.contains("remote will LOSE 1 commit(s)")),
+            "and is spelled out in the body: {:?}",
+            forced.lines
+        );
+
+        // The same state without the force flag destroys nothing, so the
+        // preview must not borrow the forced reading.
+        let plain = preview_of("git push origin main");
+        assert_eq!(plain.summary, "nothing to push");
+    }
+
+    #[test]
+    fn the_file_list_is_capped_and_excludes_the_totals_line() {
+        let mut env = TestEnv::new("preview-files-many");
+        let work = repo_with_remote(&mut env);
+        let names: Vec<String> = (0..10).map(|i| format!("file{i:02}.txt")).collect();
+        commit_files(&work, &names, "ten files");
+
+        let p = preview_of("git push origin main");
+        assert!(
+            p.lines.iter().any(|l| l.contains("... and 2 more files")),
+            "ten files, eight shown: {:?}",
+            p.lines
+        );
+        // The last --stat line is the totals; it belongs in the summary, and
+        // listing it among the files would double-count it.
+        assert!(
+            !p.lines.iter().any(|l| l.contains("files changed")),
+            "the totals line is not a file: {:?}",
+            p.lines
+        );
+        assert!(
+            p.summary.contains("files changed"),
+            "the summary is where the totals go: {}",
+            p.summary
+        );
+    }
+
+    #[test]
+    fn a_short_file_list_still_stops_before_the_totals_line() {
+        // Under the cap of eight, the ONLY thing keeping the --stat totals
+        // line out of the file list is dropping the last entry. With ten
+        // files the cap hides that, and a list that ran one line too far
+        // would look correct.
+        let mut env = TestEnv::new("preview-files-few");
+        let work = repo_with_remote(&mut env);
+        let names: Vec<String> = (0..3).map(|i| format!("file{i}.txt")).collect();
+        commit_files(&work, &names, "three files");
+
+        let p = preview_of("git push origin main");
+        assert!(
+            !p.lines.iter().any(|l| l.contains("files changed")),
+            "the totals line is not one of the files: {:?}",
+            p.lines
+        );
+        let listed = p
+            .lines
+            .iter()
+            .filter(|l| l.contains(".txt") && l.contains('|'))
+            .count();
+        assert_eq!(listed, 3, "three files, three lines: {:?}", p.lines);
+    }
+
+    #[test]
+    fn exactly_eight_files_are_all_shown_without_a_tally() {
+        // The boundary: eight fit, so there is no "and N more" to add.
+        let mut env = TestEnv::new("preview-files-eight");
+        let work = repo_with_remote(&mut env);
+        let names: Vec<String> = (0..8).map(|i| format!("file{i}.txt")).collect();
+        commit_files(&work, &names, "eight files");
+
+        let p = preview_of("git push origin main");
+        assert!(
+            !p.lines.iter().any(|l| l.contains("more files")),
+            "nothing was hidden, so nothing is tallied: {:?}",
+            p.lines
+        );
+        let listed = p.lines.iter().filter(|l| l.contains("file")).count();
+        assert!(listed >= 8, "all eight are shown: {:?}", p.lines);
+    }
+}
+
+/// The terraform planner, driven by a stub binary.
+///
+/// Neither terraform nor tofu is a reasonable test dependency, and the plan
+/// output is the only thing this code reads — so a script that prints one is
+/// a complete stand-in. It is also how the live-gate finding below was
+/// originally confirmed.
+#[cfg(all(test, unix))]
+mod terraform_stub_tests {
+    use super::*;
+
+    use crate::testutil::{TempTree, TestEnv};
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+
+    const DESTROYS_ONE: &str = "  # aws_instance.old will be destroyed\n\
+                                \x20 # terraform_data.web will be created\n\
+                                Plan: 2 to add, 0 to change, 1 to destroy.";
+    const DESTROYS_NOTHING: &str = "  # terraform_data.web will be created\n\
+                                    Plan: 1 to add, 0 to change, 0 to destroy.";
+
+    /// A fake planner that prints `plan` and exits with `code`.
+    fn stub(dir: &Path, name: &str, plan: &str, code: i32) -> PathBuf {
+        std::fs::create_dir_all(dir).expect("stub dir must be creatable");
+        let path = dir.join(name);
+        std::fs::write(&path, format!("#!/bin/sh\ncat <<'PLAN'\n{plan}\nPLAN\nexit {code}\n"))
+            .expect("stub must be writable");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("stub must be executable");
+        path
+    }
+
+    #[test]
+    fn a_plan_that_destroys_something_leads_with_the_destruction() {
+        let tmp = TempTree::new("tf-destroys");
+        let bin = stub(tmp.path(), "faketf", DESTROYS_ONE, 0);
+
+        let p = terraform_preview(bin.to_str().expect("utf-8 path"), true)
+            .expect("a successful plan is a preview");
+        assert_eq!(p.summary, "plan: +2 ~0 -1");
+        assert!(
+            p.lines
+                .iter()
+                .any(|l| l.contains("1 resource(s) will be DESTROYED")),
+            "{:?}",
+            p.lines
+        );
+    }
+
+    #[test]
+    fn a_plan_that_destroys_nothing_says_nothing_about_destruction() {
+        let tmp = TempTree::new("tf-safe");
+        let bin = stub(tmp.path(), "faketf", DESTROYS_NOTHING, 0);
+
+        let p = terraform_preview(bin.to_str().expect("utf-8 path"), false)
+            .expect("a successful plan is a preview");
+        assert_eq!(p.summary, "plan: +1 ~0 -0");
+        assert!(
+            !p.lines.iter().any(|l| l.contains("DESTROYED")),
+            "a warning about zero resources is noise: {:?}",
+            p.lines
+        );
+    }
+
+    #[test]
+    fn a_plan_that_failed_is_not_read_at_all() {
+        // Valid-looking output on a non-zero exit: an uninitialised directory
+        // prints plenty. Best effort means staying silent, not guessing.
+        let tmp = TempTree::new("tf-failed");
+        let bin = stub(tmp.path(), "faketf", DESTROYS_ONE, 1);
+
+        assert!(terraform_preview(bin.to_str().expect("utf-8 path"), false).is_none());
+    }
+
+    #[test]
+    fn both_apply_and_destroy_reach_the_planner() {
+        // PATH is process-global, so this takes the environment lock. The
+        // binary name is fixed in the source, which is why the stub has to be
+        // found the way the real one would be.
+        let env = TestEnv::new("tf-path");
+        let bin_dir = env.root().join("bin");
+        stub(&bin_dir, "terraform", DESTROYS_ONE, 0);
+
+        let previous = std::env::var_os("PATH");
+        let combined = match &previous {
+            Some(p) => format!("{}:{}", bin_dir.display(), p.to_string_lossy()),
+            None => bin_dir.display().to_string(),
+        };
+        std::env::set_var("PATH", combined);
+
+        // Both verbs are gated the same way; capture before restoring so a
+        // failing assertion cannot leave PATH rewritten for the whole process.
+        let apply = generate("terraform apply -auto-approve", None, true);
+        let destroy = generate("terraform destroy", None, true);
+
+        match previous {
+            Some(p) => std::env::set_var("PATH", p),
+            None => std::env::remove_var("PATH"),
+        }
+
+        assert!(apply.is_some(), "`terraform apply` must be previewed");
+        assert!(destroy.is_some(), "`terraform destroy` must be previewed");
+        // `env` is still alive here, holding the lock across the restore.
+        drop(env);
     }
 }
 
@@ -326,6 +728,20 @@ mod live_gate_tests {
         assert!(
             p.summary.contains("users"),
             "denial reason lost its detail: {}",
+            p.summary
+        );
+    }
+
+    /// A compound command is previewed by the first segment that has an
+    /// answer, not by the whole string: `echo hi;psql -c "DROP TABLE users"`
+    /// is not a psql command, but half of it is.
+    #[test]
+    fn a_compound_command_is_previewed_by_its_first_meaningful_segment() {
+        let p = generate(r#"echo hi;psql -d shop -c "DROP TABLE users""#, None, false)
+            .expect("the segment carrying a preview must be found");
+        assert!(
+            p.summary.contains("users"),
+            "the segment's own analysis is what surfaces: {}",
             p.summary
         );
     }

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -374,7 +374,12 @@ mod push_preview_tests {
         git_run(&work, &["symbolic-ref", "HEAD", "refs/heads/main"]);
         git_run(
             &work,
-            &["remote", "add", "origin", remote.to_str().expect("utf-8 path")],
+            &[
+                "remote",
+                "add",
+                "origin",
+                remote.to_str().expect("utf-8 path"),
+            ],
         );
         commit_one(&work, "seed.txt", "seed");
         git_run(&work, &["push", "-q", "-u", "origin", "main"]);
@@ -447,7 +452,11 @@ mod push_preview_tests {
             p.summary
         );
         let listed = p.lines.iter().filter(|l| l.contains("commit ")).count();
-        assert_eq!(listed, 5, "five commits are listed, then a tally: {:?}", p.lines);
+        assert_eq!(
+            listed, 5,
+            "five commits are listed, then a tally: {:?}",
+            p.lines
+        );
         assert!(
             p.lines.iter().any(|l| l.contains("... and 2 more")),
             "the hidden ones are counted, not dropped: {:?}",
@@ -479,11 +488,7 @@ mod push_preview_tests {
             "nothing is lost, so nothing is claimed: {}",
             p.summary
         );
-        assert!(
-            !p.lines.iter().any(|l| l.contains("LOSE")),
-            "{:?}",
-            p.lines
-        );
+        assert!(!p.lines.iter().any(|l| l.contains("LOSE")), "{:?}", p.lines);
     }
 
     #[test]
@@ -494,7 +499,7 @@ mod push_preview_tests {
         let mut env = TestEnv::new("preview-force-loss");
         let work = repo_with_remote(&mut env);
         let remote = env.root().join("remote.git");
-        advance_the_remote(&env.root().to_path_buf(), &remote);
+        advance_the_remote(env.root(), &remote);
         git_run(&work, &["fetch", "-q", "origin"]);
 
         // `-f` alone, not `--force`: both spellings must count as force.

--- a/src/protect.rs
+++ b/src/protect.rs
@@ -246,4 +246,47 @@ mod tests {
         assert_eq!(what("", "policy.yaml"), None);
         assert_eq!(what("", "settings.json"), None);
     }
+
+    #[test]
+    fn an_absolute_path_is_never_resolved_against_the_cwd() {
+        // The cwd here is itself protected, so joining it onto an absolute
+        // path would refuse a file that has nothing to do with the gate.
+        assert_eq!(what("/repo/.termaxa", "/other/notes.md"), None);
+        assert_eq!(what("C:\\repo\\.termaxa", "\\other\\notes.md"), None);
+        // A drive letter makes a path absolute just as a leading separator does.
+        assert_eq!(what("C:\\repo\\.termaxa", "D:\\other\\notes.md"), None);
+    }
+
+    #[test]
+    fn separator_noise_does_not_shift_the_parent_directory() {
+        // `.` and empty segments are dropped, or `.claude/./settings.json`
+        // reads as a file whose parent is `.` and walks straight through.
+        assert_eq!(
+            what("/repo", "/repo/.claude/./settings.json"),
+            Some("agent-hook-config")
+        );
+        assert_eq!(
+            what("/repo", "/repo/.claude//settings.json"),
+            Some("agent-hook-config")
+        );
+    }
+
+    #[test]
+    fn only_settings_json_under_dot_claude_is_control_plane() {
+        // Both halves of the filename test matter, and so does the directory:
+        // widen any one of them and ordinary project files start being refused.
+        assert_eq!(what("/repo", "/repo/config/settings.json"), None);
+        assert_eq!(what("/repo", "/repo/.claude/mcp.json"), None);
+        assert_eq!(what("/repo", "/repo/.claude/settings.yaml"), None);
+    }
+
+    #[test]
+    fn the_github_dialect_only_claims_its_own_hooks_file() {
+        // `.github/hooks/` is not wholesale off limits — one filename in it is.
+        assert_eq!(what("/repo", "/repo/.github/hooks/config.json"), None);
+        assert_eq!(
+            what("/repo", "/repo/.github/hooks/hooks.json"),
+            Some("agent-hook-config")
+        );
+    }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -535,6 +535,390 @@ fn short(s: &str) -> String {
 mod tests {
     use super::*;
     use crate::intent::Intent;
+    use crate::testutil::TempTree;
+
+    /// One audit line. Tests override only the fields they are about, so the
+    /// thing under test is visible in the test rather than in the fixture.
+    fn entry(decision: &str, command: &str) -> AuditEntry {
+        AuditEntry {
+            ts_ms: 0,
+            ts: "2026-01-01T00:00:00Z".into(),
+            source: "hook".into(),
+            command: command.into(),
+            decision: decision.into(),
+            matched_rule: None,
+            reason: "because".into(),
+            signals: Vec::new(),
+            escalated: false,
+            session: None,
+            backup: None,
+            preview: None,
+            intent: None,
+            approved: None,
+            exit_code: None,
+            cwd: "/work/proj".into(),
+        }
+    }
+
+    fn paths_in(tmp: &TempTree) -> Paths {
+        Paths {
+            project_dir: tmp.dir("proj/.termaxa"),
+            state_dir: tmp.dir("state"),
+        }
+    }
+
+    /// `compute` over a fresh state dir. The tree is returned so it outlives
+    /// the report; dropping it early would delete the manifest under it.
+    fn compute_for(entries: &[AuditEntry]) -> (Report, TempTree) {
+        let tmp = TempTree::new("report");
+        let paths = paths_in(&tmp);
+        let refs: Vec<&AuditEntry> = entries.iter().collect();
+        let report = compute(&refs, &paths).expect("compute must succeed");
+        (report, tmp)
+    }
+
+    fn n_of(decision: &str, n: usize) -> Vec<AuditEntry> {
+        (0..n)
+            .map(|i| entry(decision, &format!("{decision}{i}")))
+            .collect()
+    }
+
+    #[test]
+    fn decision_counts_and_the_risk_formula_are_exact() {
+        // 1 deny, 3 escalated, 5 ask: chosen so that every coefficient and
+        // every operator in deny×3 + escalated×2 + ask×1 changes the answer
+        // if it is swapped. Equal counts would let ×2 and +2 agree.
+        let mut entries = vec![entry("deny", "rm -rf /")];
+        entries.extend(n_of("ask", 5));
+        for i in 0..3 {
+            let mut e = entry("allow", &format!("escalated{i}"));
+            e.escalated = true;
+            entries.push(e);
+        }
+
+        let (r, _tree) = compute_for(&entries);
+        assert_eq!(
+            (r.total, r.allow, r.ask, r.deny, r.escalated),
+            (9, 3, 5, 1, 3)
+        );
+        assert_eq!(r.risk_score, 3 + 6 + 5);
+        assert_eq!(r.risk_label, "High");
+        assert_eq!(r.auto_flow, r.allow, "auto-flow is the uninterrupted count");
+    }
+
+    #[test]
+    fn the_risk_bands_are_pinned_at_their_boundaries() {
+        // One ask is one point, so the count IS the score here.
+        for (asks, label) in [(0, "Low"), (2, "Low"), (3, "Medium"), (7, "Medium"), (8, "High")] {
+            let mut entries = vec![entry("allow", "ls")];
+            entries.extend(n_of("ask", asks));
+            let (r, _tree) = compute_for(&entries);
+            assert_eq!(
+                (r.risk_score, r.risk_label),
+                (asks as u32, label),
+                "{asks} asks should read as {label}"
+            );
+        }
+    }
+
+    #[test]
+    fn blocked_lists_denials_and_impacts_skip_what_simply_ran() {
+        let mut denied = entry("deny", "drop table users");
+        denied.preview = Some("DROP TABLE users".into());
+        let mut allowed = entry("allow", "select 1");
+        allowed.preview = Some("SELECT 1 row".into());
+        let mut asked = entry("ask", "delete from sessions");
+        asked.preview = Some("DELETE ~120,000 rows".into());
+
+        let (r, _tree) = compute_for(&[allowed, denied, asked]);
+        assert_eq!(r.blocked, ["drop table users"]);
+        // An allow's preview is not an intervention point: nothing intervened.
+        assert_eq!(r.impacts, ["DROP TABLE users", "DELETE ~120,000 rows"]);
+    }
+
+    #[test]
+    fn a_rollback_is_a_post_receipt_that_names_a_rollback() {
+        let mut receipt = entry("allow", "termaxa rollback abc123");
+        receipt.source = "post".into();
+        let mut other_receipt = entry("allow", "ls -la");
+        other_receipt.source = "post".into();
+        // Two of these: a single one would let "not a post receipt" score the
+        // same as the real rule and hide the swap.
+        let asked_once = entry("ask", "termaxa rollback def456");
+        let asked_twice = entry("ask", "termaxa rollback ghi789");
+
+        let (r, _tree) = compute_for(&[receipt, other_receipt, asked_once, asked_twice]);
+        assert_eq!(
+            r.rollbacks, 1,
+            "both halves hold: a post receipt AND a rollback command"
+        );
+    }
+
+    #[test]
+    fn intents_count_classifications_while_trips_count_blocks() {
+        let breaker = crate::intent::BREAKER_RULE;
+        let tripped = |command: &str, label: &str| {
+            let mut e = entry("deny", command);
+            e.matched_rule = Some(breaker.into());
+            e.intent = Some(label.into());
+            e
+        };
+        // Classified but never blocked: legitimate destructive work.
+        let mut ordinary = entry("allow", "rm -rf ./build");
+        ordinary.intent = Some("file-delete".into());
+
+        let (r, _tree) = compute_for(&[
+            tripped("rm -rf /", "file-delete"),
+            tripped("rm -rf /etc", "file-delete"),
+            ordinary,
+            tripped("drop database prod", "db-destroy"),
+        ]);
+
+        assert_eq!(r.breaker_trips, 3);
+        assert_eq!(
+            r.intents,
+            [("file-delete".to_string(), 3), ("db-destroy".to_string(), 1)],
+            "intents count every classification, blocked or not"
+        );
+        assert_eq!(
+            r.trips_by_intent,
+            [("file-delete".to_string(), 2), ("db-destroy".to_string(), 1)],
+            "trips count only what the breaker actually stopped"
+        );
+    }
+
+    #[test]
+    fn equally_frequent_intents_are_ordered_alphabetically() {
+        // Ties have to break somewhere, or the report reorders itself between
+        // runs on identical data.
+        let with_intent = |label: &str| {
+            let mut e = entry("allow", "cmd");
+            e.intent = Some(label.into());
+            e
+        };
+        let (r, _tree) = compute_for(&[
+            with_intent("git-destructive"),
+            with_intent("db-destroy"),
+            with_intent("infra-destroy"),
+        ]);
+        let labels: Vec<&str> = r.intents.iter().map(|(l, _)| l.as_str()).collect();
+        assert_eq!(labels, ["db-destroy", "git-destructive", "infra-destroy"]);
+    }
+
+    #[test]
+    fn recent_events_are_the_last_six_oldest_first() {
+        let entries = n_of("allow", 8);
+        let (r, _tree) = compute_for(&entries);
+
+        let commands: Vec<&str> = r.recent.iter().map(|(_, c)| c.as_str()).collect();
+        assert_eq!(
+            commands,
+            ["allow2", "allow3", "allow4", "allow5", "allow6", "allow7"]
+        );
+        assert!(r.recent[0].0.contains('✓'), "an allow is marked as success");
+    }
+
+    #[test]
+    fn the_window_spans_the_first_and_last_entry() {
+        let mut first = entry("allow", "first");
+        first.ts_ms = 60_000;
+        first.ts = "2026-01-01T00:01:00Z".into();
+        let mut last = entry("allow", "last");
+        last.ts_ms = 60_000 * 8;
+        last.ts = "2026-01-01T00:08:00Z".into();
+
+        let (r, _tree) = compute_for(&[first, last]);
+        assert_eq!(r.duration_min, 7);
+        assert_eq!(r.first_ts, "2026-01-01T00:01:00Z");
+        assert_eq!(r.last_ts, "2026-01-01T00:08:00Z");
+    }
+
+    #[test]
+    fn a_clock_that_went_backwards_reports_no_duration() {
+        // saturating_sub: a line stamped before its predecessor must not
+        // underflow into a duration of half a billion years.
+        let mut first = entry("allow", "first");
+        first.ts_ms = 60_000 * 8;
+        let mut last = entry("allow", "last");
+        last.ts_ms = 60_000;
+
+        let (r, _tree) = compute_for(&[first, last]);
+        assert_eq!(r.duration_min, 0);
+    }
+
+    #[test]
+    fn backups_are_joined_against_the_manifest_and_unknown_ids_dropped() {
+        let tmp = TempTree::new("report-backups");
+        let paths = paths_in(&tmp);
+        let manifest = tmp.dir("state/backups").join("manifest.jsonl");
+        std::fs::write(
+            &manifest,
+            "{\"id\":\"b1\",\"ts\":\"t\",\"kind\":\"pg-dump\",\"command\":\"psql\",\
+             \"data\":{},\"note\":\"dump of sessions\"}\n",
+        )
+        .expect("manifest must be writable");
+
+        let mut insured = entry("allow", "psql -c 'truncate sessions'");
+        insured.backup = Some("b1".into());
+        let mut dangling = entry("allow", "psql -c 'truncate users'");
+        // An id with no manifest record must not invent a backup line.
+        dangling.backup = Some("b404".into());
+
+        let refs = vec![&insured, &dangling];
+        let r = compute(&refs, &paths).expect("compute must succeed");
+        assert_eq!(
+            r.backups,
+            [("pg-dump".to_string(), "dump of sessions".to_string())]
+        );
+    }
+
+    #[test]
+    fn the_rollup_window_excludes_what_fell_out_of_it() {
+        let now = crate::audit::now().0;
+        let day_ms: u128 = 24 * 60 * 60 * 1000;
+
+        let mut fresh = entry("allow", "fresh");
+        fresh.ts_ms = now;
+        fresh.session = Some("s1".into());
+        fresh.backup = Some("b1".into());
+        let mut stale = entry("deny", "stale");
+        stale.ts_ms = now - 31 * day_ms;
+        stale.session = Some("s2".into());
+
+        let roll = compute_rollup(&[stale, fresh], 30);
+        assert_eq!(roll.days, 30);
+        assert_eq!(
+            (roll.commands, roll.sessions, roll.allow, roll.ask, roll.deny),
+            (1, 1, 1, 0, 0),
+            "the entry from 31 days ago is outside a 30-day window"
+        );
+        assert_eq!(roll.backups, 1);
+    }
+
+    #[test]
+    fn the_rollup_cutoff_is_exactly_the_window_in_days() {
+        // Days have to be converted to milliseconds by multiplication, all the
+        // way down. Any other arithmetic lands the cutoff hours or minutes ago
+        // instead of days, so an entry well inside the window falls out of it
+        // — which is what these two entries are placed to detect.
+        let now = crate::audit::now().0;
+        let day_ms: u128 = 24 * 60 * 60 * 1000;
+        let at = |ago: u128, command: &str| {
+            let mut e = entry("allow", command);
+            e.ts_ms = now - ago * day_ms;
+            e
+        };
+
+        let roll = compute_rollup(&[at(9, "outside"), at(5, "inside")], 7);
+        assert_eq!(
+            roll.commands, 1,
+            "five days ago is inside a seven-day window and nine days ago is not"
+        );
+    }
+
+    #[test]
+    fn the_rollup_counts_breaker_trips_not_everything_else() {
+        let now = crate::audit::now().0;
+        let tripped = |command: &str| {
+            let mut e = entry("deny", command);
+            e.ts_ms = now;
+            e.matched_rule = Some(crate::intent::BREAKER_RULE.into());
+            e
+        };
+        let mut ordinary = entry("allow", "ls");
+        ordinary.ts_ms = now;
+        ordinary.matched_rule = Some("allow-listing".into());
+
+        // Two and one, not one and one: equal counts would let "everything
+        // that is NOT a trip" score the same as the real rule.
+        let roll = compute_rollup(&[tripped("rm -rf /"), tripped("rm -rf /etc"), ordinary], 30);
+        assert_eq!(roll.breaker_trips, 2);
+    }
+
+    #[test]
+    fn the_rollup_ranks_the_busiest_directories_by_basename() {
+        let now = crate::audit::now().0;
+        let in_dir = |cwd: &str| {
+            let mut e = entry("allow", "cmd");
+            e.ts_ms = now;
+            e.cwd = cwd.into();
+            e
+        };
+        let mut entries: Vec<AuditEntry> = Vec::new();
+        for _ in 0..3 {
+            entries.push(in_dir("/work/alpha"));
+        }
+        for _ in 0..2 {
+            entries.push(in_dir("/work/beta/"));
+        }
+        entries.push(in_dir("C:\\work\\gamma"));
+        entries.push(in_dir("/work/delta"));
+        // A root cwd has no basename to report and must not become an entry.
+        entries.push(in_dir("/"));
+
+        let roll = compute_rollup(&entries, 30);
+        assert_eq!(roll.top_dirs.len(), 3, "at most three are shown");
+        assert_eq!(&roll.top_dirs[..2], ["alpha", "beta"], "busiest first");
+        assert!(
+            !roll.top_dirs.contains(&String::new()),
+            "a nameless directory is not a directory: {:?}",
+            roll.top_dirs
+        );
+    }
+
+    #[test]
+    fn a_session_label_is_shortened_for_display() {
+        assert_eq!(short("0123456789abcdef"), "session 01234567");
+        // Shorter than the cut is left whole rather than panicking on a slice.
+        assert_eq!(short("abc"), "session abc");
+    }
+
+    #[test]
+    fn a_report_with_no_activity_says_so_and_still_succeeds() {
+        let tmp = TempTree::new("report-empty");
+        let paths = paths_in(&tmp);
+        assert_eq!(
+            run(&paths, Scope::default(), false).expect("an empty log is not an error"),
+            0
+        );
+    }
+
+    #[test]
+    fn asking_for_a_session_that_is_not_there_fails_rather_than_reporting_everything() {
+        let tmp = TempTree::new("report-session");
+        let paths = paths_in(&tmp);
+        let log = AuditLog::new(&paths.state_dir).expect("log must be creatable");
+        for command in ["one", "two"] {
+            let mut e = entry("allow", command);
+            e.session = Some("abc12345".into());
+            log.append(&e).expect("append must succeed");
+        }
+
+        let scope = Scope {
+            session: Some("nope".into()),
+            ..Scope::default()
+        };
+        assert_eq!(
+            run(&paths, scope, false).expect("an empty scope is not an error"),
+            1,
+            "a scope with nothing in it must not report the whole log instead"
+        );
+
+        // The same log, scoped the ordinary way, is a report.
+        assert_eq!(run(&paths, Scope::default(), true).unwrap(), 0);
+        assert_eq!(
+            run(
+                &paths,
+                Scope {
+                    all: true,
+                    ..Scope::default()
+                },
+                false
+            )
+            .unwrap(),
+            0
+        );
+    }
 
     #[test]
     fn post_receipt_renders_as_success_not_denial() {

--- a/src/report.rs
+++ b/src/report.rs
@@ -609,7 +609,13 @@ mod tests {
     #[test]
     fn the_risk_bands_are_pinned_at_their_boundaries() {
         // One ask is one point, so the count IS the score here.
-        for (asks, label) in [(0, "Low"), (2, "Low"), (3, "Medium"), (7, "Medium"), (8, "High")] {
+        for (asks, label) in [
+            (0, "Low"),
+            (2, "Low"),
+            (3, "Medium"),
+            (7, "Medium"),
+            (8, "High"),
+        ] {
             let mut entries = vec![entry("allow", "ls")];
             entries.extend(n_of("ask", asks));
             let (r, _tree) = compute_for(&entries);
@@ -677,12 +683,18 @@ mod tests {
         assert_eq!(r.breaker_trips, 3);
         assert_eq!(
             r.intents,
-            [("file-delete".to_string(), 3), ("db-destroy".to_string(), 1)],
+            [
+                ("file-delete".to_string(), 3),
+                ("db-destroy".to_string(), 1)
+            ],
             "intents count every classification, blocked or not"
         );
         assert_eq!(
             r.trips_by_intent,
-            [("file-delete".to_string(), 2), ("db-destroy".to_string(), 1)],
+            [
+                ("file-delete".to_string(), 2),
+                ("db-destroy".to_string(), 1)
+            ],
             "trips count only what the breaker actually stopped"
         );
     }
@@ -788,7 +800,13 @@ mod tests {
         let roll = compute_rollup(&[stale, fresh], 30);
         assert_eq!(roll.days, 30);
         assert_eq!(
-            (roll.commands, roll.sessions, roll.allow, roll.ask, roll.deny),
+            (
+                roll.commands,
+                roll.sessions,
+                roll.allow,
+                roll.ask,
+                roll.deny
+            ),
             (1, 1, 1, 0, 0),
             "the entry from 31 days ago is outside a 30-day window"
         );

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -143,3 +143,119 @@ fn execute(argv: &[String]) -> Result<i32> {
     let status = Command::new(&argv[0]).args(&argv[1..]).status()?;
     Ok(status.code().unwrap_or(1))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::testutil::TempTree;
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|p| p.to_string()).collect()
+    }
+
+    /// A project whose policy gives every command the same verdict.
+    fn project_with_default(tmp: &TempTree, default: &str) -> crate::paths::Paths {
+        let project_dir = tmp.dir("proj/.termaxa");
+        std::fs::write(
+            project_dir.join("policy.yaml"),
+            format!("version: 1\ndefault: {}\nrules: []\n", default),
+        )
+        .expect("policy must be writable");
+        crate::paths::Paths {
+            project_dir,
+            state_dir: tmp.dir("state"),
+        }
+    }
+
+    #[test]
+    fn shell_join_leaves_ordinary_arguments_alone() {
+        // Nothing here carries structure, so nothing should gain quotes —
+        // the reconstruction is what rules are matched against.
+        assert_eq!(shell_join(&argv(&["git", "status"])), "git status");
+    }
+
+    #[test]
+    fn shell_join_keeps_a_quoted_argument_in_one_piece() {
+        // The v0.6 failure this function exists for: `-c "TRUNCATE users"`
+        // flattened into three words, so the backup layer never saw a
+        // truncate worth insuring.
+        assert_eq!(
+            shell_join(&argv(&["psql", "-c", "TRUNCATE users"])),
+            "psql -c \"TRUNCATE users\""
+        );
+    }
+
+    #[test]
+    fn shell_join_quotes_an_empty_argument() {
+        // An empty argument is a token too; unquoted it vanishes from the
+        // string entirely and `sh -c ""` reads as a bare `sh -c`.
+        assert_eq!(shell_join(&argv(&["sh", "-c", ""])), "sh -c \"\"");
+    }
+
+    #[test]
+    fn shell_join_quotes_on_a_quote_character_without_whitespace() {
+        assert_eq!(shell_join(&argv(&["say", "it's"])), "say \"it's\"");
+        assert_eq!(shell_join(&argv(&["say", "a\"b"])), "say \"a\\\"b\"");
+    }
+
+    #[test]
+    fn shell_join_escapes_backslashes_before_quoting() {
+        // Backslashes go first, or the escape added for `"` gets escaped in
+        // turn and the quoting closes early.
+        assert_eq!(
+            shell_join(&argv(&["cat", "C:\\tmp dir\\x"])),
+            "cat \"C:\\\\tmp dir\\\\x\""
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn execute_returns_the_child_exit_code() {
+        // 7 on purpose: none of 0, 1 or -1, so a body that reports a fixed
+        // code instead of the child's cannot pass.
+        assert_eq!(execute(&argv(&["sh", "-c", "exit 7"])).unwrap(), 7);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn execute_returns_the_child_exit_code() {
+        assert_eq!(execute(&argv(&["cmd", "/C", "exit 7"])).unwrap(), 7);
+    }
+
+    #[test]
+    fn execute_reports_an_unlaunchable_command_as_an_error() {
+        // Spawn failure must surface, not read as a successful exit 0.
+        assert!(execute(&argv(&["termaxa-no-such-binary-xyzzy"])).is_err());
+    }
+
+    #[test]
+    fn run_refuses_an_empty_command_line() {
+        let tmp = TempTree::new("runner-empty");
+        let paths = project_with_default(&tmp, "allow");
+
+        let err = run(&paths, &[]).expect_err("there is nothing to gate or execute");
+        assert!(
+            err.to_string().contains("nothing to run"),
+            "the error should say what was missing, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn run_blocks_a_denied_command_and_records_the_decision() {
+        let tmp = TempTree::new("runner-deny");
+        let paths = project_with_default(&tmp, "deny");
+
+        let code = run(&paths, &argv(&["echo", "hello"])).expect("a block is not an error");
+        assert_eq!(code, 1, "a blocked command must not report success");
+
+        let log = std::fs::read_to_string(paths.log_file())
+            .expect("every decision is logged, including the ones that ran nothing");
+        assert!(log.contains("\"decision\":\"deny\""), "{}", log);
+        assert!(log.contains("\"command\":\"echo hello\""), "{}", log);
+        // Nothing was launched, so there is no child exit code to report.
+        assert!(log.contains("\"exit_code\":null"), "{}", log);
+        assert!(log.contains("\"approved\":false"), "{}", log);
+    }
+}

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -535,7 +535,11 @@ mod tests {
         assert!(segs[1].starts_with("rm -rf"), "{segs:?}");
 
         let targets = redirect_targets("echo 'a\"b' > out.txt");
-        assert_eq!(targets.len(), 1, "the redirect is outside the quotes: {targets:?}");
+        assert_eq!(
+            targets.len(),
+            1,
+            "the redirect is outside the quotes: {targets:?}"
+        );
         assert_eq!(targets[0].target, "out.txt");
     }
 
@@ -546,7 +550,10 @@ mod tests {
         // and the `&&` becomes a separator.
         let segs = split_segments("echo \"a\\\"b && c\"");
         assert_eq!(segs.len(), 1, "{segs:?}");
-        assert_eq!(segs[0], "echo \"a\\\"b && c\"", "the text must survive intact");
+        assert_eq!(
+            segs[0], "echo \"a\\\"b && c\"",
+            "the text must survive intact"
+        );
     }
 
     #[test]

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -430,4 +430,184 @@ mod tests {
         assert!(!has_substitution("echo '$(safe)'"));
         assert!(!has_substitution("git status"));
     }
+
+    // -----------------------------------------------------------------------
+    // The edges of the character walk.
+    //
+    // Both parsers in this file were tested on realistic commands and never on
+    // the boundaries: a quote of one kind inside the other, an operator at the
+    // very end of the input, a segment that BEGINS with a redirect, an escape
+    // with nothing after it. Those are where a hand-written lexer goes wrong,
+    // and where a command slips past the gate whole.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_quote_of_one_kind_does_not_open_the_other() {
+        // If the apostrophe in `it's` opened a single-quoted run, everything
+        // after it would be literal text and the `&&` would stop separating
+        // commands. That is a bypass, not a formatting quirk.
+        let segs = split_segments("echo \"it's fine\" && rm -rf /tmp/x");
+        assert_eq!(segs.len(), 2, "{segs:?}");
+        assert!(segs[1].starts_with("rm -rf"), "{segs:?}");
+
+        let segs = split_segments("echo 'say \"hi\"' && rm -rf /tmp/x");
+        assert_eq!(segs.len(), 2, "{segs:?}");
+
+        // Same question for the redirect scanner: the apostrophe must not
+        // swallow the `>` that follows it.
+        let targets = redirect_targets("echo \"it's\" > out.txt");
+        assert_eq!(targets.len(), 1, "{targets:?}");
+        assert_eq!(targets[0].target, "out.txt");
+
+        let targets = redirect_targets("echo 'a \"b\"' > out.txt");
+        assert_eq!(targets[0].target, "out.txt");
+    }
+
+    #[test]
+    fn single_quotes_hide_a_substitution_and_double_quotes_do_not() {
+        // In a shell, `'` protects a backtick and `"` does not. Reading it the
+        // other way round either misses a substitution or flags every string.
+        assert!(!has_substitution("echo 'a `b` c'"));
+        assert!(has_substitution("echo \"a `b` c\""));
+        assert!(!has_substitution("echo 'a $(b) c'"));
+        assert!(has_substitution("echo \"a $(b) c\""));
+    }
+
+    #[test]
+    fn an_operator_at_the_very_end_is_not_read_past() {
+        // Each of these ends on a character whose handler looks at the NEXT
+        // one. Reading past the end is a panic in the hook, which is a gate
+        // that stopped answering.
+        assert_eq!(split_segments("ls &"), ["ls"]);
+        assert_eq!(split_segments("ls |"), ["ls"]);
+        assert_eq!(split_segments("ls &&"), ["ls"]);
+        assert_eq!(split_segments("ls ||"), ["ls"]);
+        // A trailing backslash, inside quotes and bare.
+        assert_eq!(split_segments("echo \"a\\"), ["echo \"a\\"]);
+        assert_eq!(redirect_targets("echo a\\").len(), 0);
+        assert_eq!(redirect_targets("echo > out.txt\\").len(), 1);
+    }
+
+    #[test]
+    fn a_segment_may_begin_with_the_operator() {
+        // Nothing precedes the first character, and the checks for "what came
+        // before this?" have to survive that.
+        let targets = redirect_targets("> out.txt");
+        assert_eq!(targets.len(), 1, "{targets:?}");
+        assert_eq!(targets[0].target, "out.txt");
+        assert!(targets[0].truncates);
+
+        // A leading `&>` combines streams rather than truncating a file, and
+        // asking what precedes the `&` must not run off the front.
+        assert_eq!(redirect_targets("&> log.txt").len(), 0);
+        assert_eq!(split_segments("&> log.txt"), ["&> log.txt"]);
+    }
+
+    #[test]
+    fn a_redirect_with_nothing_after_it_has_no_target() {
+        // The skip-the-whitespace loop runs to the end of the input here, so
+        // the bound on it is the only thing between this and a panic.
+        assert_eq!(redirect_targets("echo >").len(), 0);
+        assert_eq!(redirect_targets("echo >   ").len(), 0);
+        assert_eq!(redirect_targets("echo >>").len(), 0);
+    }
+
+    #[test]
+    fn a_quoted_target_keeps_the_spaces_inside_it() {
+        // The quote has to close, or the scan swallows the rest of the line
+        // and reports a target nobody wrote.
+        let targets = redirect_targets("echo > 'my file.txt' && ls");
+        assert_eq!(targets.len(), 1, "{targets:?}");
+        assert_eq!(targets[0].target, "my file.txt");
+
+        let targets = redirect_targets("echo > \"my file.txt\"");
+        assert_eq!(targets[0].target, "my file.txt");
+    }
+
+    #[test]
+    fn an_unbalanced_quote_inside_the_other_kind_changes_nothing() {
+        // A balanced pair proves less than it looks: toggling the wrong state
+        // twice returns it to where it started. One `"` inside single quotes
+        // is what shows whether the guard is consulted, and if it is not, the
+        // `&&` after it stops separating commands.
+        let segs = split_segments("echo 'it\"s' && rm -rf /tmp/x");
+        assert_eq!(segs.len(), 2, "{segs:?}");
+        assert!(segs[1].starts_with("rm -rf"), "{segs:?}");
+
+        let targets = redirect_targets("echo 'a\"b' > out.txt");
+        assert_eq!(targets.len(), 1, "the redirect is outside the quotes: {targets:?}");
+        assert_eq!(targets[0].target, "out.txt");
+    }
+
+    #[test]
+    fn an_escaped_quote_does_not_close_the_string_it_is_inside() {
+        // `"a\"b && c"` is one argument containing an ampersand pair, not two
+        // commands. If the escape is not honoured, the `"` closes the string
+        // and the `&&` becomes a separator.
+        let segs = split_segments("echo \"a\\\"b && c\"");
+        assert_eq!(segs.len(), 1, "{segs:?}");
+        assert_eq!(segs[0], "echo \"a\\\"b && c\"", "the text must survive intact");
+    }
+
+    #[test]
+    fn a_backslash_inside_single_quotes_escapes_nothing() {
+        // Single quotes are literal in a shell: a backslash there protects
+        // nothing, so the closing quote is still a closing quote.
+        let targets = redirect_targets("echo '\\' > out.txt");
+        assert_eq!(targets.len(), 1, "{targets:?}");
+        assert_eq!(targets[0].target, "out.txt");
+    }
+
+    #[test]
+    fn an_operator_pair_is_consumed_exactly_once() {
+        // `&&>` is `&&` followed by a redirect. Consuming one character too
+        // few leaves the second `&` in the next segment; one too many eats
+        // the character after it.
+        assert_eq!(split_segments("ls &&> out.txt"), ["ls", "> out.txt"]);
+        // A pipe with no space after it: the character following must reach
+        // the next segment rather than being swallowed as part of the operator.
+        assert_eq!(split_segments("ls |grep x"), ["ls", "grep x"]);
+        assert_eq!(split_segments("ls ||grep x"), ["ls", "grep x"]);
+    }
+
+    #[test]
+    fn a_segment_may_begin_with_a_backslash() {
+        // Nothing precedes the first character, and the escape arm's bound is
+        // the only thing keeping the index from running off the front of the
+        // input. `\> out.txt` writes a literal `>` and redirects nothing.
+        assert_eq!(redirect_targets("\\> out.txt").len(), 0);
+        assert_eq!(split_segments("\\> out.txt"), ["\\> out.txt"]);
+    }
+
+    #[test]
+    fn every_sink_spelling_is_a_sink() {
+        // Seven spellings share one `matches!` arm, and the mutation pass
+        // cannot see inside a macro: it generates no per-arm mutants, so a
+        // spelling dropped from this list would go unnoticed by the tool
+        // that checks the rest of this file. Hence the explicit walk.
+        for sink in [
+            "/dev/null",
+            "/dev/zero",
+            "/dev/stdout",
+            "/dev/stderr",
+            "/dev/tty",
+            "/dev/full",
+            "NUL",
+            "nul",
+            "/DEV/NULL",
+        ] {
+            assert!(
+                redirect_targets(&format!("echo x > {sink}")).is_empty(),
+                "{sink} destroys nothing and must not be an overwrite target"
+            );
+        }
+        // And a path that merely looks like one is still a file.
+        for real in ["/dev/null.bak", "/dev/nullify", "nulled.txt"] {
+            assert_eq!(
+                redirect_targets(&format!("echo x > {real}")).len(),
+                1,
+                "{real} is an ordinary file"
+            );
+        }
+    }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -215,6 +215,50 @@ mod tests {
         );
     }
 
+    #[test]
+    fn every_colour_helper_keeps_the_text_it_wraps() {
+        // The words are the product: a helper that dropped or replaced its
+        // text would still "look coloured" to a passing eye.
+        for (name, got) in [
+            ("green", green("hello")),
+            ("amber", amber("hello")),
+            ("red", red("hello")),
+            ("dim", dim("hello")),
+            ("bold", bold("hello")),
+            ("cyan", cyan("hello")),
+        ] {
+            assert!(got.contains("hello"), "{name}() dropped its text: {got:?}");
+        }
+    }
+
+    #[test]
+    fn every_colour_helper_answers_to_the_same_gate() {
+        // Either all of them wrap or none does. A mixed answer means one
+        // stopped consulting `colour_enabled` and hard-coded its own verdict.
+        for (name, got) in [
+            ("green", green("x")),
+            ("amber", amber("x")),
+            ("red", red("x")),
+            ("dim", dim("x")),
+            ("bold", bold("x")),
+            ("cyan", cyan("x")),
+        ] {
+            assert_eq!(
+                got != "x",
+                colour_enabled(),
+                "{name}() disagrees with the colour gate: {got:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unrecognised_decision_word_passes_through_unchanged() {
+        // `decision` is a presentation map, not a validator: a word it does
+        // not know must still reach the reader.
+        assert_eq!(decision("skipped"), "skipped");
+        assert!(mark("skipped", "hook").contains('•'));
+    }
+
     /// Test helper: drop ANSI escape sequences so assertions can look at the
     /// text a human would see.
     fn strip_ansi(s: &str) -> String {

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -141,7 +141,13 @@ fn a_denied_command_never_causes_the_preview_to_run_anything() {
 
     // The other half: liveness is decided by the verdict, not switched off
     // altogether. A command that was not denied still gets a live preview.
-    run_termaxa(&home, &proj, &["check", "terraform apply"], "", Some(&bin_dir));
+    run_termaxa(
+        &home,
+        &proj,
+        &["check", "terraform apply"],
+        "",
+        Some(&bin_dir),
+    );
     assert!(
         marker.exists(),
         "an undenied command should still be previewed live"
@@ -153,7 +159,12 @@ fn log_filters_by_decision_and_by_source() {
     let tmp = scratch("log-filter");
     let (home, proj) = (tmp.join("home"), project(&tmp));
 
-    termaxa(&home, &proj, &["check", "rm -rf /nonexistent-tmx-fixture"], "");
+    termaxa(
+        &home,
+        &proj,
+        &["check", "rm -rf /nonexistent-tmx-fixture"],
+        "",
+    );
     termaxa(&home, &proj, &["check", "cat notes.txt"], "");
     termaxa(&home, &proj, &["run", "--", "sh", "-c", "exit 0"], "");
 
@@ -195,9 +206,24 @@ fn stats_ranks_the_commands_that_were_denied() {
     let tmp = scratch("stats");
     let (home, proj) = (tmp.join("home"), project(&tmp));
 
-    termaxa(&home, &proj, &["check", "rm -rf /nonexistent-tmx-fixture"], "");
-    termaxa(&home, &proj, &["check", "rm -rf /nonexistent-tmx-fixture"], "");
-    termaxa(&home, &proj, &["check", "rm -rf /nonexistent-tmx-other"], "");
+    termaxa(
+        &home,
+        &proj,
+        &["check", "rm -rf /nonexistent-tmx-fixture"],
+        "",
+    );
+    termaxa(
+        &home,
+        &proj,
+        &["check", "rm -rf /nonexistent-tmx-fixture"],
+        "",
+    );
+    termaxa(
+        &home,
+        &proj,
+        &["check", "rm -rf /nonexistent-tmx-other"],
+        "",
+    );
     termaxa(&home, &proj, &["check", "cat notes.txt"], "");
 
     let stats = termaxa(&home, &proj, &["stats"], "").stdout;
@@ -268,7 +294,12 @@ fn rollback_refuses_an_id_it_does_not_have() {
 
     // A backup exists, so "not found" cannot be reached by having none.
     let out = termaxa(&home, &proj, &["rollback", "definitely-not-an-id"], "y\n");
-    assert_eq!(out.code, 2, "an unknown id is an error: {out:?}", out = out.stderr);
+    assert_eq!(
+        out.code,
+        2,
+        "an unknown id is an error: {out:?}",
+        out = out.stderr
+    );
     assert!(
         out.stderr.contains("no backup with id"),
         "and says so: {:?}",
@@ -284,11 +315,7 @@ fn rollback_restores_nothing_unless_it_is_confirmed() {
 
     let out = termaxa(&home, &proj, &["rollback", &id], "n\n");
     assert_eq!(out.code, 1, "a decline is not a success");
-    assert!(
-        out.stderr.contains("rollback declined"),
-        "{:?}",
-        out.stderr
-    );
+    assert!(out.stderr.contains("rollback declined"), "{:?}", out.stderr);
     assert!(
         !proj.join("doomed.txt").exists(),
         "declining must leave the file deleted, not restore it"
@@ -296,7 +323,11 @@ fn rollback_restores_nothing_unless_it_is_confirmed() {
 
     // And confirming does restore it, so the guard is a gate rather than a wall.
     let out = termaxa(&home, &proj, &["rollback", &id], "y\n");
-    assert_eq!(out.code, 0, "a confirmed rollback succeeds: {:?}", out.stderr);
+    assert_eq!(
+        out.code, 0,
+        "a confirmed rollback succeeds: {:?}",
+        out.stderr
+    );
     assert!(
         proj.join("doomed.txt").exists(),
         "the insured file must come back"

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -172,6 +172,13 @@ fn log_filters_by_decision_and_by_source() {
     termaxa(&home, &proj, &["check", "cat notes.txt"], "");
     termaxa(&home, &proj, &["run", "--", "sh", "-c", "exit 0"], "");
 
+    // The control leg: unfiltered, BOTH commands are there. Without it, a
+    // filter test proves nothing when the seeding silently failed, because an
+    // empty log excludes everything perfectly.
+    let all = termaxa(&home, &proj, &["log", "-n", "50"], "").stdout;
+    assert!(all.contains("rm -rf /"), "{all:?}");
+    assert!(all.contains("cat notes.txt"), "{all:?}");
+
     let denied = termaxa(&home, &proj, &["log", "--decision", "deny"], "").stdout;
     assert!(denied.contains("rm -rf /"), "{denied:?}");
     assert!(
@@ -229,6 +236,12 @@ fn stats_ranks_the_commands_that_were_denied() {
         "",
     );
     termaxa(&home, &proj, &["check", "cat notes.txt"], "");
+
+    // Same control: the allowed command is in the log, so its absence from the
+    // denial ranking below is the ranking working rather than the log being
+    // empty.
+    let all = termaxa(&home, &proj, &["log", "-n", "50"], "").stdout;
+    assert!(all.contains("cat notes.txt"), "{all:?}");
 
     let stats = termaxa(&home, &proj, &["stats"], "").stdout;
     assert!(stats.contains("top denied"), "{stats:?}");

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -1,0 +1,304 @@
+//! `check`, `log`, `stats` and `rollback` as a user drives them.
+//!
+//! These subcommands filter, count, confirm and preview — all of it inside
+//! `dispatch`, which reads the process cwd and stdin and prints. There is no
+//! seam to call, so the binary is the unit under test.
+//!
+//! Everything is seeded through the CLI: `run` is the only path that records
+//! an approval and an exit code, which is what the outcome column renders.
+
+#![cfg(unix)]
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+struct Output {
+    stdout: String,
+    stderr: String,
+    code: i32,
+}
+
+fn termaxa(home: &Path, cwd: &Path, args: &[&str], stdin: &str) -> Output {
+    run_termaxa(home, cwd, args, stdin, None)
+}
+
+fn run_termaxa(
+    home: &Path,
+    cwd: &Path,
+    args: &[&str],
+    stdin: &str,
+    extra_path: Option<&Path>,
+) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_termaxa"));
+    cmd.args(args)
+        .current_dir(cwd)
+        .env("TERMAXA_HOME", home)
+        .env("NO_COLOR", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    // Only the child's PATH is rewritten, so a stub binary cannot leak into
+    // any other test in this process.
+    if let Some(dir) = extra_path {
+        let inherited = std::env::var("PATH").unwrap_or_default();
+        cmd.env("PATH", format!("{}:{}", dir.display(), inherited));
+    }
+    let mut child = cmd.spawn().expect("the binary must be runnable");
+    child
+        .stdin
+        .take()
+        .expect("stdin must be piped")
+        .write_all(stdin.as_bytes())
+        .expect("stdin must be writable");
+    let out = child.wait_with_output().expect("the child must exit");
+    Output {
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        code: out.status.code().unwrap_or(-1),
+    }
+}
+
+/// A scratch tree, cleared first so a crashed earlier run cannot leak in.
+fn scratch(tag: &str) -> PathBuf {
+    let base = std::env::temp_dir().join(format!("termaxa-cli-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(base.join("home")).expect("scratch root must be creatable");
+    base
+}
+
+/// `sh` runs silently, `rm` is insurable, and everything else is asked about.
+fn project(root: &Path) -> PathBuf {
+    let proj = root.join("proj");
+    std::fs::create_dir_all(proj.join(".termaxa")).expect("project dir must be creatable");
+    std::fs::write(
+        proj.join(".termaxa").join("policy.yaml"),
+        "version: 1\ndefault: ask\nrules:\n  - match: \"rm -rf /*\"\n    action: deny\n  \
+         - match: \"sh*\"\n    action: allow\n",
+    )
+    .expect("policy must be writable");
+    proj
+}
+
+/// A project that denies `terraform destroy` and asks about everything else.
+fn project_gating_terraform(root: &Path) -> PathBuf {
+    let proj = root.join("proj");
+    std::fs::create_dir_all(proj.join(".termaxa")).expect("project dir must be creatable");
+    std::fs::write(
+        proj.join(".termaxa").join("policy.yaml"),
+        "version: 1\ndefault: ask\nrules:\n  - match: \"terraform destroy*\"\n    action: deny\n",
+    )
+    .expect("policy must be writable");
+    proj
+}
+
+/// A stub `terraform` that leaves a marker behind, so "did the preview spawn
+/// anything?" is answerable as a fact rather than inferred from output.
+fn stub_terraform(bin_dir: &Path, marker: &Path) {
+    std::fs::create_dir_all(bin_dir).expect("stub dir must be creatable");
+    let path = bin_dir.join("terraform");
+    std::fs::write(
+        &path,
+        format!(
+            "#!/bin/sh\ntouch '{}'\necho 'Plan: 0 to add, 0 to change, 1 to destroy.'\n",
+            marker.display()
+        ),
+    )
+    .expect("stub must be writable");
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+        .expect("stub must be executable");
+}
+
+#[test]
+fn a_denied_command_never_causes_the_preview_to_run_anything() {
+    // v0.14.2, reported by Tim Schipper: `check` builds the preview before it
+    // reports the decision, so DENYING a `terraform destroy` was the thing
+    // that ran `terraform plan -destroy` in the working directory. The more
+    // correctly the gate behaved, the more confidently it ran the plan.
+    let tmp = scratch("deny-inert");
+    let (home, proj) = (tmp.join("home"), project_gating_terraform(&tmp));
+    let bin_dir = tmp.join("bin");
+    let marker = tmp.join("plan-was-run");
+    stub_terraform(&bin_dir, &marker);
+
+    let denied = run_termaxa(
+        &home,
+        &proj,
+        &["check", "terraform destroy -auto-approve"],
+        "",
+        Some(&bin_dir),
+    );
+    assert!(
+        denied.stdout.contains("deny"),
+        "the fixture must actually deny: {:?}",
+        denied.stdout
+    );
+    assert!(
+        !marker.exists(),
+        "a denied command must not cause a subprocess"
+    );
+
+    // The other half: liveness is decided by the verdict, not switched off
+    // altogether. A command that was not denied still gets a live preview.
+    run_termaxa(&home, &proj, &["check", "terraform apply"], "", Some(&bin_dir));
+    assert!(
+        marker.exists(),
+        "an undenied command should still be previewed live"
+    );
+}
+
+#[test]
+fn log_filters_by_decision_and_by_source() {
+    let tmp = scratch("log-filter");
+    let (home, proj) = (tmp.join("home"), project(&tmp));
+
+    termaxa(&home, &proj, &["check", "rm -rf /nonexistent-tmx-fixture"], "");
+    termaxa(&home, &proj, &["check", "cat notes.txt"], "");
+    termaxa(&home, &proj, &["run", "--", "sh", "-c", "exit 0"], "");
+
+    let denied = termaxa(&home, &proj, &["log", "--decision", "deny"], "").stdout;
+    assert!(denied.contains("rm -rf /"), "{denied:?}");
+    assert!(
+        !denied.contains("cat notes.txt"),
+        "a filter that keeps everything is not a filter: {denied:?}"
+    );
+
+    let from_run = termaxa(&home, &proj, &["log", "--source", "run"], "").stdout;
+    assert!(from_run.contains("exit 0"), "{from_run:?}");
+    assert!(
+        !from_run.contains("cat notes.txt"),
+        "`check` entries are not `run` entries: {from_run:?}"
+    );
+}
+
+#[test]
+fn the_log_says_what_became_of_each_command() {
+    let tmp = scratch("log-outcome");
+    let (home, proj) = (tmp.join("home"), project(&tmp));
+
+    // Allowed and executed: an exit code, but no approval to report.
+    termaxa(&home, &proj, &["run", "--", "sh", "-c", "exit 3"], "");
+    // Asked, and approved: both.
+    termaxa(&home, &proj, &["run", "--", "echo", "yes-please"], "y\n");
+    // Asked, and declined: nothing ran.
+    termaxa(&home, &proj, &["run", "--", "echo", "no-thanks"], "n\n");
+
+    let log = termaxa(&home, &proj, &["log", "-n", "50"], "").stdout;
+    assert!(log.contains("→ exit 3"), "{log:?}");
+    assert!(log.contains("→ approved, exit 0"), "{log:?}");
+    assert!(log.contains("→ not run"), "{log:?}");
+}
+
+#[test]
+fn stats_ranks_the_commands_that_were_denied() {
+    let tmp = scratch("stats");
+    let (home, proj) = (tmp.join("home"), project(&tmp));
+
+    termaxa(&home, &proj, &["check", "rm -rf /nonexistent-tmx-fixture"], "");
+    termaxa(&home, &proj, &["check", "rm -rf /nonexistent-tmx-fixture"], "");
+    termaxa(&home, &proj, &["check", "rm -rf /nonexistent-tmx-other"], "");
+    termaxa(&home, &proj, &["check", "cat notes.txt"], "");
+
+    let stats = termaxa(&home, &proj, &["stats"], "").stdout;
+    assert!(stats.contains("top denied"), "{stats:?}");
+    assert!(
+        stats.contains("2× rm -rf /"),
+        "the same denial twice is a count of two: {stats:?}"
+    );
+    assert!(
+        !stats.contains("cat notes.txt"),
+        "what was allowed is not a denial: {stats:?}"
+    );
+}
+
+#[test]
+fn stats_stays_quiet_about_denials_when_there_are_none() {
+    let tmp = scratch("stats-quiet");
+    let (home, proj) = (tmp.join("home"), project(&tmp));
+
+    termaxa(&home, &proj, &["check", "cat notes.txt"], "");
+
+    let stats = termaxa(&home, &proj, &["stats"], "").stdout;
+    assert!(
+        !stats.contains("top denied"),
+        "an empty ranking is a heading with nothing under it: {stats:?}"
+    );
+}
+
+/// Delete an insurable file through the gate and return the backup's id.
+///
+/// Insurance is best effort in production — `runner` prints "backup failed
+/// (…); proceeding" and carries on — so a failure here must report what the
+/// gate actually said, or the test just says "no backup" and leaves the cause
+/// to guesswork.
+fn take_a_backup(home: &Path, proj: &Path) -> String {
+    std::fs::write(proj.join("doomed.txt"), "precious\n").expect("file must be writable");
+    let deleted = termaxa(home, proj, &["run", "--", "rm", "doomed.txt"], "y\n");
+    assert_eq!(
+        deleted.code, 0,
+        "the delete itself must succeed.\nstdout: {}\nstderr: {}",
+        deleted.stdout, deleted.stderr
+    );
+
+    let listed = termaxa(home, proj, &["backups"], "").stdout;
+    let id = listed
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        !id.is_empty() && !listed.contains("no backups yet"),
+        "the delete should have been insured.\nbackups: {listed:?}\n\
+         run stdout: {}\nrun stderr: {}",
+        deleted.stdout,
+        deleted.stderr
+    );
+    id
+}
+
+#[test]
+fn rollback_refuses_an_id_it_does_not_have() {
+    let tmp = scratch("rollback-unknown");
+    let (home, proj) = (tmp.join("home"), project(&tmp));
+    take_a_backup(&home, &proj);
+
+    // A backup exists, so "not found" cannot be reached by having none.
+    let out = termaxa(&home, &proj, &["rollback", "definitely-not-an-id"], "y\n");
+    assert_eq!(out.code, 2, "an unknown id is an error: {out:?}", out = out.stderr);
+    assert!(
+        out.stderr.contains("no backup with id"),
+        "and says so: {:?}",
+        out.stderr
+    );
+}
+
+#[test]
+fn rollback_restores_nothing_unless_it_is_confirmed() {
+    let tmp = scratch("rollback-declined");
+    let (home, proj) = (tmp.join("home"), project(&tmp));
+    let id = take_a_backup(&home, &proj);
+
+    let out = termaxa(&home, &proj, &["rollback", &id], "n\n");
+    assert_eq!(out.code, 1, "a decline is not a success");
+    assert!(
+        out.stderr.contains("rollback declined"),
+        "{:?}",
+        out.stderr
+    );
+    assert!(
+        !proj.join("doomed.txt").exists(),
+        "declining must leave the file deleted, not restore it"
+    );
+
+    // And confirming does restore it, so the guard is a gate rather than a wall.
+    let out = termaxa(&home, &proj, &["rollback", &id], "y\n");
+    assert_eq!(out.code, 0, "a confirmed rollback succeeds: {:?}", out.stderr);
+    assert!(
+        proj.join("doomed.txt").exists(),
+        "the insured file must come back"
+    );
+}

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -45,12 +45,16 @@ fn run_termaxa(
         cmd.env("PATH", format!("{}:{}", dir.display(), inherited));
     }
     let mut child = cmd.spawn().expect("the binary must be runnable");
-    child
+    // A command may answer without reading stdin at all: `rollback` with an
+    // unknown id refuses before it ever prompts. The child then exits while
+    // this write is in flight and the pipe closes under it, which is the
+    // child not needing what was offered rather than a failure of the test.
+    // The assertions below carry the signal either way.
+    let _ = child
         .stdin
         .take()
         .expect("stdin must be piped")
-        .write_all(stdin.as_bytes())
-        .expect("stdin must be writable");
+        .write_all(stdin.as_bytes());
     let out = child.wait_with_output().expect("the child must exit");
     Output {
         stdout: String::from_utf8_lossy(&out.stdout).into_owned(),

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -301,4 +301,12 @@ fn rollback_restores_nothing_unless_it_is_confirmed() {
         proj.join("doomed.txt").exists(),
         "the insured file must come back"
     );
+    // The mark is part of the assertion on purpose: "1 path(s) restored" is
+    // also a substring of "-1 path(s) restored", so a count that went the
+    // wrong way would read as correct.
+    assert!(
+        out.stdout.contains("✓ 1 path(s) restored"),
+        "the count is the report of what happened: {:?}",
+        out.stdout
+    );
 }

--- a/tests/colour_gate.rs
+++ b/tests/colour_gate.rs
@@ -1,0 +1,142 @@
+//! The colour gate and the welcome screen, proven against the REAL binary.
+//!
+//! `colour_enabled()` caches its answer in a `OnceLock` for the life of the
+//! process, so a unit test cannot set `NO_COLOR` and observe the effect:
+//! whichever test touched colour first has already fixed the answer for the
+//! whole suite, and the result depends on test order. The question is only
+//! answerable one process at a time — the same reason `probe_inertness.rs`
+//! runs the binary rather than the function.
+//!
+//! `Command::output()` hands the child a pipe, which makes every run here the
+//! `termaxa ... > out.txt` case the gate exists for.
+
+use std::process::Command;
+
+/// Escape sequences start with ESC `[`; their presence is the whole question.
+const ESC: &str = "\x1b[";
+
+/// Bare `termaxa` (the welcome screen) with an explicit colour environment.
+fn welcome_with(env: &[(&str, &str)]) -> String {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_termaxa"));
+    // Start from a known state: whatever the developer or CI has set for
+    // these must not decide what this test observes.
+    cmd.env_remove("NO_COLOR")
+        .env_remove("TERMAXA_NO_COLOR")
+        .env_remove("CLICOLOR_FORCE");
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+
+    let out = cmd.output().expect("the binary must be runnable");
+    assert!(
+        out.status.success(),
+        "bare `termaxa` should exit 0, got {:?}",
+        out.status
+    );
+    String::from_utf8(out.stdout).expect("output must be UTF-8")
+}
+
+#[test]
+fn the_welcome_screen_teaches_the_first_command() {
+    let out = welcome_with(&[]);
+    assert!(
+        out.contains(env!("CARGO_PKG_VERSION")),
+        "the welcome screen names the version: {out:?}"
+    );
+    assert!(out.contains("Predict what will happen."), "{out:?}");
+    assert!(
+        out.contains("termaxa check \"rm -rf /\""),
+        "the one runnable command is the point of this screen: {out:?}"
+    );
+}
+
+#[test]
+fn redirected_output_carries_no_escape_sequences() {
+    let out = welcome_with(&[]);
+    assert!(
+        !out.contains(ESC),
+        "a pipe is not a terminal; escapes here end up in someone's log file: {out:?}"
+    );
+}
+
+#[test]
+fn clicolor_force_asks_for_colour_and_gets_it() {
+    // CI that wants colour says so explicitly, and outranks TTY detection.
+    let out = welcome_with(&[("CLICOLOR_FORCE", "1")]);
+    assert!(out.contains(ESC), "expected escapes, got {out:?}");
+}
+
+#[test]
+fn clicolor_force_set_to_zero_is_not_a_request() {
+    let out = welcome_with(&[("CLICOLOR_FORCE", "0")]);
+    assert!(!out.contains(ESC), "`0` means no, got {out:?}");
+}
+
+/// The other half of the contract: a real terminal DOES get colour.
+///
+/// `CLICOLOR_FORCE` cannot stand in for this — it returns before `is_tty` is
+/// ever consulted, so the detection itself would go untested and a gate that
+/// answered "never a terminal" would look perfectly healthy. Linux-only:
+/// `ptsname_r` is a GNU extension, and one platform proving the branch is
+/// enough.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_real_terminal_gets_colour() {
+    use std::io::Read;
+    use std::os::fd::{FromRawFd, OwnedFd};
+    use std::process::Stdio;
+
+    // SAFETY: the POSIX pty handshake, each step checked before the next is
+    // made. Both descriptors are handed to OwnedFd, which closes them.
+    let (master, slave) = unsafe {
+        let master = libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY);
+        assert!(master >= 0, "posix_openpt failed");
+        assert_eq!(libc::grantpt(master), 0, "grantpt failed");
+        assert_eq!(libc::unlockpt(master), 0, "unlockpt failed");
+
+        let mut name = [0 as libc::c_char; 256];
+        assert_eq!(
+            libc::ptsname_r(master, name.as_mut_ptr(), name.len()),
+            0,
+            "ptsname_r failed"
+        );
+        let slave = libc::open(name.as_ptr(), libc::O_RDWR | libc::O_NOCTTY);
+        assert!(slave >= 0, "opening the pty slave failed");
+        (OwnedFd::from_raw_fd(master), OwnedFd::from_raw_fd(slave))
+    };
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_termaxa"))
+        .env_remove("NO_COLOR")
+        .env_remove("TERMAXA_NO_COLOR")
+        .env_remove("CLICOLOR_FORCE")
+        // Moving the slave end into Stdio also drops the parent's own handle
+        // on it, which is what lets the read below finish.
+        .stdout(Stdio::from(slave))
+        .spawn()
+        .expect("the binary must be runnable");
+    assert!(
+        child.wait().expect("the child must be waitable").success(),
+        "bare `termaxa` should exit 0"
+    );
+
+    let mut out = String::new();
+    // A pty master reports EIO rather than EOF once the slave end is gone;
+    // whatever was read before that is still in the buffer.
+    let _ = std::fs::File::from(master).read_to_string(&mut out);
+    assert!(
+        out.contains(ESC),
+        "a terminal should get colour, got {out:?}"
+    );
+}
+
+#[test]
+fn either_no_color_variable_beats_clicolor_force() {
+    // https://no-color.org: the user's opt-out wins over a tool's opt-in.
+    for var in ["NO_COLOR", "TERMAXA_NO_COLOR"] {
+        let out = welcome_with(&[(var, "1"), ("CLICOLOR_FORCE", "1")]);
+        assert!(
+            !out.contains(ESC),
+            "{var} must win over CLICOLOR_FORCE, got {out:?}"
+        );
+    }
+}

--- a/tests/doctor_output.rs
+++ b/tests/doctor_output.rs
@@ -11,14 +11,14 @@
 //! one that does not, or the test asserts the developer's laptop rather than
 //! the code.
 //!
-//! NOT asserted here: that a correctly wired hook reports as Live. The probe
-//! sends `rm -rf /` and waits PROBE_TIMEOUT (2s) for an answer, and answering
-//! that command means walking the filesystem to the delete preview's budget:
-//! measured at 5.8-7.1s on the machine this was written on, against 0.00s for
-//! the same probe with a target that does not exist. So the probe times out
-//! and a live hook is reported as `NOT firing — commands are ungated`.
-//! Asserting the observed behaviour here would pin that in place, so these
-//! tests assert agent DETECTION, which is decided before the probe runs.
+//! Liveness IS asserted here, and for a while it could not be. The probe
+//! sends `rm -rf /` and waits PROBE_TIMEOUT (2s), and answering that command
+//! means walking the filesystem to the delete preview's budget. That budget
+//! was consulted only between directories, so one wide directory on a slow
+//! mount ran to completion regardless: 5.8-7.1s measured here, the probe
+//! timing out, and a correctly gated setup reported as `NOT firing`. With the
+//! budget bound inside the directory as well, the same probe answers in
+//! roughly 300ms and these tests can say what they mean.
 
 #![cfg(unix)]
 
@@ -169,6 +169,54 @@ fn an_initialised_project_without_an_agent_has_nothing_to_fix() {
     assert!(
         out.stdout.contains("no agent harness detected"),
         "no agent directory and no agent binary means no harness: {:?}",
+        out.stdout
+    );
+}
+
+#[test]
+fn a_wired_hook_reports_as_live_and_leaves_nothing_to_fix() {
+    let tmp = scratch("live");
+    let bin = controlled_path(&tmp);
+    let proj = project(&tmp, DENIES);
+    wire_claude(&proj);
+    Command::new(env!("CARGO_BIN_EXE_termaxa"))
+        .arg("init")
+        .current_dir(&proj)
+        .env("TERMAXA_HOME", tmp.join("home"))
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("the binary must be runnable");
+
+    let out = doctor(&tmp.join("home"), &proj, &bin);
+    assert!(
+        out.stdout.contains("hook configured and live"),
+        "the registered command answered when doctor invoked it: {:?}",
+        out.stdout
+    );
+    // The policy denies `rm -rf /`, so the permissiveness note stays quiet.
+    assert!(!out.stdout.contains("does not deny"), "{:?}", out.stdout);
+    assert_eq!(out.code, 0, "nothing to fix: {:?}", out.stdout);
+}
+
+#[test]
+fn a_live_hook_over_a_policy_that_denies_nothing_is_flagged() {
+    // Live means "answered when doctor invoked it", which is not the same as
+    // "will stop anything". A green tick over a policy that denies nothing is
+    // worth one more line.
+    let tmp = scratch("permissive");
+    let bin = controlled_path(&tmp);
+    let proj = project(&tmp, "version: 1\ndefault: allow\nrules: []\n");
+    wire_claude(&proj);
+
+    let out = doctor(&tmp.join("home"), &proj, &bin);
+    assert!(
+        out.stdout.contains("hook configured and live"),
+        "{:?}",
+        out.stdout
+    );
+    assert!(
+        out.stdout.contains("does not deny `rm -rf /`"),
+        "a gate that stops nothing has to say so next to its tick: {:?}",
         out.stdout
     );
 }

--- a/tests/doctor_output.rs
+++ b/tests/doctor_output.rs
@@ -1,0 +1,315 @@
+//! `termaxa doctor` as a reader receives it.
+//!
+//! doctor's answers depend on the WORLD: which agent directories exist, which
+//! agent binaries are on PATH, and whether the registered hook answers when
+//! invoked. None of that is reachable from a unit test on a helper, and the
+//! function returns an exit code while saying everything else in print.
+//!
+//! So these drive the binary, and they hand it a PATH containing only a
+//! handful of symlinks. That is the load-bearing part: `which("claude")` must
+//! answer the same on a machine that happens to have Claude installed as on
+//! one that does not, or the test asserts the developer's laptop rather than
+//! the code.
+//!
+//! NOT asserted here: that a correctly wired hook reports as Live. The probe
+//! sends `rm -rf /` and waits PROBE_TIMEOUT (2s) for an answer, and answering
+//! that command means walking the filesystem to the delete preview's budget:
+//! measured at 5.8-7.1s on the machine this was written on, against 0.00s for
+//! the same probe with a target that does not exist. So the probe times out
+//! and a live hook is reported as `NOT firing — commands are ungated`.
+//! Asserting the observed behaviour here would pin that in place, so these
+//! tests assert agent DETECTION, which is decided before the probe runs.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+struct Output {
+    stdout: String,
+    code: i32,
+}
+
+/// Run `termaxa doctor` in `proj`, with a PATH holding only `also` plus a
+/// shell (the probe invokes the registered command through one).
+fn doctor(home: &Path, proj: &Path, bin_dir: &Path) -> Output {
+    let out = Command::new(env!("CARGO_BIN_EXE_termaxa"))
+        .arg("doctor")
+        .current_dir(proj)
+        .env("TERMAXA_HOME", home)
+        .env("NO_COLOR", "1")
+        .env("PATH", bin_dir)
+        .output()
+        .expect("the binary must be runnable");
+    Output {
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        code: out.status.code().unwrap_or(-1),
+    }
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let base = std::env::temp_dir().join(format!("termaxa-doctor-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(base.join("home")).expect("scratch root must be creatable");
+    base
+}
+
+/// A PATH directory holding a shell (the probe invokes through one) and
+/// `which` (doctor asks it whether a tool exists), and nothing else. Agent
+/// binaries are absent by construction, so their detection comes down to
+/// exactly what each test puts here.
+fn controlled_path(root: &Path) -> PathBuf {
+    let bin = root.join("bin");
+    std::fs::create_dir_all(&bin).expect("bin dir must be creatable");
+    for tool in ["sh", "which"] {
+        let real = ["/bin", "/usr/bin"]
+            .iter()
+            .map(|d| Path::new(d).join(tool))
+            .find(|p| p.exists())
+            .unwrap_or_else(|| panic!("{tool} must exist somewhere standard"));
+        std::os::unix::fs::symlink(&real, bin.join(tool)).expect("symlink must be creatable");
+    }
+    bin
+}
+
+/// A stub executable on the controlled PATH, so "this agent's CLI is
+/// installed" becomes a fact the test sets rather than one it inherits.
+fn stub_tool(bin: &Path, name: &str) {
+    let path = bin.join(name);
+    std::fs::write(&path, "#!/bin/sh\nexit 0\n").expect("stub must be writable");
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+        .expect("stub must be executable");
+}
+
+fn project(root: &Path, policy: &str) -> PathBuf {
+    let proj = root.join("proj");
+    std::fs::create_dir_all(proj.join(".termaxa")).expect("project dir must be creatable");
+    std::fs::write(proj.join(".termaxa").join("policy.yaml"), policy)
+        .expect("policy must be writable");
+    proj
+}
+
+const DENIES: &str =
+    "version: 1\ndefault: ask\nrules:\n  - match: \"rm -rf /*\"\n    action: deny\n";
+
+/// Register the real test binary as the hook, in each agent's own shape.
+fn wire_claude(proj: &Path) {
+    let dir = proj.join(".claude");
+    std::fs::create_dir_all(&dir).expect("agent dir must be creatable");
+    std::fs::write(
+        dir.join("settings.json"),
+        serde_json::json!({
+            "hooks": { "PreToolUse": [ { "matcher": "Bash", "hooks": [
+                { "type": "command", "command": format!("{} hook", env!("CARGO_BIN_EXE_termaxa")) }
+            ] } ] }
+        })
+        .to_string(),
+    )
+    .expect("settings must be writable");
+}
+
+fn wire_copilot(proj: &Path) {
+    let dir = proj.join(".github").join("hooks");
+    std::fs::create_dir_all(&dir).expect("agent dir must be creatable");
+    std::fs::write(
+        dir.join("hooks.json"),
+        serde_json::json!({
+            "version": 1,
+            "hooks": { "preToolUse": [
+                { "type": "command", "command": format!("{} hook", env!("CARGO_BIN_EXE_termaxa")),
+                  "failClosed": true }
+            ] }
+        })
+        .to_string(),
+    )
+    .expect("hooks must be writable");
+}
+
+#[test]
+fn a_directory_with_nothing_in_it_is_reported_as_such() {
+    let tmp = scratch("bare");
+    let bin = controlled_path(&tmp);
+    let empty = tmp.join("empty");
+    std::fs::create_dir_all(&empty).expect("dir must be creatable");
+
+    let out = doctor(&tmp.join("home"), &empty, &bin);
+    assert_eq!(out.code, 1, "a missing policy is something to fix");
+    assert!(
+        out.stdout.contains("no .termaxa/policy.yaml"),
+        "{:?}",
+        out.stdout
+    );
+    assert!(
+        out.stdout.contains("no agent harness detected"),
+        "with no agent directory and no agent binary, there is no harness: {:?}",
+        out.stdout
+    );
+    assert!(out.stdout.contains("run `termaxa init`"), "{:?}", out.stdout);
+}
+
+#[test]
+fn an_initialised_project_without_an_agent_has_nothing_to_fix() {
+    let tmp = scratch("clean");
+    let bin = controlled_path(&tmp);
+    let proj = project(&tmp, DENIES);
+    // `init` records the policy baseline, which is the remaining problem in
+    // an otherwise healthy tree.
+    Command::new(env!("CARGO_BIN_EXE_termaxa"))
+        .arg("init")
+        .current_dir(&proj)
+        .env("TERMAXA_HOME", tmp.join("home"))
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("the binary must be runnable");
+
+    let out = doctor(&tmp.join("home"), &proj, &bin);
+    assert_eq!(out.code, 0, "nothing left to fix: {:?}", out.stdout);
+    assert!(out.stdout.contains("Everything checks out"), "{:?}", out.stdout);
+    assert!(
+        out.stdout.contains("no agent harness detected"),
+        "no agent directory and no agent binary means no harness: {:?}",
+        out.stdout
+    );
+}
+
+#[test]
+fn each_agent_is_detected_by_its_own_evidence() {
+    // Claude Code and Cursor by their directories; Copilot by its CLI being
+    // on PATH together with a registration. None of those binaries exist on
+    // this PATH unless the test puts them there, so what is asserted is the
+    // detection rule rather than the machine the suite runs on.
+    let tmp = scratch("agents");
+    let bin = controlled_path(&tmp);
+    let proj = project(&tmp, DENIES);
+    // Directories only for the two that are detected by one: a registration
+    // would add a liveness probe, and each probe costs its whole timeout.
+    std::fs::create_dir_all(proj.join(".claude")).expect("agent dir must be creatable");
+    std::fs::create_dir_all(proj.join(".cursor")).expect("agent dir must be creatable");
+    wire_copilot(&proj);
+    stub_tool(&bin, "gh");
+
+    let out = doctor(&tmp.join("home"), &proj, &bin);
+    for agent in ["Claude Code", "Cursor", "Copilot"] {
+        assert!(
+            out.stdout.contains(agent),
+            "{agent} should have been detected: {:?}",
+            out.stdout
+        );
+    }
+    assert!(
+        !out.stdout.contains("no agent harness detected"),
+        "{:?}",
+        out.stdout
+    );
+    // Cursor is detected here but not registered, and the restart advice
+    // only makes sense once there is a registration to restart into.
+    assert!(
+        !out.stdout.contains("restart Cursor"),
+        "nothing was wired, so there is nothing to restart for: {:?}",
+        out.stdout
+    );
+}
+
+#[test]
+fn a_hook_that_has_already_run_silences_the_warning() {
+    // The warning pairs "an agent is present" with "the gate has never seen
+    // one of its commands". Once an agent has actually reached the gate,
+    // repeating it would be noise on a healthy install.
+    let tmp = scratch("hooked");
+    let bin = controlled_path(&tmp);
+    let home = tmp.join("home");
+    let proj = project(&tmp, DENIES);
+    std::fs::create_dir_all(proj.join(".claude")).expect("agent dir must be creatable");
+
+    let payload = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "cwd": proj.display().to_string(),
+        "session_id": "sess-doctor",
+        "tool_input": { "command": "ls -la" }
+    })
+    .to_string();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_termaxa"))
+        .arg("hook")
+        .current_dir(&proj)
+        .env("TERMAXA_HOME", &home)
+        .env("NO_COLOR", "1")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("the binary must be runnable");
+    {
+        use std::io::Write as _;
+        child
+            .stdin
+            .take()
+            .expect("stdin must be piped")
+            .write_all(payload.as_bytes())
+            .expect("the payload must be writable");
+    }
+    child.wait().expect("the hook must exit");
+
+    let out = doctor(&home, &proj, &bin);
+    assert!(
+        out.stdout.contains("audit entries (1 from hooks)"),
+        "the entry came from a hook, and the count says which: {:?}",
+        out.stdout
+    );
+    assert!(
+        !out.stdout.contains("no hook entries yet"),
+        "the gate has seen an agent command, so the warning must stop: {:?}",
+        out.stdout
+    );
+}
+
+#[test]
+fn an_unregistered_agent_directory_is_reported_as_not_wired() {
+    // The directory is evidence the harness exists; the registration is a
+    // separate question, and conflating them is how a green tick ends up
+    // over an ungated session.
+    let tmp = scratch("unwired");
+    let bin = controlled_path(&tmp);
+    let proj = project(&tmp, DENIES);
+    std::fs::create_dir_all(proj.join(".claude")).expect("agent dir must be creatable");
+
+    let out = doctor(&tmp.join("home"), &proj, &bin);
+    assert!(out.stdout.contains("Claude Code"), "{:?}", out.stdout);
+    assert!(
+        !out.stdout.contains("no agent harness detected"),
+        "the directory alone is enough to detect the harness: {:?}",
+        out.stdout
+    );
+    assert_eq!(out.code, 1, "an unwired agent is something to fix");
+}
+
+#[test]
+fn the_log_line_separates_hook_entries_from_the_rest() {
+    let tmp = scratch("log");
+    let bin = controlled_path(&tmp);
+    let home = tmp.join("home");
+    let proj = project(&tmp, DENIES);
+    wire_claude(&proj);
+
+    // A `check` is an audit entry, but it is not an agent reaching the gate.
+    Command::new(env!("CARGO_BIN_EXE_termaxa"))
+        .args(["check", "rm -rf /nonexistent-tmx-fixture"])
+        .current_dir(&proj)
+        .env("TERMAXA_HOME", &home)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("the binary must be runnable");
+
+    let out = doctor(&home, &proj, &bin);
+    assert!(
+        out.stdout.contains("audit entries (0 from hooks)"),
+        "a check is not a hook entry: {:?}",
+        out.stdout
+    );
+    assert!(
+        out.stdout.contains("no hook entries yet"),
+        "an agent is wired and has never reached the gate, which is the \
+         pairing worth warning about: {:?}",
+        out.stdout
+    );
+}

--- a/tests/doctor_output.rs
+++ b/tests/doctor_output.rs
@@ -145,7 +145,11 @@ fn a_directory_with_nothing_in_it_is_reported_as_such() {
         "with no agent directory and no agent binary, there is no harness: {:?}",
         out.stdout
     );
-    assert!(out.stdout.contains("run `termaxa init`"), "{:?}", out.stdout);
+    assert!(
+        out.stdout.contains("run `termaxa init`"),
+        "{:?}",
+        out.stdout
+    );
 }
 
 #[test]
@@ -165,7 +169,11 @@ fn an_initialised_project_without_an_agent_has_nothing_to_fix() {
 
     let out = doctor(&tmp.join("home"), &proj, &bin);
     assert_eq!(out.code, 0, "nothing left to fix: {:?}", out.stdout);
-    assert!(out.stdout.contains("Everything checks out"), "{:?}", out.stdout);
+    assert!(
+        out.stdout.contains("Everything checks out"),
+        "{:?}",
+        out.stdout
+    );
     assert!(
         out.stdout.contains("no agent harness detected"),
         "no agent directory and no agent binary means no harness: {:?}",

--- a/tests/doctor_output.rs
+++ b/tests/doctor_output.rs
@@ -246,13 +246,25 @@ fn each_agent_is_detected_by_its_own_evidence() {
     stub_tool(&bin, "gh");
 
     let out = doctor(&tmp.join("home"), &proj, &bin);
-    for agent in ["Claude Code", "Cursor", "Copilot"] {
+    // The agent LINE and its state, not the bare name: every name also appears
+    // in the list of things to fix, so `contains("Cursor")` is satisfied by the
+    // output of NOT detecting it. Each agent here is detected a different way
+    // and lands in a different state, and the assertion says which.
+    for agent in ["Claude Code", "Cursor"] {
         assert!(
-            out.stdout.contains(agent),
-            "{agent} should have been detected: {:?}",
+            out.stdout
+                .contains(&format!("{agent:<13}detected, hook NOT configured")),
+            "{agent} is detected by its directory alone, and is not wired: {:?}",
             out.stdout
         );
     }
+    assert!(
+        out.stdout
+            .contains(&format!("{:<13}hook configured and live", "Copilot CLI")),
+        "Copilot is detected by gh on PATH plus a registration, and that \
+         registration answers: {:?}",
+        out.stdout
+    );
     assert!(
         !out.stdout.contains("no agent harness detected"),
         "{:?}",
@@ -263,6 +275,35 @@ fn each_agent_is_detected_by_its_own_evidence() {
     assert!(
         !out.stdout.contains("restart Cursor"),
         "nothing was wired, so there is nothing to restart for: {:?}",
+        out.stdout
+    );
+}
+
+#[test]
+fn a_wired_cursor_is_told_to_restart() {
+    // The counterpart to the silence asserted above. Without this, deleting
+    // the hint from doctor entirely would break no test: an absence is only
+    // meaningful next to a presence.
+    let tmp = scratch("cursor-wired");
+    let bin = controlled_path(&tmp);
+    let proj = project(&tmp, DENIES);
+    let dir = proj.join(".cursor");
+    std::fs::create_dir_all(&dir).expect("agent dir must be creatable");
+    std::fs::write(
+        dir.join("hooks.json"),
+        serde_json::json!({
+            "beforeShellExecution": [
+                { "command": format!("{} hook", env!("CARGO_BIN_EXE_termaxa")) }
+            ]
+        })
+        .to_string(),
+    )
+    .expect("hooks must be writable");
+
+    let out = doctor(&tmp.join("home"), &proj, &bin);
+    assert!(
+        out.stdout.contains("restart Cursor"),
+        "a registration Cursor has not reloaded is a hook that does not fire: {:?}",
         out.stdout
     );
 }
@@ -330,7 +371,14 @@ fn an_unregistered_agent_directory_is_reported_as_not_wired() {
     std::fs::create_dir_all(proj.join(".claude")).expect("agent dir must be creatable");
 
     let out = doctor(&tmp.join("home"), &proj, &bin);
-    assert!(out.stdout.contains("Claude Code"), "{:?}", out.stdout);
+    assert!(
+        out.stdout.contains(&format!(
+            "{:<13}detected, hook NOT configured",
+            "Claude Code"
+        )),
+        "{:?}",
+        out.stdout
+    );
     assert!(
         !out.stdout.contains("no agent harness detected"),
         "the directory alone is enough to detect the harness: {:?}",

--- a/tests/hook_dialects.rs
+++ b/tests/hook_dialects.rs
@@ -1,0 +1,772 @@
+//! `termaxa hook` against each agent's own payload shape.
+//!
+//! This is the path every gated command actually takes, and almost none of it
+//! is reachable from a unit test: it reads stdin, resolves paths from the
+//! payload, writes state, prints one dialect's JSON and exits with a code the
+//! harness reads. So these run the binary and read what a harness would.
+//!
+//! The dialect matters as much as the verdict. A correct deny rendered in the
+//! wrong shape is a deny nobody receives.
+
+#![cfg(unix)]
+
+use std::io::Write as _;
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+struct Out {
+    stdout: String,
+    code: i32,
+}
+
+fn hook(home: &Path, cwd: &Path, payload: &serde_json::Value, env: &[(&str, &str)]) -> Out {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_termaxa"));
+    cmd.arg("hook")
+        .current_dir(cwd)
+        .env("TERMAXA_HOME", home)
+        .env("NO_COLOR", "1")
+        .env_remove("TERMAXA_HOOK_PROBE")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let mut child = cmd.spawn().expect("the binary must be runnable");
+    child
+        .stdin
+        .take()
+        .expect("stdin must be piped")
+        .write_all(payload.to_string().as_bytes())
+        .expect("the payload must be writable");
+    let out = child.wait_with_output().expect("the hook must exit");
+    Out {
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        code: out.status.code().unwrap_or(-1),
+    }
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let base = std::env::temp_dir().join(format!("termaxa-hookd-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(base.join("home")).expect("scratch root must be creatable");
+    base
+}
+
+const DENIES: &str =
+    "version: 1\ndefault: ask\nrules:\n  - match: \"rm -rf /*\"\n    action: deny\n";
+
+/// A policy that denies something harmless. The built-in starter policy denies
+/// `rm -rf` too, so a test asking "which policy answered?" cannot use it: both
+/// the project's and the fallback's would say deny and the question would go
+/// unasked. Nothing built in objects to `echo`.
+const DENIES_AN_ECHO: &str =
+    "version: 1\ndefault: ask\nrules:\n  - match: \"echo tmx-marker*\"\n    action: deny\n";
+const PROJECT_ONLY: &str = "echo tmx-marker";
+
+fn project(root: &Path, policy: &str) -> PathBuf {
+    let proj = root.join("proj");
+    std::fs::create_dir_all(proj.join(".termaxa")).expect("project dir must be creatable");
+    std::fs::write(proj.join(".termaxa").join("policy.yaml"), policy)
+        .expect("policy must be writable");
+    proj
+}
+
+/// A command the fixture policy denies, and one it merely asks about.
+const DENIED: &str = "rm -rf /nonexistent-tmx-fixture";
+
+// ---------------------------------------------------------------------------
+// Dialect detection. The response shape is how the harness learns the verdict.
+// ---------------------------------------------------------------------------
+
+fn is_claude_shape(out: &str) -> bool {
+    out.contains("hookSpecificOutput") && out.contains("permissionDecision")
+}
+
+fn is_cursor_shape(out: &str) -> bool {
+    out.contains("\"permission\"")
+}
+
+#[test]
+fn cursor_is_recognised_by_its_tool_name_and_conversation_together() {
+    let tmp = scratch("cursor-pair");
+    let (home, proj) = (tmp.join("home"), project(&tmp, DENIES));
+
+    let out = hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Shell",
+            "conversation_id": "conv-1",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "command": DENIED }
+        }),
+        &[],
+    );
+    assert!(
+        is_cursor_shape(&out.stdout),
+        "Shell plus a conversation id is Cursor: {:?}",
+        out.stdout
+    );
+
+    // Either half alone is not Cursor. `Shell` without a conversation, and a
+    // conversation with an ordinary tool name, both belong to Claude Code.
+    let out = hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Shell",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "command": DENIED }
+        }),
+        &[],
+    );
+    assert!(
+        is_claude_shape(&out.stdout),
+        "Shell alone is not Cursor: {:?}",
+        out.stdout
+    );
+
+    let out = hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "conversation_id": "conv-1",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "command": DENIED }
+        }),
+        &[],
+    );
+    assert!(
+        is_claude_shape(&out.stdout),
+        "a conversation id with a Bash tool is not Cursor: {:?}",
+        out.stdout
+    );
+}
+
+#[test]
+fn copilot_is_recognised_by_every_shell_tool_it_names() {
+    let tmp = scratch("copilot");
+    let (home, proj) = (tmp.join("home"), project(&tmp, DENIES));
+
+    for tool in ["shell", "bash", "run_in_terminal"] {
+        let out = hook(
+            &home,
+            &proj,
+            &serde_json::json!({
+                "hook_event_name": "PreToolUse",
+                "toolName": tool,
+                "toolArgs": serde_json::json!({ "command": DENIED }).to_string(),
+                "cwd": proj.display().to_string(),
+            }),
+            &[],
+        );
+        assert_eq!(out.code, 2, "{tool} must be gated: {:?}", out.stdout);
+    }
+
+    // A tool that does not run a shell is not a shell, even carrying a command.
+    let out = hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "toolName": "read_file",
+            "toolArgs": serde_json::json!({ "command": DENIED }).to_string(),
+            "cwd": proj.display().to_string(),
+        }),
+        &[],
+    );
+    assert_ne!(
+        out.code, 2,
+        "reading a file is not running one: {:?}",
+        out.stdout
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The cwd the payload carries. The agent may spawn the hook anywhere.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_payload_cwd_decides_the_project_not_where_the_hook_was_spawned() {
+    // The Cursor bug: Claude Code happened to spawn hooks inside the project,
+    // which masked the assumption until another harness did not.
+    let tmp = scratch("cwd-payload");
+    let (home, proj) = (tmp.join("home"), project(&tmp, DENIES_AN_ECHO));
+    let elsewhere = tmp.join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).expect("dir must be creatable");
+
+    let out = hook(
+        &home,
+        &elsewhere,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "command": PROJECT_ONLY }
+        }),
+        &[],
+    );
+    assert!(
+        out.stdout.contains("\"deny\""),
+        "the project named in the payload is the one that governs: {:?}",
+        out.stdout
+    );
+    // Asserting the code alone would not do: a hook that resolved no policy
+    // at all also exits 2, so the verdict has to be read from stdout.
+    assert_eq!(out.code, 2);
+}
+
+#[test]
+fn a_cwd_that_is_not_a_directory_falls_back_instead_of_being_trusted() {
+    // A path that does not exist is not a project root, and resolving from it
+    // would find no policy at all. Falling back to where the process is keeps
+    // this project's rules in force.
+    let tmp = scratch("cwd-bogus");
+    let (home, proj) = (tmp.join("home"), project(&tmp, DENIES_AN_ECHO));
+
+    let out = hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "cwd": "/nonexistent-tmx-cwd",
+            "tool_input": { "command": PROJECT_ONLY }
+        }),
+        &[],
+    );
+    assert!(
+        out.stdout.contains("\"deny\""),
+        "a cwd that is not a directory must not be trusted over the fallback: {:?}",
+        out.stdout
+    );
+    assert_eq!(out.code, 2);
+}
+
+/// Every audit line recorded under any project in this home.
+fn project_logs(home: &Path) -> String {
+    let mut all = String::new();
+    if let Ok(projects) = std::fs::read_dir(home.join("projects")) {
+        for p in projects.flatten() {
+            if let Ok(text) = std::fs::read_to_string(p.path().join("logs").join("audit.jsonl")) {
+                all.push_str(&text);
+            }
+        }
+    }
+    all
+}
+
+#[test]
+fn a_post_receipt_is_recorded_against_the_project_the_payload_names() {
+    // A receipt carries no verdict, so where it is FILED is the whole of its
+    // behaviour: a receipt written to the wrong project is a receipt the
+    // report will never show.
+    let tmp = scratch("post-cwd");
+    let (home, proj) = (tmp.join("home"), project(&tmp, DENIES_AN_ECHO));
+    let elsewhere = tmp.join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).expect("dir must be creatable");
+
+    hook(
+        &home,
+        &elsewhere,
+        &serde_json::json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "command": "echo tmx-receipt" }
+        }),
+        &[],
+    );
+
+    let logs = project_logs(&home);
+    assert!(
+        logs.contains("tmx-receipt") && logs.contains("\"post\""),
+        "the receipt belongs to the project the payload named: {logs:?}"
+    );
+
+    // And a cwd that cannot be used falls back rather than being trusted. A
+    // receipt filed nowhere is one the breaker never sees, which is the whole
+    // reason post receipts exist: they are what marks work as approved.
+    let tmp = scratch("post-cwd-bogus");
+    let (home, proj) = (tmp.join("home"), project(&tmp, DENIES_AN_ECHO));
+    hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "cwd": "/nonexistent-tmx-cwd",
+            "tool_input": { "command": "echo tmx-fallback-receipt" }
+        }),
+        &[],
+    );
+    assert!(
+        project_logs(&home).contains("tmx-fallback-receipt"),
+        "the fallback is what keeps the receipt auditable"
+    );
+}
+
+#[test]
+fn a_refused_write_is_recorded_against_the_project_the_payload_names() {
+    // Same question for the write path: a deny that went unrecorded is still
+    // a deny, but it is one nobody can audit afterwards.
+    let tmp = scratch("write-cwd");
+    let (home, proj) = (tmp.join("home"), project(&tmp, DENIES_AN_ECHO));
+    let elsewhere = tmp.join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).expect("dir must be creatable");
+    let policy = proj.join(".termaxa").join("policy.yaml");
+
+    let out = hook(
+        &home,
+        &elsewhere,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "file_path": policy.display().to_string(), "content": "default: allow" }
+        }),
+        &[],
+    );
+    assert!(out.stdout.contains("\"deny\""), "{:?}", out.stdout);
+
+    let logs = project_logs(&home);
+    assert!(
+        logs.contains("policy.yaml"),
+        "the refusal belongs in the audit log of the project it protected: {logs:?}"
+    );
+
+    // And with a cwd that cannot be used, the record still lands: the refusal
+    // is printed either way, so only the log says whether the fallback worked.
+    let tmp = scratch("write-cwd-bogus");
+    let (home, proj) = (tmp.join("home"), project(&tmp, DENIES_AN_ECHO));
+    let policy = proj.join(".termaxa").join("policy.yaml");
+    let out = hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "cwd": "/nonexistent-tmx-cwd",
+            "tool_input": { "file_path": policy.display().to_string(), "content": "default: allow" }
+        }),
+        &[],
+    );
+    assert!(out.stdout.contains("\"deny\""), "{:?}", out.stdout);
+    assert!(
+        project_logs(&home).contains("policy.yaml"),
+        "the fallback is what makes the refusal auditable"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Silence, answers, and the exit code the harness reads.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_denied_command_answers_and_exits_two() {
+    let tmp = scratch("deny");
+    let (home, proj) = (tmp.join("home"), project(&tmp, DENIES));
+
+    let out = hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "command": DENIED }
+        }),
+        &[],
+    );
+    assert!(out.stdout.contains("\"deny\""), "{:?}", out.stdout);
+    assert_eq!(out.code, 2, "the exit code is the belt to stdout's braces");
+}
+
+#[test]
+fn an_unmatched_allow_says_nothing_at_all_to_claude_code() {
+    // decline-not-allow: where no rule matched and the default is allow, the
+    // gate has formed no opinion, and saying "allow" would assert one.
+    let tmp = scratch("silent");
+    let (home, proj) = (
+        tmp.join("home"),
+        project(&tmp, "version: 1\ndefault: allow\nrules: []\n"),
+    );
+
+    let out = hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "command": "ls -la" }
+        }),
+        &[],
+    );
+    assert!(
+        out.stdout.trim().is_empty(),
+        "no opinion means no output: {:?}",
+        out.stdout
+    );
+    assert_eq!(out.code, 0);
+
+    // A probe is the exception: doctor cannot tell silence from a dead hook.
+    let out = hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "cwd": proj.display().to_string(),
+            "session_id": "termaxa-doctor-probe",
+            "tool_input": { "command": "ls -la" }
+        }),
+        &[("TERMAXA_HOOK_PROBE", "1")],
+    );
+    assert!(
+        !out.stdout.trim().is_empty(),
+        "a probe must always answer: {:?}",
+        out.stdout
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Insurance, and who is allowed to cause it.
+// ---------------------------------------------------------------------------
+
+fn backup_count(home: &Path) -> usize {
+    let mut n = 0;
+    if let Ok(projects) = std::fs::read_dir(home.join("projects")) {
+        for p in projects.flatten() {
+            if let Ok(entries) = std::fs::read_dir(p.path().join("backups")) {
+                n += entries.flatten().count();
+            }
+        }
+    }
+    n
+}
+
+#[test]
+fn insurance_is_taken_for_what_runs_and_for_nothing_else() {
+    let tmp = scratch("insure");
+    // A narrow deny: `rm -rf /*` would match every absolute path, including
+    // the one this test is about to insure.
+    let (home, proj) = (
+        tmp.join("home"),
+        project(
+            &tmp,
+            "version: 1\ndefault: ask\nrules:\n  - match: \"*doomed-denied*\"\n    action: deny\n",
+        ),
+    );
+    let doomed = proj.join("doomed.txt");
+    let denied_file = proj.join("doomed-denied.txt");
+
+    let ask_to_delete = |file: &Path| {
+        serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "command": format!("rm -rf {}", file.display()) }
+        })
+    };
+
+    // A command that will run is insured first.
+    std::fs::write(&doomed, "precious").expect("file must be writable");
+    let out = hook(&home, &proj, &ask_to_delete(&doomed), &[]);
+    assert_ne!(out.code, 2, "the fixture policy only denies rm -rf /*");
+    assert!(
+        backup_count(&home) > 0,
+        "an insurable command that is about to run gets a backup"
+    );
+
+    // A probe runs nothing, so it insures nothing.
+    let before = backup_count(&home);
+    hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "cwd": proj.display().to_string(),
+            "session_id": "termaxa-doctor-probe",
+            "tool_input": { "command": format!("rm -rf {}", doomed.display()) }
+        }),
+        &[("TERMAXA_HOOK_PROBE", "1")],
+    );
+    assert_eq!(
+        backup_count(&home),
+        before,
+        "a probe must not cause insurance: nothing is going to happen"
+    );
+
+    // A denied command runs nothing either. The file exists, so the only
+    // reason not to insure it is that nothing is going to happen to it.
+    std::fs::write(&denied_file, "precious").expect("file must be writable");
+    let before = backup_count(&home);
+    let out = hook(&home, &proj, &ask_to_delete(&denied_file), &[]);
+    assert_eq!(out.code, 2, "the fixture denies this one: {:?}", out.stdout);
+    assert_eq!(
+        backup_count(&home),
+        before,
+        "insuring a blocked command is insurance against nothing"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A denied command must not cause a subprocess (v0.14.2), on the hook path.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_denied_command_never_runs_its_preview() {
+    let tmp = scratch("inert");
+    let home = tmp.join("home");
+    let proj = project(
+        &tmp,
+        "version: 1\ndefault: ask\nrules:\n  - match: \"terraform destroy*\"\n    action: deny\n",
+    );
+    let bin_dir = tmp.join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("bin dir must be creatable");
+    let marker = tmp.join("plan-was-run");
+    let stub = bin_dir.join("terraform");
+    std::fs::write(
+        &stub,
+        format!(
+            "#!/bin/sh\ntouch '{}'\necho 'Plan: 0 to add, 0 to change, 1 to destroy.'\n",
+            marker.display()
+        ),
+    )
+    .expect("stub must be writable");
+    std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755))
+        .expect("stub must be executable");
+
+    let path = format!(
+        "{}:{}",
+        bin_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let denied = hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "command": "terraform destroy -auto-approve" }
+        }),
+        &[("PATH", &path)],
+    );
+    assert_eq!(denied.code, 2, "{:?}", denied.stdout);
+    assert!(
+        !marker.exists(),
+        "denying is what used to make it run the plan"
+    );
+
+    // Not denied, so the preview is allowed to do its work.
+    hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "command": "terraform apply" }
+        }),
+        &[("PATH", &path)],
+    );
+    assert!(
+        marker.exists(),
+        "an undenied command still gets a live preview"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The write path: the gate's own files.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn writing_to_the_gates_own_configuration_is_denied_in_every_dialect() {
+    let tmp = scratch("write");
+    let (home, proj) = (tmp.join("home"), project(&tmp, DENIES));
+    let policy = proj.join(".termaxa").join("policy.yaml");
+
+    // Claude Code shape.
+    let out = hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "file_path": policy.display().to_string(), "content": "default: allow" }
+        }),
+        &[],
+    );
+    assert!(is_claude_shape(&out.stdout), "{:?}", out.stdout);
+    assert!(out.stdout.contains("\"deny\""), "{:?}", out.stdout);
+
+    // Cursor identifies itself by its conversation id alone here.
+    let out = hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "conversation_id": "conv-9",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "file_path": policy.display().to_string(), "content": "default: allow" }
+        }),
+        &[],
+    );
+    assert!(
+        is_cursor_shape(&out.stdout),
+        "a conversation id is enough to know the dialect: {:?}",
+        out.stdout
+    );
+
+    // An ordinary file is not the gate's business, and it says nothing.
+    let out = hook(
+        &home,
+        &proj,
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "cwd": proj.display().to_string(),
+            "tool_input": { "file_path": proj.join("src.rs").display().to_string(), "content": "x" }
+        }),
+        &[],
+    );
+    assert!(
+        out.stdout.trim().is_empty(),
+        "no opinion about ordinary files: {:?}",
+        out.stdout
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The circuit breaker, and the commands it must not press against.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_ungated_overwrite_neither_accumulates_pressure_nor_trips_on_it() {
+    // Agents redirect constantly. A default-ask `cargo build > build.log` is
+    // the policy having no opinion, and if the breaker counted those, the
+    // third build log of any real session would be denied. The pressure here
+    // is real and belongs to another command entirely.
+    let tmp = scratch("breaker");
+    let home = tmp.join("home");
+    let proj = project(
+        &tmp,
+        "version: 1\ndefault: ask\nrules:\n  - match: \"*secret.env*\"\n    action: ask\n\
+         circuit_breaker:\n  enabled: true\n  threshold: 2\n",
+    );
+
+    let overwrite = |command: &str| {
+        serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "cwd": proj.display().to_string(),
+            "session_id": "sess-breaker",
+            "tool_input": { "command": command }
+        })
+    };
+
+    // Three attempts at the same GATED overwrite: a rule matched each one, so
+    // each is pressure the breaker is meant to feel.
+    let mut last = 0;
+    for _ in 0..3 {
+        last = hook(&home, &proj, &overwrite("echo x > secret.env"), &[]).code;
+    }
+    assert_eq!(
+        last, 2,
+        "three gated attempts past a threshold of two is what a breaker is for"
+    );
+
+    // Now an overwrite no rule objected to. It must neither be judged by the
+    // pressure above nor add to it.
+    let out = hook(&home, &proj, &overwrite("cargo build > build.log"), &[]);
+    assert_ne!(
+        out.code, 2,
+        "a build log is not the .env attempts that came before it: {:?}",
+        out.stdout
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Notifications. A diagnostic must not page anyone.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_probe_denial_notifies_nobody_while_a_real_one_does() {
+    use std::io::Read as _;
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("a local port must be bindable");
+    let port = listener.local_addr().expect("the port must be readable").port();
+    listener
+        .set_nonblocking(true)
+        .expect("the listener must be non-blocking");
+
+    let tmp = scratch("notify");
+    let home = tmp.join("home");
+    let proj = project(
+        &tmp,
+        &format!(
+            "version: 1\ndefault: ask\nrules:\n  - match: \"rm -rf /*\"\n    action: deny\n\
+             notify:\n  webhook: http://127.0.0.1:{port}/hook\n  on: [deny]\n"
+        ),
+    );
+
+    /// Anything that arrived within a short window, answered so the sender
+    /// does not sit on its timeout.
+    fn arrivals(listener: &TcpListener) -> usize {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(800);
+        let mut seen = 0;
+        while std::time::Instant::now() < deadline {
+            match listener.accept() {
+                Ok((mut sock, _)) => {
+                    let mut buf = [0u8; 512];
+                    let _ = sock.read(&mut buf);
+                    let _ = sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+                    seen += 1;
+                    // The positive case is answered by the first arrival; only
+                    // proving an absence needs the whole window.
+                    return seen;
+                }
+                Err(_) => std::thread::sleep(std::time::Duration::from_millis(20)),
+            }
+        }
+        seen
+    }
+
+    let denial = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "cwd": proj.display().to_string(),
+        "tool_input": { "command": DENIED }
+    });
+
+    let out = hook(&home, &proj, &denial, &[]);
+    assert_eq!(out.code, 2, "the fixture must actually deny");
+    assert!(
+        arrivals(&listener) > 0,
+        "a real denial is what the webhook is configured for"
+    );
+
+    // The same denial as a probe. `termaxa doctor` invokes the hook once per
+    // detected agent, and every one of those would page whoever is on call.
+    let mut probe = denial.clone();
+    probe["session_id"] = serde_json::Value::String("termaxa-doctor-probe".into());
+    hook(&home, &proj, &probe, &[("TERMAXA_HOOK_PROBE", "1")]);
+    assert_eq!(
+        arrivals(&listener),
+        0,
+        "a diagnostic must not page anyone"
+    );
+}
+

--- a/tests/hook_dialects.rs
+++ b/tests/hook_dialects.rs
@@ -34,12 +34,14 @@ fn hook(home: &Path, cwd: &Path, payload: &serde_json::Value, env: &[(&str, &str
         cmd.env(k, v);
     }
     let mut child = cmd.spawn().expect("the binary must be runnable");
-    child
+    // The hook reads its payload to EOF, but a build that fails earlier exits
+    // first and closes the pipe under this write. Let the assertions report
+    // that rather than an EPIPE from the plumbing.
+    let _ = child
         .stdin
         .take()
         .expect("stdin must be piped")
-        .write_all(payload.to_string().as_bytes())
-        .expect("the payload must be writable");
+        .write_all(payload.to_string().as_bytes());
     let out = child.wait_with_output().expect("the hook must exit");
     Out {
         stdout: String::from_utf8_lossy(&out.stdout).into_owned(),

--- a/tests/hook_dialects.rs
+++ b/tests/hook_dialects.rs
@@ -707,7 +707,10 @@ fn a_probe_denial_notifies_nobody_while_a_real_one_does() {
     use std::net::TcpListener;
 
     let listener = TcpListener::bind("127.0.0.1:0").expect("a local port must be bindable");
-    let port = listener.local_addr().expect("the port must be readable").port();
+    let port = listener
+        .local_addr()
+        .expect("the port must be readable")
+        .port();
     listener
         .set_nonblocking(true)
         .expect("the listener must be non-blocking");
@@ -763,10 +766,5 @@ fn a_probe_denial_notifies_nobody_while_a_real_one_does() {
     let mut probe = denial.clone();
     probe["session_id"] = serde_json::Value::String("termaxa-doctor-probe".into());
     hook(&home, &proj, &probe, &[("TERMAXA_HOOK_PROBE", "1")]);
-    assert_eq!(
-        arrivals(&listener),
-        0,
-        "a diagnostic must not page anyone"
-    );
+    assert_eq!(arrivals(&listener), 0, "a diagnostic must not page anyone");
 }
-

--- a/tests/init_output.rs
+++ b/tests/init_output.rs
@@ -1,0 +1,104 @@
+//! What `termaxa init` tells you about the machine it just ran on.
+//!
+//! The detection block and the manual snippet are print-only: `run` returns
+//! Ok(()) whether it found four harnesses or none. As in the doctor tests,
+//! PATH is reduced to a shell and `which`, so "is Claude installed?" is a
+//! fact each test sets rather than a property of the developer's laptop.
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let base = std::env::temp_dir().join(format!("termaxa-init-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(base.join("home")).expect("scratch root must be creatable");
+    base
+}
+
+/// A PATH with a shell and `which` on it, and no agent CLI whatsoever.
+fn controlled_path(root: &Path) -> PathBuf {
+    let bin = root.join("bin");
+    std::fs::create_dir_all(&bin).expect("bin dir must be creatable");
+    for tool in ["sh", "which"] {
+        let real = ["/bin", "/usr/bin"]
+            .iter()
+            .map(|d| Path::new(d).join(tool))
+            .find(|p| p.exists())
+            .unwrap_or_else(|| panic!("{tool} must exist somewhere standard"));
+        std::os::unix::fs::symlink(&real, bin.join(tool)).expect("symlink must be creatable");
+    }
+    bin
+}
+
+fn init_in(home: &Path, dir: &Path, bin: &Path) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_termaxa"))
+        .arg("init")
+        .current_dir(dir)
+        .env("TERMAXA_HOME", home)
+        .env("NO_COLOR", "1")
+        .env("PATH", bin)
+        .output()
+        .expect("the binary must be runnable");
+    assert!(out.status.success(), "init should succeed: {:?}", out.status);
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn a_harness_is_detected_by_its_directory_alone() {
+    let tmp = scratch("detect");
+    let bin = controlled_path(&tmp);
+    let proj = tmp.join("proj");
+    std::fs::create_dir_all(proj.join(".claude")).expect("agent dir must be creatable");
+
+    let out = init_in(&tmp.join("home"), &proj, &bin);
+    // The detection line specifically: "To wire Termaxa into Claude Code"
+    // appears further down as advice whether or not anything was found.
+    assert!(
+        out.contains("✓ Claude Code"),
+        "the directory is evidence even with no CLI on PATH: {out:?}"
+    );
+    assert!(
+        !out.contains("none found"),
+        "something was found, so it must not report otherwise: {out:?}"
+    );
+}
+
+#[test]
+fn an_empty_directory_is_told_it_has_no_harness() {
+    let tmp = scratch("bare");
+    let bin = controlled_path(&tmp);
+    let proj = tmp.join("proj");
+    std::fs::create_dir_all(&proj).expect("dir must be creatable");
+
+    let out = init_in(&tmp.join("home"), &proj, &bin);
+    assert!(
+        out.contains("none found"),
+        "an empty list needs saying, or the section just stops: {out:?}"
+    );
+    assert!(
+        !out.contains("✓ Claude Code"),
+        "nothing is installed here, so nothing may be ticked: {out:?}"
+    );
+}
+
+#[test]
+fn the_manual_snippet_is_printed_for_people_wiring_by_hand() {
+    // The snippet is the fallback for anyone not using one of the --flags,
+    // so it going missing would be silent.
+    let tmp = scratch("snippet");
+    let bin = controlled_path(&tmp);
+    let proj = tmp.join("proj");
+    std::fs::create_dir_all(&proj).expect("dir must be creatable");
+
+    let out = init_in(&tmp.join("home"), &proj, &bin);
+    assert!(
+        out.contains(".claude/settings.json snippet:"),
+        "{out:?}"
+    );
+    assert!(
+        out.contains("\"command\": \"termaxa hook\""),
+        "the snippet has to carry the command it is telling you to paste: {out:?}"
+    );
+}

--- a/tests/init_output.rs
+++ b/tests/init_output.rs
@@ -41,7 +41,11 @@ fn init_in(home: &Path, dir: &Path, bin: &Path) -> String {
         .env("PATH", bin)
         .output()
         .expect("the binary must be runnable");
-    assert!(out.status.success(), "init should succeed: {:?}", out.status);
+    assert!(
+        out.status.success(),
+        "init should succeed: {:?}",
+        out.status
+    );
     String::from_utf8_lossy(&out.stdout).into_owned()
 }
 
@@ -93,10 +97,7 @@ fn the_manual_snippet_is_printed_for_people_wiring_by_hand() {
     std::fs::create_dir_all(&proj).expect("dir must be creatable");
 
     let out = init_in(&tmp.join("home"), &proj, &bin);
-    assert!(
-        out.contains(".claude/settings.json snippet:"),
-        "{out:?}"
-    );
+    assert!(out.contains(".claude/settings.json snippet:"), "{out:?}");
     assert!(
         out.contains("\"command\": \"termaxa hook\""),
         "the snippet has to carry the command it is telling you to paste: {out:?}"

--- a/tests/report_output.rs
+++ b/tests/report_output.rs
@@ -1,0 +1,274 @@
+//! The Execution Report as a reader actually receives it.
+//!
+//! `report::run` prints; it returns only an exit code. A unit test can call it
+//! and see `Ok(0)` while the whole rendering does nothing at all, so the
+//! sections, the counts and the risk line are only really pinned by reading
+//! the process' output — the same reason `colour_gate.rs` runs the binary.
+//!
+//! The log is seeded through the CLI rather than written by hand: that keeps
+//! the fixture honest (it is whatever the gate really records) and means this
+//! test also fails if `check` stops logging.
+
+use std::io::Write as _;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+fn termaxa(home: &Path, cwd: &Path, args: &[&str]) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_termaxa"))
+        .args(args)
+        .current_dir(cwd)
+        .env("TERMAXA_HOME", home)
+        // The report prints marks and headings; colour would put escape
+        // sequences in the middle of the strings asserted below.
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("the binary must be runnable");
+    String::from_utf8(out.stdout).expect("output must be UTF-8")
+}
+
+/// A scratch tree for one test, cleared before use so a crashed earlier run
+/// cannot leak state into this one. Mirrors `probe_inertness.rs`: the pid
+/// keeps two concurrent `cargo test` runs apart.
+fn scratch(tag: &str) -> std::path::PathBuf {
+    let base = std::env::temp_dir().join(format!("termaxa-report-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(base.join("home")).expect("scratch root must be creatable");
+    base
+}
+
+/// A project the gate will accept, plus a home for its state.
+fn project(root: &Path) -> std::path::PathBuf {
+    let proj = root.join("proj");
+    std::fs::create_dir_all(proj.join(".termaxa")).expect("project dir must be creatable");
+    std::fs::write(
+        proj.join(".termaxa").join("policy.yaml"),
+        "version: 1\ndefault: ask\nrules:\n  - match: \"rm -rf /*\"\n    action: deny\n  - match: \"ls*\"\n    action: allow\n",
+    )
+    .expect("policy must be writable");
+    proj
+}
+
+#[test]
+fn the_markdown_report_carries_the_counts_and_the_risk_formula() {
+    let tmp = scratch("md");
+    let home = tmp.join("home");
+    let proj = project(&tmp);
+
+    // Three decisions the policy above produces: one deny, two allows.
+    termaxa(&home, &proj, &["check", "rm -rf /"]);
+    termaxa(&home, &proj, &["check", "ls -la"]);
+    termaxa(&home, &proj, &["check", "ls"]);
+
+    let out = termaxa(&home, &proj, &["report", "--md", "--all"]);
+
+    assert!(
+        out.contains("# Termaxa Execution Report"),
+        "the report must render at all, got: {out:?}"
+    );
+    assert!(
+        out.contains("- **Commands:** 3 — 2 allow / 0 ask / 1 deny"),
+        "the counts line must reflect what was recorded, got: {out:?}"
+    );
+    assert!(
+        out.contains("## Blocked") && out.contains("rm -rf /"),
+        "a denied command has to appear under Blocked, got: {out:?}"
+    );
+    assert!(
+        out.contains("Score 3 — transparent formula: deny×3 + escalation×2 + ask×1."),
+        "the risk line prints its own inputs so nobody has to trust it, got: {out:?}"
+    );
+    assert!(
+        out.contains("## Risk: Medium"),
+        "one deny is three points, which is Medium, got: {out:?}"
+    );
+    assert!(
+        out.contains("## Insurance") && out.contains("No insured operations in scope."),
+        "the Insurance section states its absence rather than going missing, got: {out:?}"
+    );
+    assert!(out.contains("## Last 30 days"), "{out:?}");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn the_terminal_report_renders_the_same_facts_in_its_own_shape() {
+    let tmp = scratch("term");
+    let home = tmp.join("home");
+    let proj = project(&tmp);
+
+    termaxa(&home, &proj, &["check", "rm -rf /"]);
+    termaxa(&home, &proj, &["check", "ls"]);
+
+    let out = termaxa(&home, &proj, &["report", "--all"]);
+
+    assert!(!out.is_empty(), "the terminal report must print something");
+    assert!(
+        out.contains("rm -rf /"),
+        "the blocked command belongs in the report, got: {out:?}"
+    );
+    assert!(
+        out.contains('3') && out.to_lowercase().contains("risk"),
+        "the risk score and its label are the point of the summary, got: {out:?}"
+    );
+    // The markdown heading syntax must NOT leak into the terminal rendering.
+    assert!(
+        !out.contains("# Termaxa Execution Report"),
+        "terminal output should not be markdown, got: {out:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// A project whose breaker trips on the second destructive attempt, so a
+/// handful of hook calls is enough to reach the Insight threshold.
+fn project_with_a_hair_trigger(root: &Path) -> std::path::PathBuf {
+    let proj = root.join("proj");
+    std::fs::create_dir_all(proj.join(".termaxa")).expect("project dir must be creatable");
+    std::fs::write(
+        proj.join(".termaxa").join("policy.yaml"),
+        "version: 1\ndefault: ask\nrules: []\ncircuit_breaker:\n  enabled: true\n  threshold: 1\n",
+    )
+    .expect("policy must be writable");
+    proj
+}
+
+/// One PreToolUse hook call. The breaker only exists on this path — it needs
+/// a session to count within — so the sections it feeds can only be set up
+/// through the hook, not through `check`.
+fn hook(home: &Path, proj: &Path, session: &str, command: &str) {
+    let payload = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "cwd": proj.display().to_string(),
+        "session_id": session,
+        "tool_input": { "command": command }
+    })
+    .to_string();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_termaxa"))
+        .arg("hook")
+        .current_dir(proj)
+        .env("TERMAXA_HOME", home)
+        .env("NO_COLOR", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("the binary must be runnable");
+    child
+        .stdin
+        .take()
+        .expect("stdin must be piped")
+        .write_all(payload.as_bytes())
+        .expect("the payload must be writable");
+    child.wait().expect("the hook must exit");
+}
+
+#[test]
+fn repeated_blocked_attempts_raise_every_section_they_feed() {
+    let tmp = scratch("sections");
+    let home = tmp.join("home");
+    let proj = project_with_a_hair_trigger(&tmp);
+
+    // Four attempts at the same destructive intent in one session: the first
+    // is merely asked about, the rest trip the breaker.
+    for _ in 0..4 {
+        hook(&home, &proj, "sess-insight", "rm -rf ./build");
+    }
+
+    let md = termaxa(&home, &proj, &["report", "--md", "--all"]);
+    assert!(
+        md.contains("## Destructive intents") && md.contains("**file-delete**"),
+        "a classified intent must raise its section, got: {md:?}"
+    );
+    assert!(
+        md.contains("## Impact at intervention points"),
+        "an intervention with a preview must raise the impact section, got: {md:?}"
+    );
+    assert!(
+        md.contains("## Insight"),
+        "three blocked attempts of one intent is the Insight threshold, got: {md:?}"
+    );
+    assert!(
+        md.contains("- **Top directories:**"),
+        "entries carry a cwd, so the rollup has directories to rank, got: {md:?}"
+    );
+
+    let term = termaxa(&home, &proj, &["report", "--all"]);
+    assert!(term.contains("Destructive intents"), "{term:?}");
+    assert!(term.contains("Insight"), "{term:?}");
+    assert!(term.contains("Top directories"), "{term:?}");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn a_quiet_session_raises_none_of_those_sections() {
+    // The other side of every `if !…is_empty()` guard: absent sections must
+    // stay absent rather than printing an empty heading.
+    let tmp = scratch("quiet");
+    let home = tmp.join("home");
+    let proj = project(&tmp);
+
+    termaxa(&home, &proj, &["check", "ls"]);
+
+    let md = termaxa(&home, &proj, &["report", "--md", "--all"]);
+    assert!(!md.contains("## Destructive intents"), "{md:?}");
+    assert!(!md.contains("## Impact at intervention points"), "{md:?}");
+    assert!(!md.contains("## Insight"), "{md:?}");
+    assert!(md.contains("## Risk: Low"), "an allow alone is Low: {md:?}");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn the_risk_label_is_coloured_by_its_own_severity() {
+    // Under NO_COLOR every label renders identically, so the mapping from
+    // label to colour is only observable with colour turned on.
+    let tmp = scratch("risk-colour");
+    let home = tmp.join("home");
+    let proj = project(&tmp);
+
+    let coloured = |args: &[&str]| -> String {
+        let out = Command::new(env!("CARGO_BIN_EXE_termaxa"))
+            .args(args)
+            .current_dir(&proj)
+            .env("TERMAXA_HOME", &home)
+            .env_remove("NO_COLOR")
+            .env_remove("TERMAXA_NO_COLOR")
+            .env("CLICOLOR_FORCE", "1")
+            .output()
+            .expect("the binary must be runnable");
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    };
+
+    coloured(&["check", "ls"]);
+    let low = coloured(&["report", "--all"]);
+    assert!(
+        low.contains("\x1b[32mLow"),
+        "Low risk is green, got: {low:?}"
+    );
+
+    coloured(&["check", "rm -rf /"]);
+    let medium = coloured(&["report", "--all"]);
+    assert!(
+        medium.contains("\x1b[33mMedium"),
+        "Medium risk is amber, got: {medium:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn a_home_with_no_log_reports_no_activity() {
+    let tmp = scratch("empty");
+    let home = tmp.join("home");
+    let proj = project(&tmp);
+
+    let out = termaxa(&home, &proj, &["report"]);
+    assert!(
+        out.contains("(no activity to report)"),
+        "an empty log has to say so, got: {out:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/tests/report_output.rs
+++ b/tests/report_output.rs
@@ -55,7 +55,7 @@ fn the_markdown_report_carries_the_counts_and_the_risk_formula() {
     let proj = project(&tmp);
 
     // Three decisions the policy above produces: one deny, two allows.
-    termaxa(&home, &proj, &["check", "rm -rf /"]);
+    termaxa(&home, &proj, &["check", "rm -rf /nonexistent-tmx-fixture"]);
     termaxa(&home, &proj, &["check", "ls -la"]);
     termaxa(&home, &proj, &["check", "ls"]);
 
@@ -96,7 +96,7 @@ fn the_terminal_report_renders_the_same_facts_in_its_own_shape() {
     let home = tmp.join("home");
     let proj = project(&tmp);
 
-    termaxa(&home, &proj, &["check", "rm -rf /"]);
+    termaxa(&home, &proj, &["check", "rm -rf /nonexistent-tmx-fixture"]);
     termaxa(&home, &proj, &["check", "ls"]);
 
     let out = termaxa(&home, &proj, &["report", "--all"]);
@@ -248,7 +248,7 @@ fn the_risk_label_is_coloured_by_its_own_severity() {
         "Low risk is green, got: {low:?}"
     );
 
-    coloured(&["check", "rm -rf /"]);
+    coloured(&["check", "rm -rf /nonexistent-tmx-fixture"]);
     let medium = coloured(&["report", "--all"]);
     assert!(
         medium.contains("\x1b[33mMedium"),

--- a/tests/report_output.rs
+++ b/tests/report_output.rs
@@ -154,12 +154,13 @@ fn hook(home: &Path, proj: &Path, session: &str, command: &str) {
         .stdout(Stdio::piped())
         .spawn()
         .expect("the binary must be runnable");
-    child
+    // See cli_surface.rs: a child that exits before reading closes the pipe,
+    // and that is its answer rather than a plumbing failure.
+    let _ = child
         .stdin
         .take()
         .expect("stdin must be piped")
-        .write_all(payload.as_bytes())
-        .expect("the payload must be writable");
+        .write_all(payload.as_bytes());
     child.wait().expect("the hook must exit");
 }
 


### PR DESCRIPTION
A mutation-testing pass over the whole suite, file by file, plus the four
findings it produced and one fix folded in from Manoj.

cargo-mutants introduces a fault (swap an operator, replace a function body
with a constant, delete a match arm) and the only question is whether a test
notices. A mutant that survives is a test that passes under the change it
exists to catch. Every file below was taken to a clean score, each as its own
commit carrying its before and after.

## Scores

| file | before | after |
|---|---|---|
| report.rs | 14.49% | 100% |
| main.rs | 31.25% | 100% |
| notify.rs | 37.50% | 100% |
| preview.rs | 45.71% | 100% |
| backup.rs | 48.68% | 100% |
| ui.rs | 59.46% | 100% |
| delete.rs | 60.38% | 96.33% |
| hook.rs | 63.49% | 100% |
| pg.rs | 68.10% | 100% |
| doctor.rs | 70.21% | 100% |
| paths.rs | 70.59% | 100% |
| intent.rs | 74.04% | 100% |
| policy.rs | 74.32% | 100% |
| protect.rs | 77.42% | 100% |
| shell.rs | 77.78% | 100% |
| init.rs | 81.25% | 100% |
| fingerprint.rs | 95.71% | 100% |
| runner.rs / context.rs / audit.rs | 0% / 18.18% / 25.00% | 100% |

189 tests to 379. Three files had no tests at all: runner.rs, context.rs,
audit.rs.

delete.rs is the one file short of 100%. Its four survivors are the TIME half
of the scan budget, which needs a filesystem slow enough to blow 300ms inside
one directory; no test can arrange that deterministically. They are left alive
rather than suppressed, because "we cannot reach this" is a different claim
from "this cannot matter", and the count half of the same condition is covered
at both check sites.

## Four findings, all confirmed against the running binary

**1. doctor reported a live hook as dead.** The liveness probe sends `rm -rf /`
and waits 2s; answering that command walks the filesystem to the delete
preview's budget, measured at 5.8-7.1s on WSL2 with Windows drives mounted.
The probe timed out and a correctly gated setup printed "registered but NOT
firing — commands are ungated". hook_configured inverted: red over a gated
session.

Root cause one level down: both budgets (MAX_FILES 5,000, MAX_TIME 300ms) were
consulted only BETWEEN directories, so one wide directory ran to completion
inside a single loop body. /mnt/c/Windows/WinSxS, 16,423 entries, 5.55s. The
same defect showed up with no slow filesystem at all: 5,200 files in one
directory returned files=5,200 with capped=false, walking past the cap and then
reporting it had not.

Fixed by Manoj's commit, included here with his authorship. After it, on the
machine that produced the field case:

    scan_budgeted("/")   5.6s  -> 300ms
    doctor end to end    dead  -> live, 0.30s
    one wide directory   5,500 files capped:false -> 5,000 capped:true
    probe_inertness.rs   17.6s -> 0.91s, fixture untouched

**2. `git clean --force` is invisible to the intent classifier.** `git clean -f`
classifies as git-destructive; the long spelling classifies as nothing, though
both delete the same untracked files. The rm predicate handles its own long
form explicitly while the git clean arm reads only bundled short flags. Policy
rules still catch the command; it is the circuit breaker and the report that go
quiet. Pinned as a named known-gap test rather than fixed.

**3. Dead code in hook.rs.** Lines 483 and 520 are the same
`if input.is_post { ... return Ok(()); }` block twice over, comments and all.
The first returns for every post input, so the second is unreachable, about 34
lines. rustc cannot warn because the condition is a runtime value. Found
because its mutants cannot be killed: nothing there executes. Left in place and
reported rather than deleted.

**4. `TRUNCATE a,b` runs with no pg_dump behind it.** A comma with no space
after it is valid SQL that pg.rs does not parse, so the table list comes back
empty and `backup::pg_backup_targets` plans nothing:

    TRUNCATE a, b   parsed, insurance planned
    TRUNCATE a,b    not parsed, NO insurance

The intent classifier matches on text, so policy and the breaker still gate it.
Only the safety net is decided by whitespace, which is the same class as the
v0.14 path bug whose comment in delete.rs reads "path syntax must never decide
whether a safety net exists". Pinned as a named known-gap test.

## What the tests look like

Where behaviour is only observable from outside the process, the tests run the
binary and read what a harness would: five integration files covering the hook
dialects, the CLI surface, doctor, init and the report. `report::run` returns an
exit code and nothing else, so the whole rendering could do nothing and a unit
test would still see Ok(0).

Some things needed a real environment rather than a mock: a pty, because
`colour_enabled` caches in a OnceLock and CLICOLOR_FORCE returns before is_tty
is consulted; real git repositories for the push preview and the branch
backup; stub binaries for psql, pg_dump and terraform, reached by absolute path
where possible so the process environment stays untouched.

## Suppressions

23 across 9 files, each carrying the argument for why the mutant cannot be
killed rather than a bare entry: SHA-256's ch and maj identities, wildcard
backtracking that reconverges (checked exhaustively over 30,276 pattern/text
pairs), match arms byte-identical to their default, and the dead is_post block,
which is recorded as DEAD rather than equivalent. One suppression was retired
in this branch because a new test closed it.

## Assertions that were wrong rather than missing

Five tests passed for the wrong reason and were fixed rather than added to:
`"1 path(s) restored"` is a substring of `"-1 path(s) restored"`, so the count
check passed under the exact mutation it existed to catch; two hook cwd tests
passed because the built-in starter policy also denies `rm -rf`, so the
fallback produced an identical verdict; a quote test used a balanced pair,
which returns the wrong state to the right one; and a socket read took the
headers as the payload.
