### PR TITLE
v0.16 item 2: one scanner for one grammar

### DIFF
--- a/.chaos-mcp/suppressions.json
+++ b/.chaos-mcp/suppressions.json
@@ -15,14 +15,14 @@
         "line": 131,
         "mutator": "replace ^ with | in sha256_hex",
         "addedAt": 1786705435998,
-        "reason": "equivalent: SHA-256 `ch` is (e&f)^(!e&g), whose terms are masked by e and !e and so are disjoint — XOR and OR agree on every bit pattern (verified over all 8)",
+        "reason": "equivalent: SHA-256 `ch` is (e&f)^(!e&g), whose terms are masked by e and !e and so are disjoint \u2014 XOR and OR agree on every bit pattern (verified over all 8)",
         "fingerprint": "fe05454fb5c0"
       },
       {
         "line": 138,
         "mutator": "replace ^ with | in sha256_hex",
         "addedAt": 1786705435998,
-        "reason": "equivalent: SHA-256 `maj` is the majority function, identical in XOR and OR form — both single-operator swaps match maj on all 8 bit patterns under Rust's & > ^ > | precedence",
+        "reason": "equivalent: SHA-256 `maj` is the majority function, identical in XOR and OR form \u2014 both single-operator swaps match maj on all 8 bit patterns under Rust's & > ^ > | precedence",
         "fingerprint": "735600a52303"
       }
     ],
@@ -31,35 +31,35 @@
         "line": 49,
         "mutator": "replace is_tty -> bool with true",
         "addedAt": 1786706277919,
-        "reason": "platform-gated: this is the #[cfg(windows)] is_tty, not compiled on Linux, so no test run on this target can observe the change — audit on Windows to score it",
+        "reason": "platform-gated: this is the #[cfg(windows)] is_tty, not compiled on Linux, so no test run on this target can observe the change \u2014 audit on Windows to score it",
         "fingerprint": "dda202a6fe45"
       },
       {
         "line": 49,
         "mutator": "replace is_tty -> bool with false",
         "addedAt": 1786706277919,
-        "reason": "platform-gated: this is the #[cfg(windows)] is_tty, not compiled on Linux, so no test run on this target can observe the change — audit on Windows to score it",
+        "reason": "platform-gated: this is the #[cfg(windows)] is_tty, not compiled on Linux, so no test run on this target can observe the change \u2014 audit on Windows to score it",
         "fingerprint": "dda202a6fe45"
       },
       {
         "line": 50,
         "mutator": "delete - in is_tty",
         "addedAt": 1786706277919,
-        "reason": "platform-gated: STD_OUTPUT_HANDLE in the #[cfg(windows)] is_tty, not compiled on Linux — audit on Windows to score it",
+        "reason": "platform-gated: STD_OUTPUT_HANDLE in the #[cfg(windows)] is_tty, not compiled on Linux \u2014 audit on Windows to score it",
         "fingerprint": "1cc2dfc8f009"
       },
       {
         "line": 61,
         "mutator": "replace != with == in is_tty",
         "addedAt": 1786706277919,
-        "reason": "platform-gated: the GetConsoleMode check in the #[cfg(windows)] is_tty, not compiled on Linux — audit on Windows to score it",
+        "reason": "platform-gated: the GetConsoleMode check in the #[cfg(windows)] is_tty, not compiled on Linux \u2014 audit on Windows to score it",
         "fingerprint": "2cd1cbb6d021"
       },
       {
         "line": 69,
         "mutator": "replace is_tty -> bool with true",
         "addedAt": 1786706277919,
-        "reason": "platform-gated: the #[cfg(not(any(unix, windows)))] fallback, compiled on neither of the targets this project ships — unreachable from any test here",
+        "reason": "platform-gated: the #[cfg(not(any(unix, windows)))] fallback, compiled on neither of the targets this project ships \u2014 unreachable from any test here",
         "fingerprint": "fcbcf165908d"
       }
     ],
@@ -68,14 +68,14 @@
         "line": 54,
         "mutator": "replace > with >= in generate",
         "addedAt": 1786713336077,
-        "reason": "equivalent: the two differ only at one segment, and there find_map over that single segment calls generate_one with the same text — normalize trims the whitespace, and a dropped trailing separator is an inert token to every downstream parser (pg tokenizes, git matches a prefix)",
+        "reason": "equivalent: the two differ only at one segment, and there find_map over that single segment calls generate_one with the same text \u2014 normalize trims the whitespace, and a dropped trailing separator is an inert token to every downstream parser (pg tokenizes, git matches a prefix)",
         "fingerprint": "b573b51bf054"
       },
       {
         "line": 168,
         "mutator": "replace > with >= in git_push_preview",
         "addedAt": 1786713336077,
-        "reason": "equivalent: they differ only at exactly one --stat line, which cannot reach here — git() returns None for empty output, so the block runs only with per-file lines plus the totals line, i.e. two or more",
+        "reason": "equivalent: they differ only at exactly one --stat line, which cannot reach here \u2014 git() returns None for empty output, so the block runs only with per-file lines plus the totals line, i.e. two or more",
         "fingerprint": "a840fd70ac75"
       }
     ],
@@ -84,14 +84,14 @@
         "line": 312,
         "mutator": "replace + with * in wildcard_match",
         "addedAt": 1786720071482,
-        "reason": "equivalent: after the mutated backtrack (pi = star) the next iteration re-enters the star branch and sets star = pi, mark = ti, pi = star + 1 — exactly the state the real branch produces, so the two reconverge before anything is observable. Checked exhaustively over 30,276 pattern/text pairs from {a, b, *} (patterns and texts up to length 6): no input distinguishes them",
+        "reason": "equivalent: after the mutated backtrack (pi = star) the next iteration re-enters the star branch and sets star = pi, mark = ti, pi = star + 1 \u2014 exactly the state the real branch produces, so the two reconverge before anything is observable. Checked exhaustively over 30,276 pattern/text pairs from {a, b, *} (patterns and texts up to length 6): no input distinguishes them",
         "fingerprint": "2590c17b32bd"
       },
       {
         "line": 214,
         "mutator": "replace < with <= in Policy::evaluate",
         "addedAt": 1786720710037,
-        "reason": "equivalent: idx < bi and idx <= bi differ only at idx == bi, and that means the same index into self.rules — so both arms of the if produce the identical (index, rule) pair and `best` is unchanged either way",
+        "reason": "equivalent: idx < bi and idx <= bi differ only at idx == bi, and that means the same index into self.rules \u2014 so both arms of the if produce the identical (index, rule) pair and `best` is unchanged either way",
         "fingerprint": "26f79d8eac41"
       }
     ],
@@ -100,14 +100,14 @@
         "line": 521,
         "mutator": "replace && with || in run",
         "addedAt": 1786731671137,
