### PR TITLE
v0.16 (roadmap 2.7): hygiene, with the reasoning kept

### DIFF
--- a/.chaos-mcp/suppressions.json
+++ b/.chaos-mcp/suppressions.json
@@ -95,22 +95,6 @@
         "fingerprint": "26f79d8eac41"
       }
     ],
-    "src/hook.rs": [
-      {
-        "line": 521,
-        "mutator": "replace && with || in run",
-        "addedAt": 1786731671137,
-        "reason": "unreachable: this is a duplicate of the `if input.is_post` block above it, which returns Ok(()) for every post input, so nothing here executes. Not equivalent \u2014 dead. The block should be deleted; the suppression goes away with it",
-        "fingerprint": "c7754d516339"
-      },
-      {
-        "line": 521,
-        "mutator": "delete ! in run",
-        "addedAt": 1786731671137,
-        "reason": "unreachable: this is a duplicate of the `if input.is_post` block above it, which returns Ok(()) for every post input, so nothing here executes. Not equivalent \u2014 dead. The block should be deleted; the suppression goes away with it",
-        "fingerprint": "c7754d516339"
-      }
-    ],
     "src/delete.rs": [
       {
         "line": 224,

--- a/examples/policy.yaml
+++ b/examples/policy.yaml
@@ -157,9 +157,6 @@ rules:
   - match: "*Remove-Item*-Force*"
     action: deny
     reason: "Forced delete (PowerShell) blocked by default policy."
-  - match: "*Get-ChildItem*Remove-Item*"
-    action: deny
-    reason: "Bulk delete pipeline (PowerShell) blocked by default policy."
   - match: "*del /s*"
     action: deny
     reason: "Recursive delete (cmd) blocked by default policy."

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -427,7 +427,7 @@ fn hook_live(settings: &Path, dir: &Path) -> (HookState, Option<bool>) {
         "hook_event_name": "PreToolUse",
         "tool_name": "Bash",
         "cwd": dir.display().to_string(),
-        "session_id": "termaxa-doctor-probe",
+        "session_id": crate::hook::PROBE_SESSION,
         "tool_input": { "command": "rm -rf /" }
     })
     .to_string();

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -5,6 +5,22 @@ use anyhow::Result;
 use serde_json::json;
 use std::io::Read;
 
+/// The session id `doctor`'s liveness probe sends, and the value the hook
+/// checks to recognise a probe and stay inert. One meaning, one spelling
+/// (decision #21): it was written out independently in `doctor.rs` and here,
+/// and a sentinel that only works when two string literals agree is a silent
+/// failure waiting to happen - a typo in either would make the probe write a
+/// real audit line, or make a real session go inert.
+///
+/// HONEST RESIDUE: four integration-test literals remain - three in
+/// `tests/hook_dialects.rs` and one in `tests/probe_inertness.rs`. `termaxa`
+/// is a binary crate with no lib target, so integration tests cannot import
+/// this const at all. Those literals are the reason a rename here would need
+/// `grep termaxa-doctor-probe` rather than the compiler. Unifying them needs
+/// a lib target, which is a larger change than this sweep and is the honest
+/// remaining half of decision #21 here.
+pub const PROBE_SESSION: &str = "termaxa-doctor-probe";
+
 /// Which agent is calling us. Detected from the input's shape, so
 /// `termaxa hook` is ONE command that speaks every agent's dialect.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -513,43 +529,6 @@ pub fn run() -> Result<()> {
         return Ok(());
     }
 
