### PR TITLE
v0.16: resolve-then-evaluate

### DIFF
--- a/examples/policy.yaml
+++ b/examples/policy.yaml
@@ -73,10 +73,23 @@ rules:
   # here: agents write files constantly, and a gate that asks on every redirect
   # is auto-approved into meaninglessness. Insurance without friction is the
   # trade — see #14.
+  #
+  # The two string rules below are kept, and a `match_path` rule now sits with
+  # them. They are not redundant: the string rules read the command as typed,
+  # the path rule reads what the command actually TOUCHES after resolution.
+  # `> .env` and `> ./.env` are the same file and different strings - the
+  # second walked past both string rules for four releases (known-limitations
+  # 0.2, pinned as a test until v0.16). Matching the resolved target closes
+  # every spelling of one path at once, which is what the string rules could
+  # never do by adding more patterns.
   - match: "*> .env*"
     action: deny
     reason: "Overwriting .env destroys credentials that are not in the repo."
   - match: "*>.env*"
+    action: deny
+    reason: "Overwriting .env destroys credentials that are not in the repo."
+  - match: "*.env*"
+    match_path: "*/.env"
     action: deny
     reason: "Overwriting .env destroys credentials that are not in the repo."
   - match: "*> /etc/*"

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -523,14 +523,61 @@ pub fn is_inside(target: &Path, root: &Path) -> bool {
 /// Put a path into a form two paths can actually be compared in: canonicalized
 /// when possible, with Windows' `\\?\` verbatim prefix stripped, and
 /// case-folded on platforms with case-insensitive filesystems.
+///
+/// CANONICALIZES THE DEEPEST EXISTING ANCESTOR, not just the path itself.
+/// `canonicalize` fails on a path that does not exist yet, and the old
+/// fallback returned the raw lexical path - so comparing an existing root
+/// against a not-yet-created child put the two sides in DIFFERENT forms
+/// whenever any ancestor was a symlink. `is_inside` then answered false for a
+/// child that is plainly inside its parent.
+///
+/// Found by CI (2026-08-16) on all three runners while two developer machines
+/// passed: GitHub's runners reach the temp directory through a symlink and
+/// `/tmp` here does not. Reproduced locally by pointing a root at a symlink -
+/// child absent, is_inside false; child created, is_inside true. Same path,
+/// two answers, decided by whether the target had been created yet, which is
+/// exactly backwards for a tool that judges commands BEFORE they run.
+///
+/// Real-world reach, not just tests: macOS `/tmp` and `/var` are symlinks,
+/// as are plenty of home directories on shared mounts. Any project reached
+/// through one made every not-yet-created target read as outside the project.
 fn for_compare(p: &Path) -> PathBuf {
-    let c = p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+    let c = canonical_prefix(p);
     let s = c.to_string_lossy().to_string();
     let s = s.strip_prefix(r"\\?\").unwrap_or(&s).to_string();
     if cfg!(windows) {
         PathBuf::from(s.to_lowercase())
     } else {
         PathBuf::from(s)
+    }
+}
+
+/// Canonicalize as much of `p` as exists, then re-append the rest.
+///
+/// Walks up to the deepest ancestor that exists, canonicalizes THAT, and
+/// rejoins the components below it. A path that exists entirely canonicalizes
+/// entirely, as before; one that does not still gets its real prefix, so two
+/// paths under the same root always compare in the same form.
+fn canonical_prefix(p: &Path) -> PathBuf {
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    let mut cur = p.to_path_buf();
+    loop {
+        if let Ok(c) = cur.canonicalize() {
+            let mut out = c;
+            for part in tail.iter().rev() {
+                out.push(part);
+            }
+            return out;
+        }
+        match (cur.file_name(), cur.parent()) {
+            (Some(name), Some(parent)) => {
+                tail.push(name.to_os_string());
+                cur = parent.to_path_buf();
+            }
+            // Nothing along the path exists (or we reached the root without
+            // finding anything): the lexical form is the best answer there is.
+            _ => return p.to_path_buf(),
+        }
     }
 }
 
@@ -924,6 +971,48 @@ mod tests {
         assert!(is_filesystem_root(Path::new("/")));
         assert!(is_filesystem_root(Path::new("C:\\")));
         assert!(!is_filesystem_root(Path::new("/usr")));
+    }
+
+    /// Regression, CI 2026-08-16: a target that does not exist YET is still
+    /// inside its parent, even when the parent is reached through a symlink.
+    ///
+    /// `for_compare` canonicalized the existing root and fell back to the raw
+    /// lexical path for the absent child, putting the two sides in different
+    /// forms and answering false. Two developer machines passed and all three
+    /// CI runners failed, because GitHub's runners reach the temp directory
+    /// through a symlink. The bug is not test-only: macOS `/tmp` and `/var`
+    /// are symlinks, so any project under one had every not-yet-created
+    /// target read as outside the project.
+    ///
+    /// The control leg is the point - the fix must not make `is_inside`
+    /// simply answer true more often.
+    #[cfg(unix)]
+    #[test]
+    fn a_target_that_does_not_exist_yet_is_still_inside_a_symlinked_root() {
+        let t = TempTree::new("symlink-root");
+        let real = t.dir("real");
+        let link = t.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink must be creatable");
+
+        // The failing case: absent child under a symlinked root.
+        assert!(
+            is_inside(&link.join("not-created-yet"), &link),
+            "an absent child is still inside its parent"
+        );
+        assert!(
+            is_inside(&link.join("a/b/c/d"), &link),
+            "however deep, and however much of it exists"
+        );
+        // Present child, which passed even before the fix.
+        let present = t.dir("real/present");
+        assert!(is_inside(&present, &link));
+
+        // CONTROL LEG: genuinely outside is still outside. Without this, a fix
+        // that always answered true would pass every assertion above.
+        assert!(
+            !is_inside(t.path().join("elsewhere").as_path(), &link),
+            "a sibling of the root is not inside it"
+        );
     }
 
     #[test]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -566,7 +566,11 @@ pub fn run() -> Result<()> {
 
     let policy = Policy::load(&paths.policy_file())?;
 
-    let base = policy.evaluate_command(&command);
+    // The payload's cwd is where the command runs; the project root comes
+    // from the located policy. Never the process cwd - a hook runs wherever
+    // the harness spawned it.
+    let ctx = crate::resolve::EvalContext::from_paths(&start_dir, &paths);
+    let base = policy.evaluate_command(&command, &ctx);
     let signals = context::gather(&command);
     let (mut decision, escalated) = context::apply(base, &signals);
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -79,10 +79,23 @@ rules:
   # here: agents write files constantly, and a gate that asks on every redirect
   # is auto-approved into meaninglessness. Insurance without friction is the
   # trade — see #14.
+  #
+  # The two string rules below are kept, and a `match_path` rule now sits with
+  # them. They are not redundant: the string rules read the command as typed,
+  # the path rule reads what the command actually TOUCHES after resolution.
+  # `> .env` and `> ./.env` are the same file and different strings - the
+  # second walked past both string rules for four releases (known-limitations
+  # 0.2, pinned as a test until v0.16). Matching the resolved target closes
+  # every spelling of one path at once, which is what the string rules could
+  # never do by adding more patterns.
   - match: "*> .env*"
     action: deny
     reason: "Overwriting .env destroys credentials that are not in the repo."
   - match: "*>.env*"
+    action: deny
+    reason: "Overwriting .env destroys credentials that are not in the repo."
+  - match: "*.env*"
+    match_path: "*/.env"
     action: deny
     reason: "Overwriting .env destroys credentials that are not in the repo."
   - match: "*> /etc/*"

--- a/src/init.rs
+++ b/src/init.rs
@@ -621,6 +621,10 @@ pub(crate) fn which(bin: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn here() -> crate::resolve::EvalContext {
+        crate::resolve::EvalContext::at(std::path::Path::new("."))
+    }
     use crate::testutil::TempTree;
 
     /// `examples/policy.yaml` is the file people copy. It had drifted to 28
@@ -717,14 +721,15 @@ mod tests {
             "cat .termaxa/policy.yaml > /etc/hosts",
         ] {
             assert_eq!(
-                p.evaluate_command(cmd).action,
+                p.evaluate_command(cmd, &here()).action,
                 crate::policy::Action::Deny,
                 "{cmd} must not be allowed via the .termaxa read exception"
             );
         }
         // The exception itself still works — that is what it is for.
         assert_eq!(
-            p.evaluate_command("cat .termaxa/policy.yaml").action,
+            p.evaluate_command("cat .termaxa/policy.yaml", &here())
+                .action,
             crate::policy::Action::Allow
         );
     }
@@ -740,7 +745,7 @@ mod tests {
             "mkfs.ext4 /dev/sdb1",
         ] {
             assert_eq!(
-                p.evaluate_command(cmd).action,
+                p.evaluate_command(cmd, &here()).action,
                 crate::policy::Action::Deny,
                 "{cmd} has no recovery path and must deny, not ask"
             );
@@ -890,7 +895,7 @@ mod tests {
             "git status & rm -rf /",
         ] {
             assert_ne!(
-                p.evaluate_command(cmd).action,
+                p.evaluate_command(cmd, &here()).action,
                 crate::policy::Action::Allow,
                 "{cmd} is still allowed"
             );

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,11 @@ fn dispatch(cli: Cli) -> Result<i32> {
                     (Policy::builtin()?, paths::demo_state_dir()?)
                 }
             };
-            let base = policy.evaluate_command(&cmd);
+            // `check` runs interactively, so the process cwd IS where the
+            // command would run - the one surface where they legitimately
+            // coincide.
+            let cwd = std::env::current_dir().unwrap_or_default();
+            let base = policy.evaluate_command(&cmd, &resolve::EvalContext::at(cwd));
             let signals = context::gather(&cmd);
             let (decision, escalated) = context::apply(base, &signals);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod policy;
 mod preview;
 mod protect;
 mod report;
+mod resolve;
 mod runner;
 mod shell;
 #[cfg(test)]

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -39,6 +39,25 @@ pub struct Rule {
     /// out of spelling) applied to the rule text itself.
     #[serde(default, skip_serializing_if = "is_false")]
     pub case_sensitive: bool,
+    /// Match this rule against the command's RESOLVED targets rather than
+    /// against the command string.
+    ///
+    /// Roadmap 2.4. `> ./.env` and `> .env` are the same file and different
+    /// strings, so a `match:` rule naming one misses the other - the gap
+    /// pinned in known-limitations 0.2. A `match_path:` rule is matched
+    /// against each target after resolution, so both spellings reach it.
+    ///
+    /// A rule may carry both fields. `match:` is required by the schema and
+    /// stays the rule's identity in reason lines and audit entries; when
+    /// `match_path:` is present, the rule fires if EITHER matches - the string
+    /// reading can only add matches, never remove them, which is the same
+    /// promise the extra readings make.
+    ///
+    /// ANY target matching fires the rule, and the reason names WHICH one. A
+    /// command with several targets is one command, and a human deciding
+    /// whether to approve it needs to know which path tripped the gate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub match_path: Option<String>,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -54,6 +73,19 @@ impl Rule {
     /// with `case_sensitive: true` is matched as written against the
     /// case-preserved reading, so `git branch*-D*` can mean `-D` and not
     /// `-d`. The field decides; the spelling never does.
+    /// Does this rule's `match_path` pattern match a resolved target? Uses the
+    /// same wildcard engine as `match`, so `*/.ssh/*` reads the way a person
+    /// writing a policy expects. The structural questions - is it outside the
+    /// project, is it a user profile - are NOT patterns; they are shapes
+    /// computed once during resolution and handled separately.
+    pub fn matches_path(&self, path: &str) -> bool {
+        match &self.match_path {
+            None => false,
+            Some(p) if self.case_sensitive => wildcard_match(&collapse(p), path),
+            Some(p) => wildcard_match(&normalize(p), &normalize(path)),
+        }
+    }
+
     pub fn matches(&self, reading: &str) -> bool {
         if self.case_sensitive {
             wildcard_match(&collapse(&self.r#match), reading)
@@ -114,6 +146,26 @@ pub struct Decision {
     pub action: Action,
     pub matched_rule: Option<String>,
     pub reason: String,
+}
+
+/// Every path this segment touches, resolved once: the redirect targets the
+/// splitter already found, plus whatever the delete extractor recognises.
+///
+/// Two sources rather than one because they answer different questions -
+/// `> .env` names a file the command WRITES, `rm .env` names one it DELETES -
+/// and a gate that reads only one of them has a hole shaped like the other.
+fn resolved_targets(
+    segment: &str,
+    ctx: &crate::resolve::EvalContext,
+) -> Vec<crate::resolve::ResolvedTarget> {
+    let mut raw: Vec<String> = Vec::new();
+    for seg in crate::shell::split_segments(segment) {
+        raw.extend(seg.redirects.iter().map(|o| o.target.clone()));
+    }
+    raw.extend(crate::delete::extract_targets(segment));
+    raw.sort();
+    raw.dedup();
+    raw.iter().map(|r| crate::resolve::target(r, ctx)).collect()
 }
 
 impl Policy {
@@ -189,11 +241,7 @@ impl Policy {
         }
     }
 
-    /// `ctx` is unused by the matcher today: this commit threads the execution
-    /// context to every evaluation site without changing a single verdict, so
-    /// the wiring is reviewable on its own. Commit 3 resolves targets here and
-    /// gives `match_path` something to match against.
-    pub fn evaluate(&self, command: &str, _ctx: &crate::resolve::EvalContext) -> Decision {
+    pub fn evaluate(&self, command: &str, ctx: &crate::resolve::EvalContext) -> Decision {
         // First-match PER READING, MOST SEVERE across readings, earliest rule
         // on ties. See `readings` for what the readings are.
         //
@@ -225,6 +273,88 @@ impl Policy {
                 });
             }
         }
+        // Roadmap 2.4: the same rules, matched against what the command
+        // actually TOUCHES rather than how it was spelled. Resolution happens
+        // once per segment and is reused by both checks below.
+        let targets = resolved_targets(command, ctx);
+
+        // A `match_path` rule fires if ANY target matches, and the reason
+        // names which one: a command with several targets is one command, and
+        // the human approving it needs to know which path tripped the gate.
+        let mut path_hit: Option<(usize, &Rule, String)> = None;
+        for (idx, rule) in self.rules.iter().enumerate() {
+            if rule.match_path.is_none() {
+                continue;
+            }
+            for t in &targets {
+                let Some(p) = &t.resolved else { continue };
+                if rule.matches_path(&p.display().to_string()) {
+                    let better = match &path_hit {
+                        None => true,
+                        Some((bi, br, _)) => {
+                            severity(rule.action) > severity(br.action)
+                                || (severity(rule.action) == severity(br.action) && idx < *bi)
+                        }
+                    };
+                    if better {
+                        path_hit = Some((idx, rule, t.display()));
+                    }
+                    break;
+                }
+            }
+        }
+
+        // An unresolved target carrying a sensitive shape fails closed. NOT a
+        // short-circuit: it enters the same most-severe-wins tournament as
+        // everything else, so an explicit allow above it still wins, which is
+        // the escape hatch every other rule already has. One decision path,
+        // not two.
+        let shape_deny = targets
+            .iter()
+            .find(|t| t.is_unresolved() && !t.shapes.is_empty());
+
+        match (path_hit, shape_deny) {
+            (Some((_, rule, target)), _) if rule.action == Action::Deny => {
+                return Decision {
+                    action: rule.action,
+                    matched_rule: Some(rule.r#match.clone()),
+                    reason: format!(
+                        "target `{}` — {}",
+                        target,
+                        rule.reason.clone().unwrap_or_else(|| format!(
+                            "matched path rule `{}`",
+                            rule.match_path.clone().unwrap_or_default()
+                        ))
+                    ),
+                };
+            }
+            (_, Some(t)) => {
+                let why = t
+                    .shapes
+                    .iter()
+                    .map(|s| s.label())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                // Only fails closed when it is WORSE than what the string
+                // rules concluded - an explicit allow is still an allow.
+                let base_sev = best
+                    .map(|(_, r)| severity(r.action))
+                    .unwrap_or_else(|| severity(self.default));
+                if base_sev < severity(Action::Deny) && base_sev > severity(Action::Allow) {
+                    return Decision {
+                        action: Action::Deny,
+                        matched_rule: None,
+                        reason: format!(
+                            "target `{}` cannot be resolved and {} — refusing rather than \
+                             guessing what it points at",
+                            t.as_written, why
+                        ),
+                    };
+                }
+            }
+            _ => {}
+        }
+
         match best {
             Some((_, rule)) => Decision {
                 action: rule.action,
@@ -363,6 +493,7 @@ mod schema_and_severity_tests {
             action: Action::Allow,
             reason: None,
             case_sensitive: false,
+            match_path: None,
         };
         let json = serde_json::to_string(&plain).expect("a rule must serialize");
         assert!(
@@ -375,6 +506,7 @@ mod schema_and_severity_tests {
             action: Action::Deny,
             reason: None,
             case_sensitive: true,
+            match_path: None,
         };
         let json = serde_json::to_string(&strict).expect("a rule must serialize");
         assert!(
@@ -542,6 +674,7 @@ mod tests {
             action: Action::Deny,
             reason: None,
             case_sensitive: true,
+            match_path: None,
         };
         let views_upper = readings("git branch -D main");
         let views_lower = readings("git branch -d main");
@@ -987,20 +1120,115 @@ mod combined_gate_tests {
         crate::resolve::EvalContext::at(std::path::Path::new("."))
     }
 
-    /// The `./` spelling is a KNOWN gap, pinned so a future fix flips this
-    /// test consciously: `cat /dev/null > ./.env` walks past the `*> .env*`
-    /// string rules (belt), but the redirect scanner still extracts the
-    /// target (suspenders) — intent classifies it and insurance backs the
-    /// file up before execution, whatever the spelling. The full fix is
-    /// matching on the RESOLVED target (v0.16, with #12's signal set).
+    /// Roadmap 2.4, the point of the whole change: a rule matched against the
+    /// RESOLVED target catches every spelling of one path, which no number of
+    /// added string patterns could do. The reason names WHICH target tripped
+    /// it, because a command may touch several and the human approving it
+    /// needs to know which one.
     #[test]
-    fn the_dot_slash_spelling_is_a_known_gap_with_insurance_beneath() {
+    fn a_path_rule_catches_every_spelling_and_names_the_target() {
+        let p = Policy::builtin().unwrap();
+        let d = p.evaluate_command("cat /dev/null > ./.env", &here());
+        assert_eq!(d.action, Action::Deny);
+        assert!(
+            d.reason.contains(".env"),
+            "the reason must name the target that tripped the gate: {}",
+            d.reason
+        );
+        // Control leg: the path rule does not fire on a path it does not
+        // match. `cat *` allows this one, which is exactly the point - the
+        // ordinary file reaches its ordinary verdict, and only the protected
+        // path is pulled out of it.
+        let ordinary = p.evaluate_command("cat /dev/null > ./notes.md", &here());
+        assert_eq!(ordinary.action, Action::Allow);
+        assert_eq!(ordinary.matched_rule.as_deref(), Some("cat *"));
+    }
+
+    /// An explicit `allow` still wins over an unresolved sensitive target, and
+    /// that is the DECIDED behaviour, not an oversight.
+    ///
+    /// `echo x > $CONFIG` cannot be resolved — the gate does not know what
+    /// file that is — and the target carries the UnexpandedVar shape. That
+    /// contributes a deny reading, but the reading enters the same
+    /// most-severe-wins tournament as everything else and loses to the
+    /// explicit `echo *` allow above it. It is not discarded; it is outranked.
+    ///
+    /// The alternative (unresolved-sensitive outranking an explicit allow)
+    /// would introduce a new precedence level above a decision the operator
+    /// wrote down deliberately. That is a separate semantic change and needs
+    /// its own tests and a migration note, so it is not made here.
+    #[test]
+    fn an_explicit_allow_outranks_an_unresolved_sensitive_target() {
         let p = Policy::builtin().unwrap();
         assert_eq!(
-            p.evaluate_command("cat /dev/null > ./.env", &here()).action,
+            p.evaluate_command("echo x > $CONFIG", &here()).action,
             Action::Allow,
-            "known gap — if this starts denying, delete this test and the comment"
+            "an explicit allow is an explicit allow"
         );
+        // The deny reading exists and is real — the resolver reports the shape
+        // — it simply loses the tournament. Asserting this separately is what
+        // makes the test about PRECEDENCE rather than about the resolver
+        // having failed to notice.
+        let t = crate::resolve::target("$CONFIG", &here());
+        assert!(t.is_unresolved());
+        assert!(t.has(crate::resolve::SensitiveShape::UnexpandedVar));
+
+        // And where no explicit allow covers it, the deny reading DOES govern.
+        // A REDIRECT to an unresolved target is seen, because redirects are
+        // one of the two target sources this commit reads.
+        let d = p.evaluate_command("truncate -s 0 x > $CONFIG", &here());
+        assert_eq!(
+            d.action,
+            Action::Deny,
+            "unresolved and sensitive, nothing explicit above it: {}",
+            d.reason
+        );
+        assert!(
+            d.reason.contains("cannot be resolved"),
+            "the reason must say the gate does not know: {}",
+            d.reason
+        );
+
+        // SCOPE, pinned so it is not mistaken for coverage: targets come from
+        // redirects and from the delete extractor. Nothing else has an
+        // extractor yet, so `truncate -s 0 $CONFIG` - which destroys a file
+        // named by an unresolvable variable - produces NO targets and reaches
+        // its ordinary verdict. cp/mv/tee/dd destinations are roadmap 2.1;
+        // truncate is covered by nothing. The machinery is only as wide as
+        // the extractors feeding it.
+        assert!(
+            resolved_targets("truncate -s 0 $CONFIG", &here()).is_empty(),
+            "if this starts finding targets, an extractor was added and this \
+             test should be narrowed rather than deleted"
+        );
+    }
+
+    /// GAP CLOSED, v0.16 — the INVERSION of the pinned known-gap test, not a
+    /// replacement, so the history stays visible in the place that proves it
+    /// is over. It read: "`cat /dev/null > ./.env` walks past the `*> .env*`
+    /// string rules (belt), but the redirect scanner still extracts the
+    /// target (suspenders)... the full fix is matching on the RESOLVED target
+    /// (v0.16)". That fix is this: the starter policy now carries a
+    /// `match_path: "*/.env"` rule, so both spellings of one file deny.
+    ///
+    /// The suspenders are asserted too, unchanged. Insurance did not become
+    /// unnecessary when the string gap closed — it is what covered the four
+    /// releases in which the gap was open, and a later policy edit could
+    /// remove the rule without removing the net.
+    #[test]
+    fn the_dot_slash_spelling_was_a_known_gap_and_is_now_closed() {
+        let p = Policy::builtin().unwrap();
+        for spelling in [
+            "cat /dev/null > ./.env",
+            "cat /dev/null > .env",
+            "cat /dev/null > ./sub/../.env",
+        ] {
+            assert_eq!(
+                p.evaluate_command(spelling, &here()).action,
+                Action::Deny,
+                "{spelling}: one file, every spelling"
+            );
+        }
         let segs = crate::shell::split_segments("cat /dev/null > ./.env");
         let r = &segs[0].redirects;
         assert!(

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -151,15 +151,15 @@ impl Policy {
     /// MOST DANGEROUS segment govern the combined verdict (deny > ask > allow).
     /// Closes the v0.6.1 field-report bypass where `git status && <anything>`
     /// rode the `git status*` wildcard.
-    pub fn evaluate_command(&self, command: &str) -> Decision {
+    pub fn evaluate_command(&self, command: &str, ctx: &crate::resolve::EvalContext) -> Decision {
         let segments = crate::shell::split_segments(command);
         if segments.len() <= 1 {
-            return self.evaluate(command);
+            return self.evaluate(command, ctx);
         }
         let total = segments.len();
         let mut worst: Option<(usize, Decision)> = None;
         for (i, seg) in segments.iter().enumerate() {
-            let d = self.evaluate(seg);
+            let d = self.evaluate(seg, ctx);
             let replace = match &worst {
                 None => true,
                 // higher severity wins; on ties, an explicitly-matched rule
@@ -189,7 +189,11 @@ impl Policy {
         }
     }
 
-    pub fn evaluate(&self, command: &str) -> Decision {
+    /// `ctx` is unused by the matcher today: this commit threads the execution
+    /// context to every evaluation site without changing a single verdict, so
+    /// the wiring is reviewable on its own. Commit 3 resolves targets here and
+    /// gives `match_path` something to match against.
+    pub fn evaluate(&self, command: &str, _ctx: &crate::resolve::EvalContext) -> Decision {
         // First-match PER READING, MOST SEVERE across readings, earliest rule
         // on ties. See `readings` for what the readings are.
         //
@@ -326,6 +330,13 @@ pub fn wildcard_match(pattern: &str, text: &str) -> bool {
 mod schema_and_severity_tests {
     use super::*;
 
+    /// Evaluation context for tests: the current directory as both cwd and
+    /// root. No test here depends on resolution, which is the point - this
+    /// commit changed no verdicts.
+    fn here() -> crate::resolve::EvalContext {
+        crate::resolve::EvalContext::at(std::path::Path::new("."))
+    }
+
     fn policy_from(yaml: &str) -> Policy {
         serde_yaml::from_str(yaml).expect("policy must parse")
     }
@@ -401,7 +412,7 @@ mod schema_and_severity_tests {
             "default: allow\nrules:\n  - match: '\"rm\"*'\n    action: deny\n  \
              - match: \"rm -rf*\"\n    action: deny\n",
         );
-        let d = p.evaluate(r#""rm" -rf /"#);
+        let d = p.evaluate(r#""rm" -rf /"#, &here());
         assert_eq!(d.action, Action::Deny);
         assert_eq!(d.matched_rule.as_deref(), Some("\"rm\"*"));
     }
@@ -414,7 +425,7 @@ mod schema_and_severity_tests {
             "default: allow\nrules:\n  - match: \"rm -rf*\"\n    action: deny\n  \
              - match: '\"rm\"*'\n    action: deny\n",
         );
-        let d = p.evaluate(r#""rm" -rf /"#);
+        let d = p.evaluate(r#""rm" -rf /"#, &here());
         assert_eq!(d.matched_rule.as_deref(), Some("rm -rf*"));
     }
 
@@ -427,7 +438,7 @@ mod schema_and_severity_tests {
             "default: allow\nrules:\n  - match: '\"cat\"*'\n    action: allow\n  \
              - match: \"cat .termaxa*\"\n    action: deny\n",
         );
-        let d = p.evaluate(r#""cat" .termaxa/policy.yaml"#);
+        let d = p.evaluate(r#""cat" .termaxa/policy.yaml"#, &here());
         assert_eq!(
             d.action,
             Action::Deny,
@@ -444,7 +455,7 @@ mod schema_and_severity_tests {
             "default: allow\nrules:\n  - match: \"rm -rf*\"\n    action: deny\n  \
              - match: \"drop table*\"\n    action: deny\n",
         );
-        let d = p.evaluate_command("rm -rf /tmp/x && drop table users");
+        let d = p.evaluate_command("rm -rf /tmp/x && drop table users", &here());
         assert_eq!(d.action, Action::Deny);
         assert_eq!(d.matched_rule.as_deref(), Some("rm -rf*"));
         assert!(d.reason.contains("segment 1/2"), "{}", d.reason);
@@ -456,7 +467,7 @@ mod schema_and_severity_tests {
         // explicit allow. A matched rule breaks TIES between equally severe
         // segments — it does not lower the verdict.
         let p = policy_from("default: ask\nrules:\n  - match: \"ls*\"\n    action: allow\n");
-        let d = p.evaluate_command("curl https://example.invalid/x | ls");
+        let d = p.evaluate_command("curl https://example.invalid/x | ls", &here());
         assert_eq!(
             d.action,
             Action::Ask,
@@ -469,6 +480,13 @@ mod schema_and_severity_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Evaluation context for tests: the current directory as both cwd and
+    /// root. No test here depends on resolution, which is the point - this
+    /// commit changed no verdicts.
+    fn here() -> crate::resolve::EvalContext {
+        crate::resolve::EvalContext::at(std::path::Path::new("."))
+    }
 
     /// Schipper review round 2, finding 2. `intent::tokens` strips quotes and
     /// `policy::normalize` does not, so the classifier saw through disguises
@@ -484,7 +502,7 @@ mod tests {
             r#"'rm' -rf /"#,
         ] {
             assert_eq!(
-                p.evaluate_command(cmd).action,
+                p.evaluate_command(cmd, &here()).action,
                 Action::Deny,
                 "{cmd} must not slip past the deny rule by quoting"
             );
@@ -498,15 +516,20 @@ mod tests {
         let p = Policy::builtin().unwrap();
         // `*drop table*` is written lowercase, so it must catch both.
         assert_eq!(
-            p.evaluate_command("psql -c \"DROP TABLE users\"").action,
+            p.evaluate_command("psql -c \"DROP TABLE users\"", &here())
+                .action,
             Action::Deny
         );
         assert_eq!(
-            p.evaluate_command("psql -c \"drop table users\"").action,
+            p.evaluate_command("psql -c \"drop table users\"", &here())
+                .action,
             Action::Deny
         );
         // `*rm -rf*` likewise.
-        assert_eq!(p.evaluate_command("rm -RF /tmp/x").action, Action::Deny);
+        assert_eq!(
+            p.evaluate_command("rm -RF /tmp/x", &here()).action,
+            Action::Deny
+        );
     }
 
     /// Until v0.15 this was impossible: `evaluate` lowercased the rule as well
@@ -549,7 +572,7 @@ mod tests {
             "remove-item -force c:\\x",
         ] {
             assert_eq!(
-                p.evaluate_command(cmd).action,
+                p.evaluate_command(cmd, &here()).action,
                 Action::Deny,
                 "{cmd} matched a deny in v0.14.2 and must keep matching"
             );
@@ -577,12 +600,14 @@ mod tests {
     fn a_quoted_spelling_of_an_excepted_command_fails_closed() {
         let p = Policy::builtin().unwrap();
         assert_eq!(
-            p.evaluate_command("cat .termaxa/policy.yaml").action,
+            p.evaluate_command("cat .termaxa/policy.yaml", &here())
+                .action,
             Action::Allow,
             "the plain excepted read stays allowed"
         );
         assert_eq!(
-            p.evaluate_command(r#""cat" .termaxa/policy.yaml"#).action,
+            p.evaluate_command(r#""cat" .termaxa/policy.yaml"#, &here())
+                .action,
             Action::Deny,
             "a disguised spelling of a .termaxa read fails closed, loudly"
         );
@@ -633,14 +658,19 @@ rules:
         )
         .unwrap();
         assert_eq!(
-            policy.evaluate("git push origin main").action,
+            policy.evaluate("git push origin main", &here()).action,
             Action::Allow
         );
         assert_eq!(
-            policy.evaluate("git push --force origin main").action,
+            policy
+                .evaluate("git push --force origin main", &here())
+                .action,
             Action::Deny
         );
-        assert_eq!(policy.evaluate("terraform apply").action, Action::Ask);
+        assert_eq!(
+            policy.evaluate("terraform apply", &here()).action,
+            Action::Ask
+        );
     }
 
     #[test]
@@ -654,7 +684,7 @@ rules:
         )
         .unwrap();
         assert_eq!(
-            policy.evaluate("kubectl   delete   pod x").action,
+            policy.evaluate("kubectl   delete   pod x", &here()).action,
             Action::Deny
         );
     }
@@ -670,7 +700,9 @@ rules:
         )
         .unwrap();
         assert_eq!(
-            policy.evaluate("psql -c 'DROP TABLE users'").action,
+            policy
+                .evaluate("psql -c 'DROP TABLE users'", &here())
+                .action,
             Action::Deny
         );
     }
@@ -690,16 +722,21 @@ rules:
         )
         .unwrap();
         // the trench-coat attack: worst segment governs
-        let d = policy.evaluate_command("git status && rm -rf /");
+        let d = policy.evaluate_command("git status && rm -rf /", &here());
         assert_eq!(d.action, Action::Deny);
         assert!(d.reason.contains("rm -rf /"));
         // benign compound with an unmatched segment falls to default (ask)
         assert_eq!(
-            policy.evaluate_command("git status && echo hi").action,
+            policy
+                .evaluate_command("git status && echo hi", &here())
+                .action,
             Action::Ask
         );
         // single commands behave exactly as before
-        assert_eq!(policy.evaluate_command("git status").action, Action::Allow);
+        assert_eq!(
+            policy.evaluate_command("git status", &here()).action,
+            Action::Allow
+        );
     }
 
     #[test]
@@ -707,14 +744,19 @@ rules:
         // The embedded starter policy must always parse (it backs `check`'s
         // zero-setup demo mode) and must classify the headline cases.
         let p = Policy::builtin().expect("built-in starter policy must parse");
-        assert_eq!(p.evaluate_command("rm -rf /").action, Action::Deny);
+        assert_eq!(p.evaluate_command("rm -rf /", &here()).action, Action::Deny);
         assert_eq!(
-            p.evaluate_command("psql -c 'DROP TABLE users'").action,
+            p.evaluate_command("psql -c 'DROP TABLE users'", &here())
+                .action,
             Action::Deny
         );
-        assert_eq!(p.evaluate_command("git status").action, Action::Allow);
         assert_eq!(
-            p.evaluate_command("git push --force origin main").action,
+            p.evaluate_command("git status", &here()).action,
+            Action::Allow
+        );
+        assert_eq!(
+            p.evaluate_command("git push --force origin main", &here())
+                .action,
             Action::Deny
         );
     }
@@ -735,7 +777,7 @@ rules:
         let p = Policy::builtin().unwrap();
         for cmd in ["Get-ChildItem | Remove-Item", "Remove-Item x"] {
             assert_eq!(
-                p.evaluate_command(cmd).action,
+                p.evaluate_command(cmd, &here()).action,
                 Action::Ask,
                 "{cmd}: an unflagged delete is ordinary work"
             );
@@ -746,7 +788,7 @@ rules:
             "Remove-Item -Recurse x",
         ] {
             assert_eq!(
-                p.evaluate_command(cmd).action,
+                p.evaluate_command(cmd, &here()).action,
                 Action::Deny,
                 "{cmd}: the flag is in the same segment as the name, so it fires"
             );
@@ -760,7 +802,7 @@ rules:
         // The command from the review: `echo *` sat below the denies and
         // allowed this outright, and everything after it was judged by a
         // policy the agent had written.
-        let d = p.evaluate_command("echo 'default: allow' > .termaxa/policy.yaml");
+        let d = p.evaluate_command("echo 'default: allow' > .termaxa/policy.yaml", &here());
         assert_eq!(d.action, Action::Deny);
         assert_eq!(d.matched_rule.as_deref(), Some("*.termaxa*"));
 
@@ -776,7 +818,7 @@ rules:
             "rm .github/hooks/hooks.json",
         ] {
             assert_eq!(
-                p.evaluate_command(cmd).action,
+                p.evaluate_command(cmd, &here()).action,
                 Action::Deny,
                 "must not be able to edit the gate: {cmd}"
             );
@@ -821,7 +863,7 @@ rules:
             "git diff .termaxa\\policy.yaml",
         ] {
             assert_eq!(
-                p.evaluate_command(cmd).action,
+                p.evaluate_command(cmd, &here()).action,
                 Action::Allow,
                 "the documented review workflow must not be blocked: {cmd}"
             );
@@ -844,7 +886,7 @@ rules:
             "tee .termaxa/policy.yaml",
         ] {
             assert_eq!(
-                p.evaluate_command(cmd).action,
+                p.evaluate_command(cmd, &here()).action,
                 Action::Deny,
                 "writes into the gate's config must stay denied: {cmd}"
             );
@@ -865,7 +907,7 @@ rules:
             "cp .termaxa/policy.yaml .codex/hooks.json",
         ] {
             assert_eq!(
-                p.evaluate_command(cmd).action,
+                p.evaluate_command(cmd, &here()).action,
                 Action::Deny,
                 "an exception must not become a way through: {cmd}"
             );
@@ -900,7 +942,11 @@ rules:
             "sudo rm --no-preserve-root -rf /",
             "rm -r --no-preserve-root /",
         ] {
-            assert_eq!(p.evaluate_command(cmd).action, Action::Deny, "{cmd}");
+            assert_eq!(
+                p.evaluate_command(cmd, &here()).action,
+                Action::Deny,
+                "{cmd}"
+            );
         }
     }
 
@@ -911,14 +957,18 @@ rules:
         // Still allowed — including bare `ls`, which needs its own rule
         // because `ls *` requires the space.
         for cmd in ["ls", "ls -la src", "grep -rn fn src", "cat Cargo.toml"] {
-            assert_eq!(p.evaluate_command(cmd).action, Action::Allow, "{cmd}");
+            assert_eq!(
+                p.evaluate_command(cmd, &here()).action,
+                Action::Allow,
+                "{cmd}"
+            );
         }
 
         // Different programs that merely start with the same letters. `ls*`
         // and `grep*` used to allow all of these.
         for cmd in ["lsof -i :5432", "lsblk", "lsattr -R /", "grepdiff --help"] {
             assert_ne!(
-                p.evaluate_command(cmd).action,
+                p.evaluate_command(cmd, &here()).action,
                 Action::Allow,
                 "a prefix is not a command: {cmd}"
             );
@@ -930,6 +980,13 @@ rules:
 mod combined_gate_tests {
     use super::*;
 
+    /// Evaluation context for tests: the current directory as both cwd and
+    /// root. No test here depends on resolution, which is the point - this
+    /// commit changed no verdicts.
+    fn here() -> crate::resolve::EvalContext {
+        crate::resolve::EvalContext::at(std::path::Path::new("."))
+    }
+
     /// The `./` spelling is a KNOWN gap, pinned so a future fix flips this
     /// test consciously: `cat /dev/null > ./.env` walks past the `*> .env*`
     /// string rules (belt), but the redirect scanner still extracts the
@@ -940,7 +997,7 @@ mod combined_gate_tests {
     fn the_dot_slash_spelling_is_a_known_gap_with_insurance_beneath() {
         let p = Policy::builtin().unwrap();
         assert_eq!(
-            p.evaluate_command("cat /dev/null > ./.env").action,
+            p.evaluate_command("cat /dev/null > ./.env", &here()).action,
             Action::Allow,
             "known gap — if this starts denying, delete this test and the comment"
         );

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -32,13 +32,6 @@
 //! That ordering is deliberate: resolution that decides is resolution that
 //! cannot be reused by a consumer wanting a different policy.
 
-// EvalContext is now threaded to every evaluation site, but nothing RESOLVES
-// yet: `ResolvedTarget` and the shapes stay dead until commit 3 gives
-// `match_path` something to match against. The allow stays one more commit,
-// scoped here, and comes off with the behaviour change - keeping the
-// mechanical threading separable from the verdicts it enables.
-#![allow(dead_code)]
-
 use crate::delete;
 use std::path::PathBuf;
 
@@ -65,13 +58,6 @@ pub struct EvalContext {
 }
 
 impl EvalContext {
-    pub fn new(cwd: impl Into<PathBuf>, root: impl Into<PathBuf>) -> Self {
-        Self {
-            cwd: cwd.into(),
-            root: root.into(),
-        }
-    }
-
     /// Context for a command running at `dir`, with no distinct project root -
     /// the directory is both. Used by surfaces that evaluate without a located
     /// project, and by tests.
@@ -160,6 +146,9 @@ impl ResolvedTarget {
         self.resolved.is_none()
     }
 
+    /// Used by tests asserting on a specific shape. Production reads the
+    /// whole list, because a reason line names every shape a target carries.
+    #[cfg(test)]
     pub fn has(&self, s: SensitiveShape) -> bool {
         self.shapes.contains(&s)
     }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,0 +1,306 @@
+//! What a command's targets actually point at.
+//!
+//! Roadmap 2.4, the spine of v0.16. Every engine used to answer "what does this
+//! command touch?" from the SPELLING — `delete.rs` resolved for its preview,
+//! `backup.rs` resolved again for its insurance, and `policy.rs` never resolved
+//! at all, matching rule patterns against the raw string. So `> ./.env` and
+//! `> .env` are the same file and different strings, and only the string
+//! reached the gate (known-limitations 0.2, still pinned).
+//!
+//! This module resolves once, upstream, and hands every consumer the same
+//! answer. It is Schipper's `protect.rs` approach — resolve against the payload
+//! cwd, classify the real path, decide — generalised from the write path to
+//! commands.
+//!
+//! TWO READINGS, ALWAYS BOTH. A target keeps `as_written` even when it resolves
+//! cleanly, because the two answer different questions: `resolved` is what will
+//! be destroyed, `as_written` is what the human typed and what a reason line
+//! must quote back. Collapsing them would make the gate's explanation of itself
+//! less legible than the command it is judging.
+//!
+//! RESOLUTION IS LEXICAL AND EXECUTES NOTHING. `.`, `..`, `~`, and the WSL and
+//! Git Bash path spellings are handled by `delete::resolve_path_in`. Shell
+//! variables are NOT expanded — expanding `$HOME` would mean reading the
+//! environment the gate runs in, which is not necessarily the environment the
+//! command will run in. `$(...)` is command substitution and stays fenced
+//! upstream by `shell::has_substitution`; this module never sees it as a target.
+//!
+//! UNRESOLVED IS A STATE, NOT A VERDICT. A target carrying `$VAR` cannot be
+//! resolved lexically, and that fact is carried in the value rather than
+//! collapsed into a decision here. The policy layer decides what an unresolved
+//! target with a given shape is worth; this module only reports what it found.
+//! That ordering is deliberate: resolution that decides is resolution that
+//! cannot be reused by a consumer wanting a different policy.
+
+// This module lands one commit ahead of its consumers, deliberately: the
+// representation is reviewable on its own, and wiring it into evaluation is a
+// separate change with its own behaviour to argue about. Until that lands,
+// every item here is dead by construction. The allow is scoped to this module
+// and comes off in the commit that threads it through `policy::evaluate`.
+#![allow(dead_code)]
+
+use crate::delete;
+use std::path::{Path, PathBuf};
+
+/// A property of a target that makes an unresolved one worth failing closed on.
+///
+/// These are computed for EVERY target, resolved or not, because a caller
+/// asking "is this sensitive?" should not have to ask "did it resolve?" first.
+/// What the policy layer does with them differs by resolution state; what this
+/// module reports does not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SensitiveShape {
+    /// `$VAR`, `${VAR}` or `%VAR%` — the target's real path depends on an
+    /// environment this gate cannot read reliably. The most important shape:
+    /// it is the only one that also makes the target unresolvable, so it is
+    /// the case where the gate genuinely does not know what it is judging.
+    UnexpandedVar,
+    /// Resolves outside the project root. Not automatically wrong — plenty of
+    /// legitimate work touches `~/.cache` — but it is the shape of the field
+    /// report this project exists because of: `rm -rf "/c/Users/harih"` from
+    /// inside a project directory.
+    OutsideRoot,
+    /// Resolves to a user profile, or a sibling of one. The 70,201-file case.
+    UnderUserProfile,
+    /// Names one of the gate's own assets: anything under `.termaxa/`, or an
+    /// agent hook configuration. Reuses `protect::classify` rather than
+    /// restating the list, so the write path and the command path cannot
+    /// disagree about what is protected (#37).
+    ProtectedName,
+}
+
+impl SensitiveShape {
+    /// Short phrase for a reason line, written to read naturally after the
+    /// target: "`$HOME/.ssh` — depends on an unexpanded variable".
+    pub fn label(self) -> &'static str {
+        match self {
+            SensitiveShape::UnexpandedVar => "depends on an unexpanded variable",
+            SensitiveShape::OutsideRoot => "resolves outside the project",
+            SensitiveShape::UnderUserProfile => "resolves to a user profile",
+            SensitiveShape::ProtectedName => "names the gate's own files",
+        }
+    }
+}
+
+/// One target of a command, in both readings.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedTarget {
+    /// Exactly what appeared in the command, quotes stripped. Never empty.
+    pub as_written: String,
+    /// The lexically resolved path, or `None` when resolution could not be
+    /// completed — today that means an unexpanded variable, the one thing
+    /// lexical resolution genuinely cannot see through.
+    pub resolved: Option<PathBuf>,
+    /// Everything notable about this target, in a stable order.
+    pub shapes: Vec<SensitiveShape>,
+}
+
+impl ResolvedTarget {
+    /// Did resolution complete? `false` means the gate does not know what path
+    /// this is, which is a different situation from knowing it is dangerous.
+    pub fn is_unresolved(&self) -> bool {
+        self.resolved.is_none()
+    }
+
+    pub fn has(&self, s: SensitiveShape) -> bool {
+        self.shapes.contains(&s)
+    }
+
+    /// The reading a human should be shown. The resolved path when it differs
+    /// meaningfully from what was typed, otherwise what was typed — the same
+    /// judgement `delete.rs` makes when it decides whether to print an
+    /// "as written" line.
+    pub fn display(&self) -> String {
+        match &self.resolved {
+            Some(p) => p.display().to_string(),
+            None => self.as_written.clone(),
+        }
+    }
+}
+
+/// Resolve one target against the command's cwd and the project root.
+///
+/// `root` is the project directory, used only to answer the outside-root
+/// question. Pass `cwd` for both when there is no distinct root to speak of.
+pub fn target(raw: &str, cwd: &Path, root: &Path) -> ResolvedTarget {
+    let as_written = raw.trim().trim_matches('"').trim_matches('\'').to_string();
+    let mut shapes = Vec::new();
+
+    if has_unexpanded_var(&as_written) {
+        shapes.push(SensitiveShape::UnexpandedVar);
+        // Resolution stops here deliberately. `delete::resolve_path_in` would
+        // happily join `$HOME/.ssh` onto the cwd and produce a real-looking
+        // path that points nowhere true. A confident wrong answer is worse
+        // than an admitted unknown in a tool that reports blast radius.
+        return ResolvedTarget {
+            as_written,
+            resolved: None,
+            shapes,
+        };
+    }
+
+    let resolved = delete::resolve_path_in(&as_written, cwd);
+
+    if !delete::is_inside(&resolved, root) {
+        shapes.push(SensitiveShape::OutsideRoot);
+    }
+    if delete::is_user_profile(&resolved) {
+        shapes.push(SensitiveShape::UnderUserProfile);
+    }
+    if crate::protect::classify(&cwd.display().to_string(), &resolved.display().to_string())
+        .is_some()
+    {
+        shapes.push(SensitiveShape::ProtectedName);
+    }
+
+    ResolvedTarget {
+        as_written,
+        resolved: Some(resolved),
+        shapes,
+    }
+}
+
+/// Does this target's path depend on a shell variable?
+///
+/// `$(` is deliberately NOT counted: that is command substitution, fenced
+/// upstream by `shell::has_substitution`, and counting it here would report
+/// the same fact twice under a name that does not fit it.
+fn has_unexpanded_var(s: &str) -> bool {
+    let b: Vec<char> = s.chars().collect();
+    for i in 0..b.len() {
+        if b[i] == '$' {
+            match b.get(i + 1) {
+                // `$(` is substitution, not a variable.
+                Some('(') => continue,
+                Some(c) if c.is_ascii_alphanumeric() || *c == '_' || *c == '{' => return true,
+                _ => {}
+            }
+        }
+        // `%VAR%` — Windows. Needs a closing `%` with at least one name
+        // character between, so a lone `%` (legal in a filename) does not count.
+        if b[i] == '%' {
+            if let Some(rest) = b.get(i + 1..) {
+                for (n, c) in rest.iter().enumerate() {
+                    if *c == '%' && n > 0 {
+                        return true;
+                    }
+                    if !(c.is_ascii_alphanumeric() || *c == '_') {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::TempTree;
+
+    #[test]
+    fn a_plain_relative_target_resolves_against_the_given_cwd_and_is_ordinary() {
+        let t = TempTree::new("resolve-plain");
+        let root = t.path();
+        let r = target("./dist", root, root);
+        assert_eq!(r.as_written, "./dist");
+        assert_eq!(r.resolved, Some(root.join("dist")));
+        assert!(!r.is_unresolved());
+        assert!(r.shapes.is_empty(), "ordinary work carries no shapes");
+    }
+
+    #[test]
+    fn the_two_readings_are_both_kept() {
+        let t = TempTree::new("resolve-readings");
+        let root = t.path();
+        let r = target("./sub/../dist", root, root);
+        // as_written survives resolution: a reason line quotes what was typed.
+        assert_eq!(r.as_written, "./sub/../dist");
+        assert_eq!(r.resolved, Some(root.join("dist")));
+    }
+
+    #[test]
+    fn an_unexpanded_variable_is_unresolved_rather_than_guessed() {
+        let t = TempTree::new("resolve-var");
+        let root = t.path();
+        for raw in ["$HOME/.ssh", "${HOME}/.ssh", "%USERPROFILE%\\.ssh", "$X"] {
+            let r = target(raw, root, root);
+            assert!(r.is_unresolved(), "{raw} must not resolve");
+            assert!(r.has(SensitiveShape::UnexpandedVar), "{raw}");
+            // The gate admits it does not know, rather than inventing a path.
+            assert_eq!(r.resolved, None);
+            assert_eq!(r.display(), raw);
+        }
+    }
+
+    #[test]
+    fn a_dollar_that_is_not_a_variable_does_not_count() {
+        let t = TempTree::new("resolve-dollar");
+        let root = t.path();
+        // Command substitution is fenced upstream; counting it here would
+        // report the same fact twice under the wrong name.
+        for raw in ["$(date).log", "cost$.txt", "100%", "50%-done"] {
+            let r = target(raw, root, root);
+            assert!(
+                !r.has(SensitiveShape::UnexpandedVar),
+                "{raw} is not a variable reference"
+            );
+        }
+    }
+
+    #[test]
+    fn a_target_outside_the_project_carries_that_shape() {
+        let t = TempTree::new("resolve-outside");
+        let root = t.path().join("project");
+        std::fs::create_dir_all(&root).unwrap();
+        let r = target("../elsewhere", &root, &root);
+        assert!(r.has(SensitiveShape::OutsideRoot));
+        // Control leg: inside the project, the shape is absent.
+        let inside = target("./src", &root, &root);
+        assert!(!inside.has(SensitiveShape::OutsideRoot));
+    }
+
+    #[test]
+    fn the_gates_own_files_are_recognised_through_protect() {
+        let t = TempTree::new("resolve-protected");
+        let root = t.path();
+        let r = target(".termaxa/policy.yaml", root, root);
+        assert!(
+            r.has(SensitiveShape::ProtectedName),
+            "the command path and the write path must agree on what is protected"
+        );
+        // Control leg: an ordinary project file is not protected.
+        let ordinary = target("src/main.rs", root, root);
+        assert!(!ordinary.has(SensitiveShape::ProtectedName));
+    }
+
+    #[test]
+    fn shapes_accumulate_rather_than_shadowing_each_other() {
+        let t = TempTree::new("resolve-multi");
+        let root = t.path().join("project");
+        std::fs::create_dir_all(&root).unwrap();
+        // A .termaxa path outside the project is BOTH outside and protected;
+        // reporting only the first found would lose half the reason.
+        let r = target("../other/.termaxa/policy.yaml", &root, &root);
+        assert!(r.has(SensitiveShape::OutsideRoot), "{:?}", r.shapes);
+        assert!(r.has(SensitiveShape::ProtectedName), "{:?}", r.shapes);
+    }
+
+    #[test]
+    fn every_shape_has_a_label_that_reads_after_a_target() {
+        for s in [
+            SensitiveShape::UnexpandedVar,
+            SensitiveShape::OutsideRoot,
+            SensitiveShape::UnderUserProfile,
+            SensitiveShape::ProtectedName,
+        ] {
+            let l = s.label();
+            assert!(!l.is_empty());
+            assert!(
+                l.chars().next().unwrap().is_lowercase(),
+                "{l}: labels continue a sentence, they do not start one"
+            );
+        }
+    }
+}

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -32,15 +32,73 @@
 //! That ordering is deliberate: resolution that decides is resolution that
 //! cannot be reused by a consumer wanting a different policy.
 
-// This module lands one commit ahead of its consumers, deliberately: the
-// representation is reviewable on its own, and wiring it into evaluation is a
-// separate change with its own behaviour to argue about. Until that lands,
-// every item here is dead by construction. The allow is scoped to this module
-// and comes off in the commit that threads it through `policy::evaluate`.
+// EvalContext is now threaded to every evaluation site, but nothing RESOLVES
+// yet: `ResolvedTarget` and the shapes stay dead until commit 3 gives
+// `match_path` something to match against. The allow stays one more commit,
+// scoped here, and comes off with the behaviour change - keeping the
+// mechanical threading separable from the verdicts it enables.
 #![allow(dead_code)]
 
 use crate::delete;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+
+/// Where a command runs, for the purpose of judging its targets.
+///
+/// Two values, both about the execution context, threaded together because
+/// they travel together: passing them as separate arguments through every
+/// evaluation call site invites transposing them, and a transposed cwd/root
+/// pair fails silently - every target reads as outside the project.
+///
+/// DELIBERATELY SMALL. No policy state, no decision state, no speculative
+/// fields. The resolver consumes this and returns facts; deciding what those
+/// facts are worth stays with the policy layer. A context that grew a
+/// `Decision` or a rule list would put the two on the same side of the line
+/// this module exists to keep.
+#[derive(Debug, Clone)]
+pub struct EvalContext {
+    /// The directory the command runs in - from the hook payload, never the
+    /// process cwd (decision #59's sibling: a hook runs wherever the harness
+    /// spawned it).
+    pub cwd: PathBuf,
+    /// The project root, used only to answer the outside-the-project question.
+    pub root: PathBuf,
+}
+
+impl EvalContext {
+    pub fn new(cwd: impl Into<PathBuf>, root: impl Into<PathBuf>) -> Self {
+        Self {
+            cwd: cwd.into(),
+            root: root.into(),
+        }
+    }
+
+    /// Context for a command running at `dir`, with no distinct project root -
+    /// the directory is both. Used by surfaces that evaluate without a located
+    /// project, and by tests.
+    pub fn at(dir: impl Into<PathBuf>) -> Self {
+        let d: PathBuf = dir.into();
+        Self {
+            cwd: d.clone(),
+            root: d,
+        }
+    }
+
+    /// Context derived from a located project. `Paths::project_dir` is the
+    /// `.termaxa/` directory, so the project root is its parent - computed
+    /// here once rather than at each call site, where getting it wrong would
+    /// make every target read as outside the project.
+    pub fn from_paths(cwd: impl Into<PathBuf>, paths: &crate::paths::Paths) -> Self {
+        let root = paths
+            .project_dir
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| paths.project_dir.clone());
+        Self {
+            cwd: cwd.into(),
+            root,
+        }
+    }
+}
 
 /// A property of a target that makes an unresolved one worth failing closed on.
 ///
@@ -122,7 +180,7 @@ impl ResolvedTarget {
 ///
 /// `root` is the project directory, used only to answer the outside-root
 /// question. Pass `cwd` for both when there is no distinct root to speak of.
-pub fn target(raw: &str, cwd: &Path, root: &Path) -> ResolvedTarget {
+pub fn target(raw: &str, ctx: &EvalContext) -> ResolvedTarget {
     let as_written = raw.trim().trim_matches('"').trim_matches('\'').to_string();
     let mut shapes = Vec::new();
 
@@ -139,16 +197,19 @@ pub fn target(raw: &str, cwd: &Path, root: &Path) -> ResolvedTarget {
         };
     }
 
-    let resolved = delete::resolve_path_in(&as_written, cwd);
+    let resolved = delete::resolve_path_in(&as_written, &ctx.cwd);
 
-    if !delete::is_inside(&resolved, root) {
+    if !delete::is_inside(&resolved, &ctx.root) {
         shapes.push(SensitiveShape::OutsideRoot);
     }
     if delete::is_user_profile(&resolved) {
         shapes.push(SensitiveShape::UnderUserProfile);
     }
-    if crate::protect::classify(&cwd.display().to_string(), &resolved.display().to_string())
-        .is_some()
+    if crate::protect::classify(
+        &ctx.cwd.display().to_string(),
+        &resolved.display().to_string(),
+    )
+    .is_some()
     {
         shapes.push(SensitiveShape::ProtectedName);
     }
@@ -203,7 +264,7 @@ mod tests {
     fn a_plain_relative_target_resolves_against_the_given_cwd_and_is_ordinary() {
         let t = TempTree::new("resolve-plain");
         let root = t.path();
-        let r = target("./dist", root, root);
+        let r = target("./dist", &EvalContext::at(root));
         assert_eq!(r.as_written, "./dist");
         assert_eq!(r.resolved, Some(root.join("dist")));
         assert!(!r.is_unresolved());
@@ -214,7 +275,7 @@ mod tests {
     fn the_two_readings_are_both_kept() {
         let t = TempTree::new("resolve-readings");
         let root = t.path();
-        let r = target("./sub/../dist", root, root);
+        let r = target("./sub/../dist", &EvalContext::at(root));
         // as_written survives resolution: a reason line quotes what was typed.
         assert_eq!(r.as_written, "./sub/../dist");
         assert_eq!(r.resolved, Some(root.join("dist")));
@@ -225,7 +286,7 @@ mod tests {
         let t = TempTree::new("resolve-var");
         let root = t.path();
         for raw in ["$HOME/.ssh", "${HOME}/.ssh", "%USERPROFILE%\\.ssh", "$X"] {
-            let r = target(raw, root, root);
+            let r = target(raw, &EvalContext::at(root));
             assert!(r.is_unresolved(), "{raw} must not resolve");
             assert!(r.has(SensitiveShape::UnexpandedVar), "{raw}");
             // The gate admits it does not know, rather than inventing a path.
@@ -241,7 +302,7 @@ mod tests {
         // Command substitution is fenced upstream; counting it here would
         // report the same fact twice under the wrong name.
         for raw in ["$(date).log", "cost$.txt", "100%", "50%-done"] {
-            let r = target(raw, root, root);
+            let r = target(raw, &EvalContext::at(root));
             assert!(
                 !r.has(SensitiveShape::UnexpandedVar),
                 "{raw} is not a variable reference"
@@ -254,10 +315,10 @@ mod tests {
         let t = TempTree::new("resolve-outside");
         let root = t.path().join("project");
         std::fs::create_dir_all(&root).unwrap();
-        let r = target("../elsewhere", &root, &root);
+        let r = target("../elsewhere", &EvalContext::at(&root));
         assert!(r.has(SensitiveShape::OutsideRoot));
         // Control leg: inside the project, the shape is absent.
-        let inside = target("./src", &root, &root);
+        let inside = target("./src", &EvalContext::at(&root));
         assert!(!inside.has(SensitiveShape::OutsideRoot));
     }
 
@@ -265,13 +326,13 @@ mod tests {
     fn the_gates_own_files_are_recognised_through_protect() {
         let t = TempTree::new("resolve-protected");
         let root = t.path();
-        let r = target(".termaxa/policy.yaml", root, root);
+        let r = target(".termaxa/policy.yaml", &EvalContext::at(root));
         assert!(
             r.has(SensitiveShape::ProtectedName),
             "the command path and the write path must agree on what is protected"
         );
         // Control leg: an ordinary project file is not protected.
-        let ordinary = target("src/main.rs", root, root);
+        let ordinary = target("src/main.rs", &EvalContext::at(root));
         assert!(!ordinary.has(SensitiveShape::ProtectedName));
     }
 
@@ -282,7 +343,7 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         // A .termaxa path outside the project is BOTH outside and protected;
         // reporting only the first found would lose half the reason.
-        let r = target("../other/.termaxa/policy.yaml", &root, &root);
+        let r = target("../other/.termaxa/policy.yaml", &EvalContext::at(&root));
         assert!(r.has(SensitiveShape::OutsideRoot), "{:?}", r.shapes);
         assert!(r.has(SensitiveShape::ProtectedName), "{:?}", r.shapes);
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -13,7 +13,9 @@ pub fn run(paths: &crate::paths::Paths, argv: &[String]) -> Result<i32> {
     let command = shell_join(argv);
 
     let policy = Policy::load(&paths.policy_file())?;
-    let base = policy.evaluate_command(&command);
+    let ctx =
+        crate::resolve::EvalContext::from_paths(std::env::current_dir().unwrap_or_default(), paths);
+    let base = policy.evaluate_command(&command, &ctx);
     let signals = context::gather(&command);
     let (decision, escalated) = context::apply(base, &signals);
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>v0.16: resolve-then-evaluate</h1>
<p>Roadmap 2.4, the spine of the release. Four commits, each gating on its own.</p>
<p>Rules can now match against what a command actually TOUCHES rather than how it
was spelled, and the starter policy ships one rule using it. The fourth commit
fixes a pre-existing bug that CI surfaced along the way.</p>
<h2>The gap this closes</h2>
<p><code>&gt; .env</code> and <code>&gt; ./.env</code> are the same file and different strings. The starter
policy's two string rules caught the first and missed the second for four
releases (known-limitations 0.2, pinned as a failing-on-fix test since v0.12).
No number of added patterns fixes that class - the next spelling is always one
edit away.</p>

command | before | after
-- | -- | --
cat /dev/null > .env | deny | deny
cat /dev/null > ./.env | allow | deny
cat /dev/null > ./sub/../.env | allow | deny


<p><code>cargo fmt --check</code> clean and <code>cargo clippy --all-targets</code> silent on both.
Windows gains fewer because the symlink regression test is unix-only.</p>
<p>Quote 403/354, never one figure: the four <code>#![cfg(unix)]</code> integration files
still run zero tests on Windows (roadmap 1.6, open).</p>
<h2>Follow-up, not in this PR</h2>
<p><code>known-limitations.md</code> 0.2 can close. The extractor-scope limit and the Windows
short-name gap should be recorded alongside it. Both belong in the docs pass
with the other outstanding updates.</p></body></html><!--EndFragment-->
</body>
</html>