-        "reason": "unreachable: this is a duplicate of the `if input.is_post` block above it, which returns Ok(()) for every post input, so nothing here executes. Not equivalent — dead. The block should be deleted; the suppression goes away with it",
+        "reason": "unreachable: this is a duplicate of the `if input.is_post` block above it, which returns Ok(()) for every post input, so nothing here executes. Not equivalent \u2014 dead. The block should be deleted; the suppression goes away with it",
         "fingerprint": "c7754d516339"
       },
       {
         "line": 521,
         "mutator": "delete ! in run",
         "addedAt": 1786731671137,
-        "reason": "unreachable: this is a duplicate of the `if input.is_post` block above it, which returns Ok(()) for every post input, so nothing here executes. Not equivalent — dead. The block should be deleted; the suppression goes away with it",
+        "reason": "unreachable: this is a duplicate of the `if input.is_post` block above it, which returns Ok(()) for every post input, so nothing here executes. Not equivalent \u2014 dead. The block should be deleted; the suppression goes away with it",
         "fingerprint": "c7754d516339"
       }
     ],
@@ -125,43 +125,6 @@
         "addedAt": 1786732519506,
         "reason": "equivalent: the arm's body is byte-identical to the `_` default arm (token.starts_with('-')), so deleting it changes no behaviour. It exists to document that PowerShell never uses a leading slash for switches",
         "fingerprint": "5b4c79689c91"
-      }
-    ],
-    "src/shell.rs": [
-      {
-        "line": 59,
-        "mutator": "replace < with > in split_segments",
-        "addedAt": 1786737505742,
-        "reason": "equivalent: not consuming the second `|` is unobservable. The unconsumed character is handled by the same `|` arm on the next iteration, which flushes an empty buffer, and flush() drops empties. Both paths produce identical segments",
-        "fingerprint": "555f7e722b0a"
-      },
-      {
-        "line": 60,
-        "mutator": "replace += with *= in split_segments",
-        "addedAt": 1786737505742,
-        "reason": "equivalent: i *= 1 leaves i unchanged, which is the same as not consuming the second `|`, and an unconsumed `|` only flushes an empty buffer, which flush() drops",
-        "fingerprint": "0d1ba708993c"
-      },
-      {
-        "line": 135,
-        "mutator": "replace < with <= in redirect_targets",
-        "addedAt": 1786737505742,
-        "reason": "equivalent: the bound differs only at a trailing backslash (i + 1 == len). There the real guard falls to the default arm and the mutant skips one position; both then leave the loop with nothing pushed",
-        "fingerprint": "f6a2746dc86a"
-      },
-      {
-        "line": 135,
-        "mutator": "replace + with * in redirect_targets",
-        "addedAt": 1786737505742,
-        "reason": "equivalent: i * 1 < len is i < len, which is always true inside the loop, so the guard reduces to !in_single. It differs only at a trailing backslash, where both paths end the loop having pushed nothing",
-        "fingerprint": "f6a2746dc86a"
-      },
-      {
-        "line": 155,
-        "mutator": "replace + with * in redirect_targets",
-        "addedAt": 1786737505742,
-        "reason": "equivalent: i = j lands on the '&' itself, which the next iteration matches with the default arm and steps over, arriving at the same position as i = j + 1",
-        "fingerprint": "507d53aa5804"
       }
     ],
     "src/pg.rs": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to Termaxa. Format loosely follows [Keep a Changelog](https://keepachangelog.com/); this project is pre-1.0, so minor versions may include breaking changes to the policy schema or CLI.
 
+## Unreleased
+
+### Changed
+
+- **Path resolution takes an explicit cwd.** A hook runs in whatever directory
+  the harness spawned it in, which is not the directory the agent's command
+  runs in, so a relative target resolved against the process cwd found nothing
+  and took no backup — silently, because "no such file" and "nothing to
+  insure" are the same answer (#15). `resolve_path_in(raw, cwd)` replaces
+  `resolve_path`; the hook passes the payload cwd, and the ambient fallback is
+  deleted rather than deprecated — with every call site threaded, the compiler
+  reported the old form as dead code, which is the proof nothing resolves
+  ambiently any more.
+
+- **One scanner for one grammar.** Segments and their redirect targets now
+  come from the same walk: `split_segments` returns `Segment` values carrying
+  the `Overwrite`s found in them, and `shell::redirect_targets` is deleted.
+  Two parsers over the same input had already produced three bugs and, once
+  their outputs were compared, two measurable disagreements: `>|` was split at
+  its `|`, so the clobber was invisible to intent and policy (which split
+  first) while backup, re-scanning the raw string, insured it; and the walks
+  read `\"` differently outside quotes. `backup` now consumes per-segment
+  redirects instead of re-scanning the raw command.
+
+  Stated behavior change: **escapes outside single quotes are literal**, as a
+  shell reads them. `echo \" ; rm -rf x` is now two segments — previously the
+  escaped quote opened a quote, the `;` never split, and the whole line
+  (including the `rm` the shell runs as its own command) could match a single
+  permissive rule. Escaped separators (`\;`, `\&`) no longer split, because
+  the shell runs one command there, and an escaped space in a redirect target
+  keeps the filename whole. Each change is pinned by a labeled test with a
+  control leg.
+
 ## v0.15.0 — stop treating commands as strings
 
 ### Changed

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -102,6 +102,11 @@ pub fn take(termaxa_dir: &Path, command: &str, cwd: &Path) -> Result<Option<Back
         }
         return Ok(None);
     }
+    let redirects = segments
+        .into_iter()
+        .next()
+        .map(|s| s.redirects)
+        .unwrap_or_default();
     let tokens = crate::pg::shell_tokens(command);
     let (ts_ms, ts) = now();
     let id = format!("b-{}", ts_ms);