-    // Post-execution event: the command already ran. Record a receipt
-    // (source "post") so the circuit breaker can exclude human-approved
-    // commands from the retry threshold (decision #13). No policy eval, no
-    // gating, no output — just append and exit.
-    if input.is_post {
-        let start_dir = if !input.cwd.is_empty() && std::path::Path::new(&input.cwd).is_dir() {
-            std::path::PathBuf::from(&input.cwd)
-        } else {
-            std::env::current_dir().unwrap_or_default()
-        };
-        if let Ok(paths) = crate::paths::resolve_from(&start_dir) {
-            if let Ok(log) = AuditLog::new(&paths.state_dir) {
-                let (ts_ms, ts) = now();
-                let _ = log.append(&AuditEntry {
-                    ts_ms,
-                    ts,
-                    source: "post".into(),
-                    command: command.clone(),
-                    decision: "executed".into(),
-                    matched_rule: None,
-                    reason: "post-execution receipt".into(),
-                    signals: vec![],
-                    escalated: false,
-                    session: input.session.clone(),
-                    backup: None,
-                    preview: None,
-                    intent: crate::intent::classify_command(&command)
-                        .map(|i| i.label().to_string()),
-                    approved: Some(true),
-                    exit_code: None,
-                    cwd: input.cwd.clone(),
-                });
-            }
-        }
-        return Ok(());
-    }
-
     // Agents spawn the hook with an arbitrary working directory, but they tell us
     // the real project dir in the payload's `cwd`. Resolve the policy explicitly
     // from THAT path rather than mutating the global process cwd (which would make
@@ -662,7 +641,7 @@ pub fn run() -> Result<()> {
     // sentinel. An agent command cannot set its harness's env; a leaked env
     // var without the sentinel changes nothing.
     let is_probe = std::env::var("TERMAXA_HOOK_PROBE").as_deref() == Ok("1")
-        && input.session.as_deref() == Some("termaxa-doctor-probe");
+        && input.session.as_deref() == Some(PROBE_SESSION);
 
     let mut backup_id: Option<String> = None;
     if !is_probe && decision.action != Action::Deny {

--- a/src/init.rs
+++ b/src/init.rs
@@ -163,9 +163,6 @@ rules:
   - match: "*Remove-Item*-Force*"
     action: deny
     reason: "Forced delete (PowerShell) blocked by default policy."
-  - match: "*Get-ChildItem*Remove-Item*"
-    action: deny
-    reason: "Bulk delete pipeline (PowerShell) blocked by default policy."
   - match: "*del /s*"
     action: deny
     reason: "Recursive delete (cmd) blocked by default policy."

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -719,6 +719,40 @@ rules:
         );
     }
 
