### PR TITLE
v0.16: one answer to "what command is this?"

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -344,11 +344,14 @@ fn overwrite_paths(redirects: &[crate::shell::Overwrite], cwd: &Path) -> Option<
 }
 
 fn rm_targets(tokens: &[String], cwd: &Path) -> Option<Vec<PathBuf>> {
-    let head = crate::delete::command_head(tokens.first()?);
+    // Same head resolution the classifier and the preview use. When these
+    // disagreed, a command could be CLASSIFIED destructive and take no
+    // insurance - gated without a net, which is worse than missing both.
+    let (head, at) = crate::delete::resolve_head(tokens)?;
     if !crate::delete::is_delete_command(&head) {
         return None;
     }
-    let paths: Vec<PathBuf> = tokens[1..]
+    let paths: Vec<PathBuf> = tokens[at + 1..]
         .iter()
         .filter(|t| !crate::delete::is_flag(&head, t))
         .map(|t| crate::delete::resolve_path_in(t, cwd))

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -190,12 +190,17 @@ pub fn extract_targets(command: &str) -> Vec<String> {
         if tokens.is_empty() {
             continue;
         }
-        let head = command_head(&tokens[0]);
+        let Some((head, at)) = resolve_head(&tokens) else {
+            continue;
+        };
         if !is_delete_command(&head) {
             continue;
         }
 
-        for t in tokens.iter().skip(1) {
+        // Targets start after the command, not after token zero: with a
+        // wrapper present those are different positions, and reading from
+        // token zero would take the wrapper's own arguments as targets.
+        for t in tokens.iter().skip(at + 1) {
             if is_flag(&head, t) {
                 continue;
             }
@@ -261,6 +266,95 @@ pub fn command_head(token: &str) -> String {
         .unwrap_or(&lower)
         .trim_end_matches(".exe")
         .to_string()
+}
+
+/// Wrapper programs that run another command, with the real command's name
+/// somewhere after their own arguments. Until v0.16 every consumer read
+/// token zero as the command, so `sudo rm -rf x` classified as nothing at
+/// all: the classifier saw `sudo`, the delete extractor saw `sudo`, and
+/// `backup` took no insurance. The gap was not specific to deletes — measured
+/// on the previous commit, `sudo terraform destroy -auto-approve` also
+/// classified as `None`. A wrapper blanked the whole engine.
+///
+/// HAND-WALKED LIST (decision #56: a membership list that sizes a decision
+/// gets walked by a person and says so). Each entry runs an arbitrary command
+/// and is common in agent output. Being on this list is NOT a claim that the
+/// wrapper is dangerous — `sudo` precedes plenty of harmless work. It says
+/// only "the real command name is further along."
+///
+/// Deliberately NOT here: `xargs` and `find -exec`, which take a command but
+/// are already handled where their own semantics matter; shell builtins
+/// (`exec`, `eval`), which do not appear as token zero of a segment the
+/// splitter produced; and `time` / `strace` / `watch`, which are diagnostic
+/// wrappers no agent has been observed reaching for in this codebase's field
+/// reports. Add them when something observes one, not before.
+const COMMAND_WRAPPERS: [&str; 6] = ["sudo", "doas", "env", "command", "nohup", "nice"];
+
+/// Flags on a wrapper that consume the FOLLOWING token as their value. Without
+/// this, `sudo -u alice rm -rf x` reads `alice` as the command name and the
+/// delete is invisible again — the same miss in a different spelling.
+fn wrapper_flag_takes_value(wrapper: &str, flag: &str) -> bool {
+    match wrapper {
+        "sudo" | "doas" => matches!(
+            flag,
+            "-u" | "-g" | "-p" | "-C" | "-D" | "-h" | "-R" | "-T" | "--user" | "--group"
+        ),
+        "env" => matches!(flag, "-u" | "--unset" | "-S" | "--split-string"),
+        "nice" => matches!(flag, "-n" | "--adjustment"),
+        _ => false,
+    }
+}
+
+/// The real command's normalized head, and the index of the token it came
+/// from. `None` when the segment is only wrappers and their arguments, which
+/// names no command to judge.
+///
+/// One answer to "what command is this?", shared by the classifier, the
+/// delete extractor and the insurance layer. They used to compute it three
+/// ways and disagreed (decision #37): `delete.rs` normalized paths through
+/// `command_head` while `intent.rs` compared token zero raw, so
+/// `C:\Windows\System32\del.exe /s /q x` was a recognised delete to one and
+/// nothing to the other — on the platform where every dialect bug has
+/// actually happened.
+pub fn resolve_head(tokens: &[String]) -> Option<(String, usize)> {
+    let mut i = 0;
+    loop {
+        let head = command_head(tokens.get(i)?);
+        if !COMMAND_WRAPPERS.contains(&head.as_str()) {
+            return Some((head, i));
+        }
+        let wrapper = head;
+        i += 1;
+        // Skip the wrapper's own arguments: flags (and their values, where the
+        // flag takes one) and `KEY=VALUE` environment assignments, which `env`
+        // and `sudo` both accept before the command name.
+        while let Some(tok) = tokens.get(i) {
+            if tok.starts_with('-') {
+                if wrapper_flag_takes_value(&wrapper, tok) {
+                    i += 1;
+                }
+                i += 1;
+            } else if is_env_assignment(tok) {
+                i += 1;
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+/// `FOO=bar` before a command name is an environment assignment, not the
+/// command. Guarded against paths that merely contain `=`: the name half must
+/// be a plain identifier.
+fn is_env_assignment(token: &str) -> bool {
+    match token.split_once('=') {
+        Some((name, _)) => {
+            !name.is_empty()
+                && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                && !name.chars().next().is_some_and(|c| c.is_ascii_digit())
+        }
+        None => false,
+    }
 }
 
 /// Does this command head delete things?

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -219,9 +219,19 @@ fn classify_segment_named(segment: &str) -> Option<Intent> {
                 t == "--force" || t == "-f" || t == "--force-with-lease" || t.starts_with('+')
             }),
             "reset" => lc.iter().any(|t| t == "--hard"),
-            "clean" => lc
-                .iter()
-                .any(|t| t.starts_with('-') && !t.starts_with("--") && t.contains('f')),
+            // `git clean` deletes untracked files, and git refuses to do it
+            // without a force flag - so the force flag IS the destructive
+            // signal. Both spellings count. The clustered short form needs
+            // the `!starts_with("--")` guard (a long flag merely CONTAINING
+            // an f, like `--dry-run`, is not `-f`), and that guard was
+            // excluding the legitimate long spelling along with it:
+            // `git clean --force` classified as nothing until v0.16, while
+            // `git clean -f` was caught. One flag, two spellings, one
+            // meaning - the same lesson as decision #47, read the flag, not
+            // the shape of the string.
+            "clean" => lc.iter().any(|t| {
+                t == "--force" || (t.starts_with('-') && !t.starts_with("--") && t.contains('f'))
+            }),
             // -D is case-sensitive: -d only deletes merged branches.
             "branch" => toks.iter().any(|t| t == "-D"),
             _ => false,
@@ -477,6 +487,31 @@ mod tests {
                 Some(Intent::FileOverwrite),
                 "{cmd} destroys a file by writing over it"
             );
+        }
+    }
+
+    /// `git clean` deletes untracked files and git refuses without a force
+    /// flag, so the flag is the signal. `--force` was missed while `-f` was
+    /// caught: the guard that stops a long flag merely containing an `f`
+    /// (`--dry-run`) from counting was excluding the real long spelling too.
+    #[test]
+    fn git_clean_counts_both_spellings_of_force() {
+        for cmd in ["git clean -f", "git clean --force", "git clean -fdx"] {
+            assert_eq!(
+                classify_command(cmd),
+                Some(Intent::GitDestructive),
+                "{cmd}: force is force in either spelling"
+            );
+        }
+        // Control legs - git deletes nothing without force, so these are not
+        // destructive, and a long flag containing an `f` must not count.
+        for cmd in [
+            "git clean -n",
+            "git clean --dry-run",
+            "git clean -d",
+            "git clean --interactive",
+        ] {
+            assert_eq!(classify_command(cmd), None, "{cmd} deletes nothing");
         }
     }
 
@@ -1137,15 +1172,14 @@ mod tests {
         }
     }
 
-    /// KNOWN GAP, pinned so a fix flips it deliberately rather than by
-    /// accident: `git clean -f` is classified and `git clean --force` is not.
-    /// The two spellings delete the same untracked files. The rm predicate a
-    /// few lines above handles its own long form by listing `--force`
-    /// explicitly; this one only reads bundled short flags, so the long
-    /// spelling presses nothing toward the breaker and shows no intent in the
-    /// report.
+    /// GAP CLOSED, v0.16 - this test is the INVERSION its own message asked
+    /// for, not a deletion. It read: "`git clean -f` is classified and
+    /// `git clean --force` is not... if this ever starts classifying, the
+    /// gap was fixed and this test should be inverted rather than deleted."
+    /// It now asserts the fixed behaviour on the same inputs, so the record
+    /// of what was broken survives in the place that proves it is not.
     #[test]
-    fn git_clean_recognises_only_the_short_force_flag() {
+    fn git_clean_was_a_known_gap_and_is_now_closed() {
         assert_eq!(
             classify_command("git clean -f"),
             Some(Intent::GitDestructive)
@@ -1156,9 +1190,8 @@ mod tests {
         );
         assert_eq!(
             classify_command("git clean --force"),
-            None,
-            "if this ever starts classifying, the gap was fixed and this test \
-             should be inverted rather than deleted"
+            Some(Intent::GitDestructive),
+            "the pinned gap: both spellings delete the same untracked files"
         );
         // A dry run destroys nothing either way.
         assert_eq!(classify_command("git clean -n"), None);

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -137,8 +137,14 @@ fn classify_segment_named(segment: &str) -> Option<Intent> {
     if toks.is_empty() {
         return None;
     }
-    let lc: Vec<String> = toks.iter().map(|t| t.to_ascii_lowercase()).collect();
-    let first = lc[0].as_str();
+    // The command's real head, past any wrapper, normalized the same way the
+    // delete extractor and the insurance layer normalize it. Reading token
+    // zero raw is what made `sudo rm -rf x`, `/bin/rm -rf x` and
+    // `C:\Windows\System32\del.exe /s /q x` all classify as nothing.
+    let (head, at) = crate::delete::resolve_head(&toks)?;
+    let first = head.as_str();
+    // Arguments begin after the command, which is `at`, not 0.
+    let lc: Vec<String> = toks[at..].iter().map(|t| t.to_ascii_lowercase()).collect();
 
     // --- file deletes: unix rm, PowerShell Remove-Item + aliases, cmd del ---
     // PowerShell aliases: rm, ri, del, erase, rd all map to Remove-Item.
@@ -472,6 +478,64 @@ mod tests {
                 "{cmd} destroys a file by writing over it"
             );
         }
+    }
+
+    /// v0.16: a wrapper program hid the real command from every engine.
+    /// Measured before the fix - each of these classified as `None`, so no
+    /// intent, no breaker pressure, and (via the same head resolution) no
+    /// insurance. The wrapper is not the danger; reading token zero as the
+    /// command was.
+    #[test]
+    fn a_wrapper_does_not_hide_the_command_it_runs() {
+        for cmd in [
+            "sudo rm -rf ./dist",
+            "doas rm -rf /",
+            "env rm -rf ./dist",
+            "env FOO=1 rm -rf ./dist",
+            "sudo -u alice rm -rf ./dist",
+            "nice -n 10 rm -rf x",
+            "nohup rm -rf x",
+            "command rm -rf x",
+        ] {
+            assert_eq!(
+                classify_command(cmd),
+                Some(Intent::FileDelete),
+                "{cmd}: the wrapper must not hide the delete"
+            );
+        }
+        // Not only deletes: a wrapper blanked the WHOLE classifier.
+        assert_eq!(
+            classify_command("sudo terraform destroy -auto-approve"),
+            Some(Intent::InfraDestroy),
+        );
+
+        // Control legs. A wrapper with no command after it names nothing to
+        // judge, and the word only counts in command position - otherwise
+        // `echo sudo rm` would classify as a delete.
+        for cmd in ["sudo", "sudo -u alice", "env FOO=1", "echo sudo rm -rf x"] {
+            assert_eq!(classify_command(cmd), None, "{cmd} must not classify");
+        }
+    }
+
+    /// The head is normalized by path and extension, as `delete.rs` always
+    /// normalized it. These two modules disagreed: the Windows full-path form
+    /// was a recognised delete to the extractor and nothing to the
+    /// classifier, on the platform where every dialect bug has happened.
+    #[test]
+    fn a_path_qualified_command_is_the_command_it_names() {
+        for cmd in [
+            "/bin/rm -rf ./dist",
+            "/usr/bin/rm -rf ./dist",
+            "C:\\Windows\\System32\\del.exe /s /q x",
+        ] {
+            assert_eq!(
+                classify_command(cmd),
+                Some(Intent::FileDelete),
+                "{cmd}: a path-qualified delete is still a delete"
+            );
+        }
+        // Control leg - a path-qualified harmless command stays harmless.
+        assert_eq!(classify_command("/bin/ls -la"), None);
     }
 
     /// Appending does not destroy, descriptor plumbing names no file, and a


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>v0.16: one answer to "what command is this?"</h1>
<p>Two commits. The first unifies command-head resolution across three modules
that computed it three ways; the second fixes a flag-matching miss that looks
related but is a different mechanism.</p>
<h2>The gap, measured before changing anything</h2>
<p>Every one of these classified as <code>None</code> on <code>3f5d767</code> - meaning no intent, no
breaker pressure, and (through the same head resolution) no insurance:</p>

command | before | after
-- | -- | --
/bin/rm -rf ./dist | None | FileDelete
/usr/bin/rm -rf ./dist | None | FileDelete
sudo rm -rf ./dist | None | FileDelete
sudo -u alice rm -rf ./dist | None | FileDelete
env rm -rf ./dist | None | FileDelete
env FOO=1 rm -rf ./dist | None | FileDelete
doas rm -rf / | None | FileDelete
C:\Windows\System32\del.exe /s /q x | None | FileDelete
sudo terraform destroy -auto-approve | None | InfraDestroy
git clean --force | None | GitDestructive


<p><code>cargo fmt --check</code> clean and <code>cargo clippy --all-targets</code> silent on both.
Quote 391/343, never one figure: the four <code>#![cfg(unix)]</code> integration files
still run zero tests on Windows (roadmap 1.6, open).</p>
<h2>Follow-up, not in this PR</h2>
<p><code>known-limitations.md</code> documents the <code>git clean --force</code> gap as open in 0.6,
and mentions it again in the breaker section. Both need updating once this
merges.</p>
<p>This is a piece of roadmap 2.4, not all of it. Resolve-then-evaluate proper -
resolving targets and deciding on the resolved value - still needs two schema
decisions settled first: whether <code>match_path:</code> fires on any matching target,
and what counts as a "sensitive shape" for an unresolvable one.</p></body></html><!--EndFragment-->
</body>
</html>