@@ -114,7 +119,7 @@ pub fn take(termaxa_dir: &Path, command: &str, cwd: &Path) -> Result<Option<Back
         backup_files(termaxa_dir, &id, &ts, command, &paths)?
     } else if let Some(state) = tf_state_target(&tokens) {
         backup_files(termaxa_dir, &id, &ts, command, &[state])?
-    } else if let Some(paths) = overwrite_targets(command, cwd) {
+    } else if let Some(paths) = overwrite_paths(&redirects, cwd) {
         backup_files(termaxa_dir, &id, &ts, command, &paths)?
     } else {
         return Ok(None);
@@ -315,12 +320,18 @@ fn backup_pg(
 /// the same mechanism as for a delete — copy aside first — because the outcome
 /// is the same: the contents are gone.
 ///
+/// v0.16 §1.5: consumes the redirects the segment arrived with, from the same
+/// split every other engine reads. Until now this function re-scanned its
+/// input string — the one caller that computed redirects from something other
+/// than a split segment, which is exactly how two engines start disagreeing
+/// about what a command targets (decision #37).
+///
 /// Only files that already EXIST are insurable. `> newfile` creates rather than
 /// destroys, and backing up a path with no contents is noise in the manifest.
-/// Appends (`>>`) are excluded upstream by `Overwrite::truncates`.
-fn overwrite_targets(command: &str, cwd: &Path) -> Option<Vec<PathBuf>> {
-    let paths: Vec<PathBuf> = crate::shell::redirect_targets(command)
-        .into_iter()
+/// Appends (`>>`) are excluded here by `Overwrite::truncates`.
+fn overwrite_paths(redirects: &[crate::shell::Overwrite], cwd: &Path) -> Option<Vec<PathBuf>> {
+    let paths: Vec<PathBuf> = redirects
+        .iter()
         .filter(|o| o.truncates)
         .map(|o| crate::delete::resolve_path_in(&o.target, cwd))
         .filter(|p| p.is_file())
@@ -567,6 +578,18 @@ mod tests {
     }
 
     use crate::testutil::TempTree;
+
+    /// The old `overwrite_targets(command, cwd)` shape, for tests: split the
+    /// command as production now does and hand the first segment's redirects
+    /// to `overwrite_paths`.
+    fn overwrite_targets(command: &str, cwd: &Path) -> Option<Vec<PathBuf>> {
+        let redirects = crate::shell::split_segments(command)
+            .into_iter()
+            .next()
+            .map(|s| s.redirects)
+            .unwrap_or_default();
+        overwrite_paths(&redirects, cwd)
+    }
 
     /// A real temp directory containing one file. The guard is returned with
     /// it: dropping it removes the tree, so the caller has to keep it alive

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -94,16 +94,18 @@ impl Intent {
 pub fn classify_command(command: &str) -> Option<Intent> {
     crate::shell::split_segments(command)
         .iter()
-        .filter_map(|seg| classify_segment(seg))
+        .filter_map(classify_segment)
         .max_by_key(|i| i.rank())
 }
 
 /// A truncating redirect destroys whatever was at the target. Checked before
 /// command-name classification, because the destructive part is the operator
 /// rather than the program: `cat`, `echo` and `ls` are all read-only commands
-/// right up until a `>` is attached to them.
-fn overwrite_intent(segment: &str) -> Option<Intent> {
-    crate::shell::redirect_targets(segment)
+/// right up until a `>` is attached to them. Reads the redirects the segment
+/// arrived with — the split found them; nothing re-scans.
+fn overwrite_intent(segment: &crate::shell::Segment) -> Option<Intent> {
+    segment
+        .redirects
         .iter()
         .any(|o| o.truncates)
         .then_some(Intent::FileOverwrite)
@@ -114,7 +116,7 @@ fn overwrite_intent(segment: &str) -> Option<Intent> {
 /// Scope is deliberately limited to *commands*: `python -c "shutil.rmtree(...)"`
 /// will not classify. That is the cooperative-gate boundary SECURITY.md
 /// documents; the breaker is a speed bump for syntax variation, not a sandbox.
-fn classify_segment(segment: &str) -> Option<Intent> {
+fn classify_segment(segment: &crate::shell::Segment) -> Option<Intent> {
     // Both classifications, highest rank wins, the command-name one on ties.
     // NOT an early return on the overwrite: `psql -c "DROP TABLE u" > out.sql`
     // is db-destroy (rank 4) that also writes a file, and the first draft
@@ -459,6 +461,10 @@ mod tests {
             "echo '' > config.json",
             "ls -la > /etc/hosts",
             "grep -r . / > /tmp/exfil",
+            // `>|` clobbers past noclobber. Until v0.16 §1.5 the splitter cut
+            // this at the `|`, so intent classified it None while backup
+            // insured it — two engines disagreeing about one command.
+            "cmd >| forced.txt",
         ] {
             assert_eq!(
                 classify_command(cmd),

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -910,7 +910,8 @@ mod combined_gate_tests {
             Action::Allow,
             "known gap — if this starts denying, delete this test and the comment"
         );
-        let r = crate::shell::redirect_targets("cat /dev/null > ./.env");
+        let segs = crate::shell::split_segments("cat /dev/null > ./.env");
+        let r = &segs[0].redirects;
         assert!(
             r.len() == 1 && r[0].truncates && r[0].target == "./.env",
             "the net beneath: insurance sees the spelling the string rules miss"

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -18,7 +18,7 @@
 ///   - `$(...)` and backticks cannot be statically analyzed — their PRESENCE
 ///     is reported so the context engine can escalate, rather than
 ///     pretending the contents were checked.
-pub fn split_segments(s: &str) -> Vec<String> {
+pub fn split_segments(s: &str) -> Vec<Segment> {
     let mut segments = Vec::new();
     let mut cur = String::new();
     let chars: Vec<char> = s.chars().collect();
@@ -54,6 +54,14 @@ pub fn split_segments(s: &str) -> Vec<String> {
             // in are `2>&1` / `>&2` / `<&-` (preceded by `>` or `<`) and
             // `&>file` / `&>>file` (followed by `>`); those are not separators.
             '&' if !is_redirection_amp(&chars, i) => flush(&mut segments, &mut cur),
+            // `>|` forces clobber past `set -o noclobber` — one operator, not
+            // a redirect followed by a pipe. Splitting here cut the target off
+            // into its own segment, so intent and policy (which split first)
+            // never saw the truncation the redirect scan reports; only backup,
+            // which then re-scanned the raw string, insured it. Found by
+            // unifying the scanners (v0.16 §1.5): the moment the redirect scan
+            // ran on split output, the disagreement became a failing test.
+            '|' if i > 0 && chars[i - 1] == '>' => cur.push(c),
             '|' => {
                 flush(&mut segments, &mut cur);
                 if i + 1 < chars.len() && chars[i + 1] == '|' {
@@ -67,6 +75,46 @@ pub fn split_segments(s: &str) -> Vec<String> {
     }
     flush(&mut segments, &mut cur);
     segments
+}
+
+/// One shell segment, carrying the redirect targets found in it.
+///
+/// v0.16 §1.5. Segments and redirect targets used to come from two separate
+/// public scanners over the same grammar, and callers chose which to trust —
+/// `intent` read redirects per segment while `backup` re-scanned the raw
+/// command (decision #37: two engines parsing the same input are already
+/// disagreeing). One public type ends the choice: a segment arrives with its
+/// redirects attached, from the same split.
+///
+/// `Deref<Target = str>` keeps every caller that only wants the text
+/// unchanged; the field is private so the text cannot drift from the
+/// redirects computed for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Segment {
+    text: String,
+    /// Files this segment writes over, in order of appearance.
+    pub redirects: Vec<Overwrite>,
+}
+
+impl std::ops::Deref for Segment {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.text
+    }
+}
+
+impl std::fmt::Display for Segment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.text)
+    }
+}
+
+/// Tests compare segment lists against string literals; the comparison is on
+/// the text alone, which is the only part a string literal can speak for.
+impl PartialEq<&str> for Segment {
+    fn eq(&self, other: &&str) -> bool {
+        self.text == *other
+    }
 }
 
 /// A file this command will write over, and how.
@@ -104,13 +152,14 @@ fn is_sink(target: &str) -> bool {
 /// engine: no intent, no preview, no backup. `cat /dev/null > .env` matched the
 /// read-only `cat *` allow rule and wiped a credentials file.
 ///
-/// HONESTY NOTE: this is a second character walk over the same grammar
-/// `split_segments` reads, kept in the same file so they drift together
-/// loudly rather than apart quietly. The unification — one scan producing
-/// segments that carry their redirects (the Segment struct, option 3 in the
-/// v0.15 scope) — is the remaining overwrite work, alongside preview and the
-/// cp/mv/tee/dd destinations. Two parsers for one grammar caused three bugs
-/// here already; do not let this comment outlive the duplication.
+/// HONESTY NOTE: this is still a second character walk over the same grammar
+/// `split_segments` reads. What changed in v0.16 §1.5 is that it is no longer
+/// a second PUBLIC scanner: only `flush` calls it, on segments the splitter
+/// just produced, so no caller can feed the two walks different inputs. The
+/// walks themselves still disagree on escape handling outside quotes
+/// (`\"` toggles a quote here but not there) — folding them into one walk is
+/// the next commit, and it must pick one escape semantics to do it. Do not
+/// let this comment outlive the second walk.
 ///
 /// Deliberately NOT treated as redirects, because they do not create or
 /// truncate a file: `2>&1`, `>&2`, `<&-` (descriptor duplication), `&>` and
@@ -119,7 +168,7 @@ fn is_sink(target: &str) -> bool {
 /// literal character), anything inside quotes, and sinks (`/dev/null` and
 /// friends — truncating one destroys nothing). `>|` (clobber past
 /// noclobber) IS a truncation of the named file.
-pub fn redirect_targets(segment: &str) -> Vec<Overwrite> {
+fn scan_redirects(segment: &str) -> Vec<Overwrite> {
     let chars: Vec<char> = segment.chars().collect();
     let mut out = Vec::new();
     let (mut in_single, mut in_double) = (false, false);
@@ -205,10 +254,13 @@ fn is_redirection_amp(chars: &[char], i: usize) -> bool {
     prev_is_redirect || next_is_redirect
 }
 
-fn flush(segments: &mut Vec<String>, cur: &mut String) {
+fn flush(segments: &mut Vec<Segment>, cur: &mut String) {
     let t = cur.trim();
     if !t.is_empty() {
-        segments.push(t.to_string());
+        segments.push(Segment {
+            text: t.to_string(),
+            redirects: scan_redirects(t),
+        });
     }
     cur.clear();
 }
@@ -234,25 +286,29 @@ pub fn has_substitution(s: &str) -> bool {
 mod tests {
     use super::*;
 
+    /// Redirects as callers now receive them: through the split, attached to
+    /// the segments they were found in. Flattened here because these tests
+    /// assert on targets, not on which segment carried them.
+    fn redirects(cmd: &str) -> Vec<Overwrite> {
+        split_segments(cmd)
+            .into_iter()
+            .flat_map(|s| s.redirects)
+            .collect()
+    }
+
     /// #14. `>` was lexed and discarded, so a command that destroys a file by
     /// writing over it was invisible to every engine.
     #[test]
     fn truncating_redirects_are_extracted() {
-        let r = redirect_targets("cat /dev/null > .env");
+        let r = redirects("cat /dev/null > .env");
         assert_eq!(r.len(), 1);
         assert_eq!(r[0].target, ".env");
         assert!(r[0].truncates);
 
+        assert_eq!(redirects("ls -la > /etc/hosts")[0].target, "/etc/hosts");
+        assert_eq!(redirects("echo x >config.json")[0].target, "config.json");
         assert_eq!(
-            redirect_targets("ls -la > /etc/hosts")[0].target,
-            "/etc/hosts"
-        );
-        assert_eq!(
-            redirect_targets("echo x >config.json")[0].target,
-            "config.json"
-        );
-        assert_eq!(
-            redirect_targets(r#"echo x > "my file.txt""#)[0].target,
+            redirects(r#"echo x > "my file.txt""#)[0].target,
             "my file.txt"
         );
     }
@@ -261,7 +317,7 @@ mod tests {
     /// fires on every log line and gets uninstalled.
     #[test]
     fn appending_is_recorded_but_not_truncating() {
-        let r = redirect_targets("echo entry >> app.log");
+        let r = redirects("echo entry >> app.log");
         assert_eq!(r.len(), 1);
         assert_eq!(r[0].target, "app.log");
         assert!(!r[0].truncates, ">> appends, it does not destroy");
@@ -281,7 +337,7 @@ mod tests {
             "make 2>&1 | tee out",
         ] {
             assert!(
-                redirect_targets(cmd).is_empty(),
+                redirects(cmd).is_empty(),
                 "{cmd} redirects a descriptor, it does not truncate a file"
             );
         }
@@ -291,9 +347,9 @@ mod tests {
     /// segment splitter already guarantees, from the same scanner.
     #[test]
     fn quoted_redirects_are_text() {
-        assert!(redirect_targets(r#"echo "a > b""#).is_empty());
-        assert!(redirect_targets("echo 'x > y'").is_empty());
-        assert!(redirect_targets(r#"git commit -m "fix > bug""#).is_empty());
+        assert!(redirects(r#"echo "a > b""#).is_empty());
+        assert!(redirects("echo 'x > y'").is_empty());
+        assert!(redirects(r#"git commit -m "fix > bug""#).is_empty());
     }
 
     /// Sinks destroy nothing, and `> /dev/null` is the most common redirect
@@ -309,7 +365,7 @@ mod tests {
             "echo x > NUL",
         ] {
             assert!(
-                redirect_targets(cmd).is_empty(),
+                redirects(cmd).is_empty(),
                 "{cmd} truncates a sink, not a file"
             );
         }
@@ -321,25 +377,23 @@ mod tests {
     fn process_substitution_is_not_a_target() {
         for cmd in ["tee >(gzip -c) < data", "diff x >(sort)", "cmd > >(bar)"] {
             assert!(
-                redirect_targets(cmd)
-                    .iter()
-                    .all(|o| !o.target.starts_with('(')),
+                redirects(cmd).iter().all(|o| !o.target.starts_with('(')),
                 "{cmd}: a paren is an operator, not a filename"
             );
         }
-        assert!(redirect_targets("tee >(gzip -c) < data").is_empty());
+        assert!(redirects("tee >(gzip -c) < data").is_empty());
     }
 
     /// `\>` outside quotes is a literal; `>|` clobbers — a truncation of the
     /// named file; `<>` opens read-write and destroys nothing.
     #[test]
     fn escapes_clobber_and_read_write_open() {
-        assert!(redirect_targets(r"echo a \> b").is_empty());
-        let r = redirect_targets("cmd >| forced.txt");
+        assert!(redirects(r"echo a \> b").is_empty());
+        let r = redirects("cmd >| forced.txt");
         assert_eq!(r.len(), 1);
         assert_eq!(r[0].target, "forced.txt");
         assert!(r[0].truncates);
-        assert!(redirect_targets("cmd <> rw.txt").is_empty());
+        assert!(redirects("cmd <> rw.txt").is_empty());
     }
 
     /// The empty-target guard, exercised: a trailing redirect names nothing
@@ -349,7 +403,7 @@ mod tests {
     fn a_trailing_redirect_with_no_target_pushes_nothing() {
         for cmd in ["cmd >", "cmd > ", "cmd >>", "cmd >|", "echo x 2>"] {
             assert!(
-                redirect_targets(cmd).is_empty(),
+                redirects(cmd).is_empty(),
                 "{cmd:?} names no target and must push no Overwrite"
             );
         }
@@ -357,13 +411,15 @@ mod tests {
         // trailing-backslash bound mutants EQUIVALENT (f6a2746dc86a) - no
         // input distinguishes the spellings, so this pins the behavior
         // they share: a bare trailing escape ends the scan with nothing
-        // pushed.
-        assert!(redirect_targets("echo x \\").is_empty());
+        // pushed. (The fingerprint is from the pass over the then-public
+        // `redirect_targets`; the scan is now `scan_redirects`, reached
+        // through the split, and the pinned behavior is the same.)
+        assert!(redirects("echo x \\").is_empty());
     }
 
     #[test]
     fn several_redirects_in_one_segment() {
-        let r = redirect_targets("cmd > out.txt 2> err.txt");
+        let r = redirects("cmd > out.txt 2> err.txt");
         assert_eq!(r.len(), 2);
         assert_eq!(r[0].target, "out.txt");
         assert_eq!(r[1].target, "err.txt");
@@ -409,6 +465,17 @@ mod tests {
         assert_eq!(
             split_segments("make 2>&1 | tee log"),
             vec!["make 2>&1", "tee log"]
+        );
+        // `>|` is a clobber, not a pipe boundary. Splitting at its `|` hid
+        // the truncation from every engine that splits first — intent
+        // classified `cmd >| file` as None while backup insured it.
+        assert_eq!(
+            split_segments("cmd >| forced.txt"),
+            vec!["cmd >| forced.txt"]
+        );
+        assert_eq!(
+            split_segments("cmd >| out.txt | grep x"),
+            vec!["cmd >| out.txt", "grep x"]
         );
     }
 
@@ -474,11 +541,11 @@ mod tests {
 
         // Same question for the redirect scanner: the apostrophe must not
         // swallow the `>` that follows it.
-        let targets = redirect_targets("echo \"it's\" > out.txt");
+        let targets = redirects("echo \"it's\" > out.txt");
         assert_eq!(targets.len(), 1, "{targets:?}");
         assert_eq!(targets[0].target, "out.txt");
 
-        let targets = redirect_targets("echo 'a \"b\"' > out.txt");
+        let targets = redirects("echo 'a \"b\"' > out.txt");
         assert_eq!(targets[0].target, "out.txt");
     }
 
@@ -503,22 +570,22 @@ mod tests {
         assert_eq!(split_segments("ls ||"), ["ls"]);
         // A trailing backslash, inside quotes and bare.
         assert_eq!(split_segments("echo \"a\\"), ["echo \"a\\"]);
-        assert_eq!(redirect_targets("echo a\\").len(), 0);
-        assert_eq!(redirect_targets("echo > out.txt\\").len(), 1);
+        assert_eq!(redirects("echo a\\").len(), 0);
+        assert_eq!(redirects("echo > out.txt\\").len(), 1);
     }
 
     #[test]
     fn a_segment_may_begin_with_the_operator() {
         // Nothing precedes the first character, and the checks for "what came
         // before this?" have to survive that.
-        let targets = redirect_targets("> out.txt");
+        let targets = redirects("> out.txt");
         assert_eq!(targets.len(), 1, "{targets:?}");
         assert_eq!(targets[0].target, "out.txt");
         assert!(targets[0].truncates);
 
         // A leading `&>` combines streams rather than truncating a file, and
         // asking what precedes the `&` must not run off the front.
-        assert_eq!(redirect_targets("&> log.txt").len(), 0);
+        assert_eq!(redirects("&> log.txt").len(), 0);
         assert_eq!(split_segments("&> log.txt"), ["&> log.txt"]);
     }
 
@@ -526,20 +593,20 @@ mod tests {
     fn a_redirect_with_nothing_after_it_has_no_target() {
         // The skip-the-whitespace loop runs to the end of the input here, so
         // the bound on it is the only thing between this and a panic.
-        assert_eq!(redirect_targets("echo >").len(), 0);
-        assert_eq!(redirect_targets("echo >   ").len(), 0);
-        assert_eq!(redirect_targets("echo >>").len(), 0);
+        assert_eq!(redirects("echo >").len(), 0);
+        assert_eq!(redirects("echo >   ").len(), 0);
+        assert_eq!(redirects("echo >>").len(), 0);
     }
 
     #[test]
     fn a_quoted_target_keeps_the_spaces_inside_it() {
         // The quote has to close, or the scan swallows the rest of the line
         // and reports a target nobody wrote.
-        let targets = redirect_targets("echo > 'my file.txt' && ls");
+        let targets = redirects("echo > 'my file.txt' && ls");
         assert_eq!(targets.len(), 1, "{targets:?}");
         assert_eq!(targets[0].target, "my file.txt");
 
-        let targets = redirect_targets("echo > \"my file.txt\"");
+        let targets = redirects("echo > \"my file.txt\"");
         assert_eq!(targets[0].target, "my file.txt");
     }
 
@@ -553,7 +620,7 @@ mod tests {
         assert_eq!(segs.len(), 2, "{segs:?}");
         assert!(segs[1].starts_with("rm -rf"), "{segs:?}");
 
-        let targets = redirect_targets("echo 'a\"b' > out.txt");
+        let targets = redirects("echo 'a\"b' > out.txt");
         assert_eq!(
             targets.len(),
             1,
@@ -579,7 +646,7 @@ mod tests {
     fn a_backslash_inside_single_quotes_escapes_nothing() {
         // Single quotes are literal in a shell: a backslash there protects
         // nothing, so the closing quote is still a closing quote.
-        let targets = redirect_targets("echo '\\' > out.txt");
+        let targets = redirects("echo '\\' > out.txt");
         assert_eq!(targets.len(), 1, "{targets:?}");
         assert_eq!(targets[0].target, "out.txt");
     }
@@ -601,7 +668,7 @@ mod tests {
         // Nothing precedes the first character, and the escape arm's bound is
         // the only thing keeping the index from running off the front of the
         // input. `\> out.txt` writes a literal `>` and redirects nothing.
-        assert_eq!(redirect_targets("\\> out.txt").len(), 0);
+        assert_eq!(redirects("\\> out.txt").len(), 0);
         assert_eq!(split_segments("\\> out.txt"), ["\\> out.txt"]);
     }
 
@@ -623,14 +690,14 @@ mod tests {
             "/DEV/NULL",
         ] {
             assert!(
-                redirect_targets(&format!("echo x > {sink}")).is_empty(),
+                redirects(&format!("echo x > {sink}")).is_empty(),
                 "{sink} destroys nothing and must not be an overwrite target"
             );
         }
         // And a path that merely looks like one is still a file.
         for real in ["/dev/null.bak", "/dev/nullify", "nulled.txt"] {
             assert_eq!(
-                redirect_targets(&format!("echo x > {real}")).len(),
+                redirects(&format!("echo x > {real}")).len(),
                 1,
                 "{real} is an ordinary file"
             );

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -457,6 +457,33 @@ mod tests {
         assert_eq!(segs[0].redirects[0].target, "a");
     }
 
+    /// Kills predicted survivors 1-3 from the suppressions-retirement
+    /// commit, before the mutation pass runs. Each leg names its mutant.
+    #[test]
+    fn the_predicted_survivors_are_killed() {
+        // 1. `i > 0` -> `i >= 0` in prev_is_amp / prev_is_lt: a command
+        // BEGINNING with `>` must extract its target without underflowing.
+        let r = redirects("> x");
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].target, "x");
+        assert!(r[0].truncates);
+        assert!(!redirects(">> log").is_empty());
+        // 2. `truncates &&` -> `||` in the clobber check: `>>|` is not an
+        // operator anywhere - bash rejects it and nothing runs, so any
+        // segmentation is safe. The walk splits at the `|` (only `>|`
+        // consumes one), extracting no target; the mutant would merge the
+        // segments and invent a redirect on `x`.
+        let segs = split_segments("cmd >>| x");
+        assert_eq!(segs, vec!["cmd >>", "x"]);
+        assert!(segs.iter().all(|s| s.redirects.is_empty()));
+        // 3. `j + 1 < len` -> `<=` in the target escape arm: a trailing
+        // backslash in TARGET position is a literal, kept in the target as
+        // backslashes always are, and must not read past the end.
+        let r = redirects(r"cmd > a\");
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].target, r"a\");
+    }
+
     /// The empty-target guard, exercised: a trailing redirect names nothing
     /// and must push nothing. The last of the five predicted survivors; the
     /// other four died to `every_sink_spelling_is_a_sink` above.

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -18,9 +18,16 @@
 ///   - `$(...)` and backticks cannot be statically analyzed — their PRESENCE
 ///     is reported so the context engine can escalate, rather than
 ///     pretending the contents were checked.
+///   - Redirect targets are extracted in the SAME walk (v0.15 #14 found `>`
+///     lexed and thrown away — `cat /dev/null > .env` wiped a credentials
+///     file invisibly; v0.16 §1.5 folded the separate scan back in after two
+///     walks over one grammar produced three bugs and then measurably
+///     disagreed, decision #37). Each `Segment` carries the `Overwrite`s
+///     found in it; there is no second scanner to feed different input.
 pub fn split_segments(s: &str) -> Vec<Segment> {
     let mut segments = Vec::new();
     let mut cur = String::new();
+    let mut cur_redirects = Vec::new();
     let chars: Vec<char> = s.chars().collect();
     let mut i = 0;
     let (mut in_single, mut in_double) = (false, false);
@@ -36,14 +43,22 @@ pub fn split_segments(s: &str) -> Vec<Segment> {
                 in_double = !in_double;
                 cur.push(c);
             }
-            '\\' if in_double && i + 1 < chars.len() => {
+            // An escape outside single quotes makes the next character
+            // LITERAL: no quote toggle, no separator, no redirect. Until
+            // v0.16 this arm only fired inside double quotes; outside them,
+            // `\"` toggled quote state and everything after it — including
+            // a `;` and whatever command followed — rode inside one segment
+            // a permissive rule could match whole. A shell runs that second
+            // command. The over-splits go with it: `echo a \; b` is ONE
+            // command to a shell, and now one segment here.
+            '\\' if !in_single && i + 1 < chars.len() => {
                 cur.push(c);
                 cur.push(chars[i + 1]);
                 i += 1;
             }
             _ if in_single || in_double => cur.push(c),
             '&' if i + 1 < chars.len() && chars[i + 1] == '&' => {
-                flush(&mut segments, &mut cur);
+                flush(&mut segments, &mut cur, &mut cur_redirects);
                 i += 1; // consume second &
             }
             // A lone `&` IS a separator — it backgrounds the segment to its
@@ -53,27 +68,100 @@ pub fn split_segments(s: &str) -> Vec<Segment> {
             // `git status*` allow rule. The redirection forms it also appears
             // in are `2>&1` / `>&2` / `<&-` (preceded by `>` or `<`) and
             // `&>file` / `&>>file` (followed by `>`); those are not separators.
-            '&' if !is_redirection_amp(&chars, i) => flush(&mut segments, &mut cur),
-            // `>|` forces clobber past `set -o noclobber` — one operator, not
-            // a redirect followed by a pipe. Splitting here cut the target off
-            // into its own segment, so intent and policy (which split first)
-            // never saw the truncation the redirect scan reports; only backup,
-            // which then re-scanned the raw string, insured it. Found by
-            // unifying the scanners (v0.16 §1.5): the moment the redirect scan
-            // ran on split output, the disagreement became a failing test.
-            '|' if i > 0 && chars[i - 1] == '>' => cur.push(c),
+            '&' if !is_redirection_amp(&chars, i) => {
+                flush(&mut segments, &mut cur, &mut cur_redirects)
+            }
+            // A redirect: consume the operator and its target in THIS walk,
+            // recording the Overwrite the segment will carry. Deliberately
+            // NOT treated as redirects, because they do not create or
+            // truncate a file: `2>&1`, `>&2` (descriptor duplication), `&>`
+            // and `&>>` (stream combination), `<>` (read-write open),
+            // `>(...)` (process substitution — an operator, not a filename),
+            // `\>` (a literal, consumed by the escape arm above), anything
+            // inside quotes, and sinks (`/dev/null` and friends — truncating
+            // one destroys nothing). `>|` (clobber past noclobber) IS a
+            // truncation of the named file, and one operator: splitting at
+            // its `|` cut the target into its own segment, hiding the
+            // truncation from every engine that splits first.
+            '>' => {
+                let prev_is_amp = i > 0 && chars[i - 1] == '&';
+                let prev_is_lt = i > 0 && chars[i - 1] == '<';
+                cur.push(c);
+                let mut j = i + 1;
+                let truncates = if chars.get(j) == Some(&'>') {
+                    cur.push('>');
+                    j += 1;
+                    false
+                } else {
+                    true
+                };
+                if truncates && chars.get(j) == Some(&'|') {
+                    cur.push('|');
+                    j += 1;
+                }
+                if chars.get(j) == Some(&'&') {
+                    // descriptor duplication — keep the `&` as text and let
+                    // the walk continue after it, as `is_redirection_amp`
+                    // always classified it
+                    cur.push('&');
+                    i = j + 1;
+                    continue;
+                }
+                while j < chars.len() && chars[j].is_whitespace() {
+                    cur.push(chars[j]);
+                    j += 1;
+                }
+                if chars.get(j) == Some(&'(') {
+                    // process substitution: `tee >(gzip)` hands tee a pipe,
+                    // not a file — hand the paren back to the walk
+                    i = j;
+                    continue;
+                }
+                // The target: everything until unquoted whitespace or an
+                // unquoted separator, escapes honored as everywhere else in
+                // the walk. Backslashes are RETAINED in the target string,
+                // as they always were for non-boundary characters.
+                let mut target = String::new();
+                let mut quote: Option<char> = None;
+                while j < chars.len() {
+                    let d = chars[j];
+                    match quote {
+                        Some(q) if d == q => quote = None,
+                        Some(_) => {}
+                        None if d == '\'' || d == '"' => quote = Some(d),
+                        None if d == '\\' && j + 1 < chars.len() => {
+                            cur.push(d);
+                            target.push(d);
+                            j += 1;
+                        }
+                        None if d.is_whitespace() => break,
+                        None if matches!(d, ';' | '\n' | '|') => break,
+                        None if d == '&' && !is_redirection_amp(&chars, j) => break,
+                        None => {}
+                    }
+                    cur.push(chars[j]);
+                    target.push(chars[j]);
+                    j += 1;
+                }
+                let target: String = target.trim_matches(|c| c == '\'' || c == '"').to_string();
+                if !target.is_empty() && !prev_is_amp && !prev_is_lt && !is_sink(&target) {
+                    cur_redirects.push(Overwrite { target, truncates });
+                }
+                i = j;
+                continue;
+            }
             '|' => {
-                flush(&mut segments, &mut cur);
+                flush(&mut segments, &mut cur, &mut cur_redirects);
                 if i + 1 < chars.len() && chars[i + 1] == '|' {
                     i += 1; // `||` — consume second |
                 }
             }
-            ';' | '\n' => flush(&mut segments, &mut cur),
+            ';' | '\n' => flush(&mut segments, &mut cur, &mut cur_redirects),
             _ => cur.push(c),
         }
         i += 1;
     }
-    flush(&mut segments, &mut cur);
+    flush(&mut segments, &mut cur, &mut cur_redirects);
     segments
 }
 
@@ -145,106 +233,6 @@ fn is_sink(target: &str) -> bool {
     )
 }
 
-/// Extract the redirect targets from ONE segment.
-///
-/// v0.15. `>` and `>>` were lexed by `split_segments` and then thrown away, so
-/// a command that destroys a file by writing over it was invisible to every
-/// engine: no intent, no preview, no backup. `cat /dev/null > .env` matched the
-/// read-only `cat *` allow rule and wiped a credentials file.
-///
-/// HONESTY NOTE: this is still a second character walk over the same grammar
-/// `split_segments` reads. What changed in v0.16 §1.5 is that it is no longer
-/// a second PUBLIC scanner: only `flush` calls it, on segments the splitter
-/// just produced, so no caller can feed the two walks different inputs. The
-/// walks themselves still disagree on escape handling outside quotes
-/// (`\"` toggles a quote here but not there) — folding them into one walk is
-/// the next commit, and it must pick one escape semantics to do it. Do not
-/// let this comment outlive the second walk.
-///
-/// Deliberately NOT treated as redirects, because they do not create or
-/// truncate a file: `2>&1`, `>&2`, `<&-` (descriptor duplication), `&>` and
-/// `&>>` (stream combination), `<>` (read-write open), `>(...)` (process
-/// substitution — an operator, not a filename), `\>` outside quotes (a
-/// literal character), anything inside quotes, and sinks (`/dev/null` and
-/// friends — truncating one destroys nothing). `>|` (clobber past
-/// noclobber) IS a truncation of the named file.
-fn scan_redirects(segment: &str) -> Vec<Overwrite> {
-    let chars: Vec<char> = segment.chars().collect();
-    let mut out = Vec::new();
-    let (mut in_single, mut in_double) = (false, false);
-    let mut i = 0;
-
-    while i < chars.len() {
-        let c = chars[i];
-        match c {
-            '\'' if !in_double => in_single = !in_single,
-            '"' if !in_single => in_double = !in_double,
-            // Escape inside double quotes (as split_segments) and bare:
-            // `echo a \> b` writes a literal `>`, it redirects nothing.
-            '\\' if !in_single && i + 1 < chars.len() => i += 1,
-            _ if in_single || in_double => {}
-            '>' => {
-                // `&>` / `&>>` combine streams; `2>&1` / `>&2` point one
-                // descriptor at another; `<>` opens read-write. None truncate.
-                let prev_is_amp = i > 0 && chars[i - 1] == '&';
-                let prev_is_lt = i > 0 && chars[i - 1] == '<';
-                let mut j = i + 1;
-                let truncates = if chars.get(j) == Some(&'>') {
-                    j += 1;
-                    false
-                } else {
-                    true
-                };
-                // `>|` forces clobber past `set -o noclobber` — still a
-                // truncation of the file that follows.
-                if truncates && chars.get(j) == Some(&'|') {
-                    j += 1;
-                }
-                if chars.get(j) == Some(&'&') {
-                    i = j + 1;
-                    continue;
-                }
-                while j < chars.len() && chars[j].is_whitespace() {
-                    j += 1;
-                }
-                // `>(...)` is process substitution: `tee >(gzip)` hands tee a
-                // pipe, not a file. The draft extracted "(gzip" as a
-                // truncating target here.
-                if chars.get(j) == Some(&'(') {
-                    i = j;
-                    continue;
-                }
-                let start = j;
-                let mut quote: Option<char> = None;
-                while j < chars.len() {
-                    let d = chars[j];
-                    match quote {
-                        Some(q) if d == q => quote = None,
-                        Some(_) => {}
-                        None if d == '\'' || d == '"' => quote = Some(d),
-                        None if d.is_whitespace() => break,
-                        None => {}
-                    }
-                    j += 1;
-                }
-                let target: String = chars[start..j]
-                    .iter()
-                    .collect::<String>()
-                    .trim_matches(|c| c == '\'' || c == '"')
-                    .to_string();
-                if !target.is_empty() && !prev_is_amp && !prev_is_lt && !is_sink(&target) {
-                    out.push(Overwrite { target, truncates });
-                }
-                i = j;
-                continue;
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-    out
-}
-
 /// Is the `&` at `i` part of a redirection rather than a command separator?
 /// `2>&1`, `1>&2`, `<&-` have `>` or `<` immediately before; `&>log` and
 /// `&>>log` have `>` immediately after.
@@ -254,13 +242,18 @@ fn is_redirection_amp(chars: &[char], i: usize) -> bool {
     prev_is_redirect || next_is_redirect
 }
 
-fn flush(segments: &mut Vec<Segment>, cur: &mut String) {
+fn flush(segments: &mut Vec<Segment>, cur: &mut String, redirects: &mut Vec<Overwrite>) {
     let t = cur.trim();
     if !t.is_empty() {
         segments.push(Segment {
             text: t.to_string(),
-            redirects: scan_redirects(t),
+            redirects: std::mem::take(redirects),
         });
+    } else {
+        // Nothing but whitespace between separators: whatever the redirect
+        // scan collected has no segment to ride on. Unreachable in practice
+        // (a redirect implies non-whitespace text), cleared for safety.
+        redirects.clear();
     }
     cur.clear();
 }
@@ -396,6 +389,74 @@ mod tests {
         assert!(redirects("cmd <> rw.txt").is_empty());
     }
 
+    /// v0.16 §1.5, behavior CHANGE, pinned deliberately: an escape outside
+    /// single quotes makes the next character literal, as a shell reads it.
+    /// Before unification `\"` toggled quote state, so the `;` and the
+    /// command after it rode inside one segment — `echo \" ; rm -rf x`
+    /// matched an `echo *` allow rule whole while the shell ran `rm -rf x`
+    /// as its own command. The v0.6.1 class, reopened through an escape.
+    #[test]
+    fn an_escaped_quote_does_not_open_a_quote() {
+        assert_eq!(
+            split_segments(r#"echo \" ; rm -rf x"#),
+            vec![r#"echo \""#, "rm -rf x"]
+        );
+        // Control leg — inside double quotes the escape behaves exactly as
+        // before: the quoted `;` stays text and the segment stays whole.
+        assert_eq!(
+            split_segments(r#"echo "keep \" this; here""#),
+            vec![r#"echo "keep \" this; here""#]
+        );
+    }
+
+    /// v0.16 §1.5, behavior CHANGE, pinned deliberately: an escaped
+    /// separator is literal, so the line is ONE command — which is what the
+    /// shell executes. The old walk split at `\;` and `\&`, judging
+    /// segments the shell never runs; an over-split that could fire a rule
+    /// on a command that does not exist (#48 territory).
+    #[test]
+    fn escaped_separators_are_literal() {
+        assert_eq!(split_segments(r"echo a \; b"), vec![r"echo a \; b"]);
+        assert_eq!(split_segments(r"echo a\;b"), vec![r"echo a\;b"]);
+        assert_eq!(
+            split_segments(r"git commit -m msg \&\& rm x"),
+            vec![r"git commit -m msg \&\& rm x"]
+        );
+        // Control legs — unescaped separators split exactly as before.
+        assert_eq!(split_segments("echo a ; b"), vec!["echo a", "b"]);
+        assert_eq!(split_segments("echo a && rm x"), vec!["echo a", "rm x"]);
+        // And a redirect on the merged line still surfaces: one segment,
+        // its overwrite attached.
+        let segs = split_segments(r"echo a \; b > out");
+        assert_eq!(segs.len(), 1);
+        assert_eq!(segs[0].redirects.len(), 1);
+        assert_eq!(segs[0].redirects[0].target, "out");
+    }
+
+    /// v0.16 §1.5, behavior CHANGE, pinned deliberately: an escaped space in
+    /// a redirect target keeps the filename whole. The old target scan broke
+    /// at the space, insuring a file named `a\` instead of the one the shell
+    /// writes over. Backslashes are retained in the target string, as they
+    /// always were for non-boundary characters.
+    #[test]
+    fn an_escaped_space_keeps_a_target_whole() {
+        let r = redirects(r"cmd > a\ b.txt");
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].target, r"a\ b.txt");
+    }
+
+    /// A separator immediately after a target ends the target AND still
+    /// splits: the walk finds the redirect and the next command both.
+    #[test]
+    fn a_separator_ends_a_target_and_still_splits() {
+        let segs = split_segments("cmd > log;next");
+        assert_eq!(segs, vec!["cmd > log", "next"]);
+        assert_eq!(segs[0].redirects[0].target, "log");
+        let segs = split_segments("cmd > a&b");
+        assert_eq!(segs, vec!["cmd > a", "b"]);
+        assert_eq!(segs[0].redirects[0].target, "a");
+    }
+
     /// The empty-target guard, exercised: a trailing redirect names nothing
     /// and must push nothing. The last of the five predicted survivors; the
     /// other four died to `every_sink_spelling_is_a_sink` above.
@@ -412,8 +473,8 @@ mod tests {
         // input distinguishes the spellings, so this pins the behavior
         // they share: a bare trailing escape ends the scan with nothing
         // pushed. (The fingerprint is from the pass over the then-public
-        // `redirect_targets`; the scan is now `scan_redirects`, reached
-        // through the split, and the pinned behavior is the same.)
+        // `redirect_targets`; the scan now lives inside `split_segments`
+        // itself, and the pinned behavior is the same.)
         assert!(redirects("echo x \\").is_empty());
     }
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>v0.16 item 2: one scanner for one grammar</h1>
<p>Closes the two-parser duplication in <code>shell.rs</code>. Segments and their redirect
targets now come from a single walk; <code>shell::redirect_targets</code> is deleted.</p>
<p>Five commits, applied in order. Two of them change policy-visible behavior and
say so in their own messages.</p>
<h2>Why this is more than a refactor</h2>
<p><code>split_segments</code> and <code>redirect_targets</code> walked the same grammar independently.
Decision #37 says two engines parsing one input are already disagreeing - and
once the outputs were compared, they were:</p>
<p><strong><code>&gt;|</code> was split at its <code>|</code>.</strong> The clobber was invisible to intent and policy,
which split first, while <code>backup</code> - re-scanning the raw command string -
insured it. Measured on <code>e88c211</code> before changing anything:
<code>classify_command("cmd &gt;| forced.txt")</code> returned <code>None</code>. The old test passed
only because it fed <code>redirect_targets</code> an unsplit string the real pipeline
never hands it.</p>
<p><strong><code>\"</code> outside quotes toggled quote state in one walk and not the other.</strong>
This is a policy bypass, present since v0.7.0. <code>echo \" ; terraform destroy -auto-approve</code> stayed <strong>one segment</strong>, so a prefix-anchored deny rule
(<code>terraform destroy*</code>) never saw a segment starting with <code>terraform</code>, and the
line matched <code>echo *</code> instead:</p>

  | pre-fix (e88c211) | this branch
-- | -- | --
terraform destroy -auto-approve | deny | deny
echo \" ; terraform destroy -auto-approve | allow (echo *) | deny (segment 2/2)


<p>Baselines on <code>e88c211</code> were 383 / 335; +5 are new unit tests in <code>shell.rs</code>,
which run on both platforms. <code>cargo fmt --check</code> clean and <code>cargo clippy --all-targets</code> silent on both.</p>
<p>Quote 388/340, never one figure: the four <code>#![cfg(unix)]</code> integration files
still run <strong>zero tests on Windows</strong> (roadmap 1.6, open).</p>
<h2>Not closed by this</h2>
<ul>
<li><strong>#12</strong> - <code>cp</code>/<code>mv</code>/<code>tee</code>/<code>dd</code> destinations, still open.</li>
<li><strong>Roadmap 2.4, resolve-then-evaluate</strong> - <code>&gt; ./.env</code> remains a pinned known gap.</li>
<li>The redirect walk is unified, but <code>has_substitution</code> keeps its own minimal
scan on purpose: it detects the <em>presence</em> of <code>$(</code> and backticks, it does not
parse the grammar.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>