+    /// A rule that cannot be reached is not a rule. `*Get-ChildItem*Remove-Item*`
+    /// shipped from v0.11 and could never fire: `split_segments` cuts at the
+    /// `|`, so no segment ever contains both names. It was removed in v0.16
+    /// rather than reworked, and this test records what the policy does with
+    /// the pipeline instead, so its removal stays deliberate.
+    ///
+    /// A bare `Remove-Item` with no destructive flag is `ask`, exactly as
+    /// `rm x` and `del x` are: deleting one named path is ordinary work, and a
+    /// gate that denies it gets uninstalled (#48). The flagged spellings are
+    /// still denied by the sibling rules, which DO fire, because each name and
+    /// its flag live in the same segment.
+    #[test]
+    fn the_powershell_pipeline_is_asked_and_its_flagged_forms_denied() {
+        let p = Policy::builtin().unwrap();
+        for cmd in ["Get-ChildItem | Remove-Item", "Remove-Item x"] {
+            assert_eq!(
+                p.evaluate_command(cmd).action,
+                Action::Ask,
+                "{cmd}: an unflagged delete is ordinary work"
+            );
+        }
+        for cmd in [
+            "Get-ChildItem . | Remove-Item -Force",
+            "Get-ChildItem -Path x | Remove-Item -Recurse -Force",
+            "Remove-Item -Recurse x",
+        ] {
+            assert_eq!(
+                p.evaluate_command(cmd).action,
+                Action::Deny,
+                "{cmd}: the flag is in the same segment as the name, so it fires"
+            );
+        }
+    }
+
     #[test]
     fn the_starter_policy_defends_its_own_configuration() {
         let p = Policy::builtin().expect("built-in starter policy must parse");

--- a/tests/probe_inertness.rs
+++ b/tests/probe_inertness.rs
@@ -123,6 +123,10 @@ fn the_probe_answers_and_writes_nothing_and_the_binding_holds() {
     //    no session state.
     let (home, project) = scratch("probe");
     let before = file_count(&home);
+    // Spelled literally because a binary crate exposes nothing to integration
+    // tests: `hook::PROBE_SESSION` is the source of truth and cannot be
+    // imported here. Three more literals live in tests/hook_dialects.rs. A
+    // rename needs `grep termaxa-doctor-probe`, not the compiler.
     let out = run_hook(&home, &project, true, "termaxa-doctor-probe");
     assert!(
         out.contains("permissionDecision") && out.contains("deny"),


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>v0.16: hygiene, with the reasoning kept</h1>
<p>Roadmap 2.7. Three items, each verified rather than assumed. One commit.</p>
<h2>Dead code: 36 lines deleted from hook.rs</h2>
<p>The second <code>if input.is_post</code> block was byte-identical to the first apart from
one word in a comment - diffed programmatically, not eyeballed - and the first
returns for every post input, so the second could never execute. <code>rustc</code> cannot
warn here: the condition is a runtime value. It was found originally because
its mutants could not be killed.</p>
<p>The suite stayed at 391 after the deletion, which is the point. Removing dead
code must move nothing; if a test had changed, the code was not dead.</p>
<p>Retires the two suppressions that named it, both of which read "unreachable:
this is a duplicate of the <code>if input.is_post</code> block above". 16 of 23 remain.</p>
<h2>Shared const: hook::PROBE_SESSION</h2>
<p>The doctor probe's sentinel session id was written out independently in
<code>doctor.rs</code> and <code>hook.rs</code>. One meaning, three strings (#21). A sentinel that
only works when two literals agree is a silent failure waiting to happen: a
typo in either would make the probe write a real audit line, or make a real
session go inert.</p>
<p><strong>The residue is named rather than hidden.</strong> Four integration-test literals
remain - three in <code>tests/hook_dialects.rs</code>, one in <code>tests/probe_inertness.rs</code>.
<code>termaxa</code> is a binary crate with no lib target, so integration tests cannot
import the const at all. A rename still needs <code>grep termaxa-doctor-probe</code>
rather than the compiler, and comments at both ends say so. Unifying those
needs a lib target, which is a larger change than this sweep.</p>
<h2>Unreachable rule removed: <em>Get-ChildItem</em>Remove-Item*</h2>
<p>Shipped in the starter policy since v0.11 and could never fire:
<code>split_segments</code> cuts at the <code>|</code>, so no segment ever contains both names.</p>
<p>Measured before removing it. Every PowerShell pipeline that denies today
denies through a sibling rule, never through this one:</p>

command | decision | matched rule
-- | -- | --
Get-ChildItem . \| Remove-Item -Force | deny | *Remove-Item*-Force*
Get-ChildItem -Path x \| Remove-Item -Recurse -Force | deny | *Remove-Item*-Recurse*
Get-ChildItem \| Remove-Item | ask | none


<p><code>cargo fmt --check</code> clean and <code>cargo clippy --all-targets</code> silent on both.
Quote 392/344, never one figure: the four <code>#![cfg(unix)]</code> integration files
still run zero tests on Windows (roadmap 1.6, open).</p>
<h2>Note for the docs, not in this PR</h2>
<p>While reading <code>tests/probe_inertness.rs</code> for the sentinel work, its INCIDENT
NOTE turned out to describe the stale-Windows-binary problem hit again on
2026-08-16 - dated 2026-08-13, same symptom, same cure. So that is a
recurrence of a recorded incident, not a new finding. The note's guess (a file
lock wedging the artifact copy) was ruled out the second time: <code>target/debug/ deps/</code> held a fresh test harness and no fresh bin, so nothing had been compiled
to copy. Stale fingerprint on the bin target, not a failed uplift.
<code>known-limitations.md</code> is updated separately.</p></body></html><!--EndFragment-->
</body>
</html>