### PR TITLE
fix: the as-written test read ambient HOME without the lock that guards it

### DIFF
--- a/src/delete.rs
+++ b/src/delete.rs
@@ -1092,7 +1092,23 @@ mod tests {
 
     #[test]
     fn the_as_written_line_appears_only_when_resolution_changed_something() {
-        let tmp = TempTree::new("del-written");
+        // TestEnv, not TempTree: the `~` leg below reads HOME/USERPROFILE
+        // through `home_dir()`, and `HomeGuard` (used by two tests in this
+        // module) removes USERPROFILE and rewrites HOME process-globally.
+        // Reading ambient env without the lock those writers hold is a race:
+        // when it lost, `~` did not expand and the target became
+        // `<cwd>/~/some-home-target`. Green on three CI runners as a pull
+        // request, red on windows-latest for the identical commit as a push -
+        // scheduling, not code.
+        //
+        // HOME is then set explicitly rather than trusted, so the assertion
+        // depends on a value this test controls instead of on whatever the
+        // machine happens to export. #18: the isolated way is the only way.
+        let env = TestEnv::new("del-written");
+        let home = env.root().join("home");
+        std::fs::create_dir_all(&home).expect("home must be creatable");
+        let _guard = HomeGuard::set(Some(&home));
+        let tmp = TempTree::new("del-written-tree");
         let dir = tmp.dir("target");
 
         // An absolute path resolves to itself, and echoing it back twice is


### PR DESCRIPTION
Red on windows-latest on main. Green on all three runners for the IDENTICAL commit as a pull request an hour earlier - scheduling, not code.

the_as_written_line_appears_only_when_resolution_changed_something asserts that `~/some-home-target` expands, which reads HOME/USERPROFILE through home_dir(). Two tests in the same module use HomeGuard, which removes USERPROFILE and rewrites HOME process-globally; its own comment says every caller holds TestEnv's lock. This test held TempTree, which takes no lock, so a concurrent HomeGuard could blank the environment underneath it mid-run.

Mechanism proved deterministically rather than by waiting for the scheduler: blank HOME and USERPROFILE, then resolve the same input, and the tilde stays literal -

  with HOME blanked, ~/some-home-target -> /tmp/proj/~/some-home-target

which is the same shape as the CI failure,
D:\a\termaxa\termaxa\~\some-home-target.

Worth recording that the obvious verification did NOT work: 20 runs of the three env-touching tests together passed WITH the fix and also passed WITHOUT it, on Linux. A passing run on a machine where the race does not reproduce is not evidence, and treating it as evidence is how this reached main. The forced-condition probe is the measurement that actually discriminates.

The fix takes the lock the writers take, and sets HOME explicitly instead of trusting whatever the machine exports - so the assertion depends on a value the test controls. #18: the isolated way is the only way. This race predates the resolve work; the new tests changed the interleaving enough to expose it.

Suite: 403 on Linux, unchanged.