### PR TITLE
v0.16 follow-ups: say which effect, and stop reading switches as files

### DIFF
--- a/src/delete.rs
+++ b/src/delete.rs
@@ -238,6 +238,14 @@ pub fn is_flag(head: &str, token: &str) -> bool {
         // two-character token (`/s`, `/q`) or an attribute selector
         // (`/a:h`). Anything longer is a path.
         "del" | "rd" | "rmdir" => token.starts_with('-') || is_cmd_switch(token),
+        // cmd-family copy/move: /Y /D /Z are switches, same shape rule and
+        // the same reason it must be a SHAPE rule - `copy /Y a b` on a Unix
+        // box would otherwise keep `/Y` and lose nothing, but `cp /etc/x y`
+        // must keep `/etc/x`. Added in v0.16 when the target extractor
+        // reported `/Y` as a file: harmless for `copy /Y a b`, but
+        // `copy /Y .env` then read `.env` as the DESTINATION, denying a
+        // command that only copies from it.
+        "copy" | "move" | "xcopy" | "robocopy" => token.starts_with('-') || is_cmd_switch(token),
         _ => token.starts_with('-'),
     }
 }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -361,7 +361,7 @@ impl Policy {
         // A `match_path` rule fires if ANY target matches, and the reason
         // names which one: a command with several targets is one command, and
         // the human approving it needs to know which path tripped the gate.
-        let mut path_hit: Option<(usize, &Rule, String)> = None;
+        let mut path_hit: Option<(usize, &Rule, String, crate::resolve::TargetRole)> = None;
         for (idx, rule) in self.rules.iter().enumerate() {
             if rule.match_path.is_none() {
                 continue;
@@ -382,13 +382,13 @@ impl Policy {
                 if rule.matches_path(&p.display().to_string()) {
                     let better = match &path_hit {
                         None => true,
-                        Some((bi, br, _)) => {
+                        Some((bi, br, _, _)) => {
                             severity(rule.action) > severity(br.action)
                                 || (severity(rule.action) == severity(br.action) && idx < *bi)
                         }
                     };
                     if better {
-                        path_hit = Some((idx, rule, t.display()));
+                        path_hit = Some((idx, rule, t.display(), t.role));
                     }
                     break;
                 }
@@ -405,13 +405,21 @@ impl Policy {
             .find(|t| t.is_unresolved() && !t.shapes.is_empty());
 
         match (path_hit, shape_deny) {
-            (Some((_, rule, target)), _) if rule.action == Action::Deny => {
+            (Some((_, rule, target, role)), _) if rule.action == Action::Deny => {
                 return Decision {
                     action: rule.action,
                     matched_rule: Some(rule.label()),
+                    // The role is in the sentence, not just in the type. A
+                    // move that reported "overwriting .env" was correct in
+                    // its verdict and wrong in its explanation: `mv` does not
+                    // overwrite the source, it REMOVES it. The rule's reason
+                    // is written for one case; the role says which case this
+                    // actually is, and a human approving a prompt should not
+                    // have to know that the two can differ.
                     reason: format!(
-                        "target `{}` — {}",
+                        "target `{}` ({}) — {}",
                         target,
+                        role.effect(),
                         rule.reason.clone().unwrap_or_else(|| format!(
                             "matched path rule `{}`",
                             rule.match_path.clone().unwrap_or_default()
@@ -1361,6 +1369,37 @@ mod combined_gate_tests {
                 .any(|r| r.r#match.is_none() && r.match_path.is_some()),
             "the starter policy should exercise the path-only shape it ships"
         );
+    }
+
+    /// The reason line names the ROLE, because the verdict and the
+    /// explanation were diverging: `mv .env dst` denied with "Overwriting
+    /// .env destroys credentials", and `mv` does not overwrite `.env` - it
+    /// REMOVES it. The rule's reason text is written for one case; the role
+    /// says which case this actually is. A human approving a prompt should
+    /// not have to know those can differ.
+    #[test]
+    fn the_reason_names_what_the_command_does_to_the_target() {
+        let p = Policy::builtin().unwrap();
+
+        let moved = p.evaluate_command("mv .env /tmp/archive/", &here());
+        assert_eq!(moved.action, Action::Deny);
+        assert!(
+            moved.reason.contains("(removed)"),
+            "a move removes its source, and the sentence should say so: {}",
+            moved.reason
+        );
+
+        let written = p.evaluate_command("cp backup.txt .env", &here());
+        assert_eq!(written.action, Action::Deny);
+        assert!(
+            written.reason.contains("(written)"),
+            "a copy writes its destination: {}",
+            written.reason
+        );
+
+        // Both still name the target itself - the role is an addition, not a
+        // replacement.
+        assert!(moved.reason.contains(".env") && written.reason.contains(".env"));
     }
 
     /// Roadmap 2.1: a path rule fires on roles that CHANGE a file, not on

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -156,6 +156,18 @@ impl TargetRole {
     /// Does this role mean something existing is at risk? `Source` is the
     /// only one that is not, which is why an extractor that reports every
     /// path-looking argument produces false positives on reads.
+    /// What this command does to the path, phrased to sit inside a reason
+    /// line: "target `x` (removed) — ...". Only destructive roles ever reach
+    /// a reason line, so Source has no natural phrasing here and says what it
+    /// is rather than inventing one.
+    pub fn effect(self) -> &'static str {
+        match self {
+            TargetRole::Source => "read",
+            TargetRole::Destination => "written",
+            TargetRole::Removed => "removed",
+        }
+    }
+
     pub fn is_destructive(self) -> bool {
         matches!(self, TargetRole::Destination | TargetRole::Removed)
     }
@@ -243,8 +255,8 @@ pub fn command_targets(segment: &str, ctx: &EvalContext) -> Vec<ResolvedTarget> 
         };
         let args = &tokens[at + 1..];
         match head.as_str() {
-            "cp" | "copy" => out.extend(copy_move_targets(args, TargetRole::Source)),
-            "mv" | "move" => out.extend(copy_move_targets(args, TargetRole::Removed)),
+            "cp" | "copy" => out.extend(copy_move_targets(&head, args, TargetRole::Source)),
+            "mv" | "move" => out.extend(copy_move_targets(&head, args, TargetRole::Removed)),
             "tee" => out.extend(tee_targets(args)),
             "dd" => out.extend(dd_targets(args)),
             _ => {}
@@ -270,7 +282,11 @@ pub fn command_targets(segment: &str, ctx: &EvalContext) -> Vec<ResolvedTarget> 
 /// `-S`/`--suffix` consume the next token; everything else starting with `-`
 /// is a boolean. Getting this wrong makes a flag's VALUE read as a path, so
 /// the list is short and explicit rather than clever.
-fn copy_move_targets(args: &[String], source_role: TargetRole) -> Vec<(String, TargetRole)> {
+fn copy_move_targets(
+    head: &str,
+    args: &[String],
+    source_role: TargetRole,
+) -> Vec<(String, TargetRole)> {
     let mut operands: Vec<String> = Vec::new();
     let mut explicit_dir: Option<String> = None;
     let mut i = 0;
@@ -283,8 +299,11 @@ fn copy_move_targets(args: &[String], source_role: TargetRole) -> Vec<(String, T
             i += 1;
         } else if a == "-S" || a == "--suffix" {
             i += 1; // consumes its value, which is not a path
-        } else if a.starts_with('-') && a.len() > 1 {
-            // boolean flag
+        } else if crate::delete::is_flag(head, a) && a.len() > 1 {
+            // A boolean switch in this command's own syntax: `-r` for cp,
+            // `/Y` for copy. Asked of `delete::is_flag` rather than answered
+            // here, so the two modules cannot come to disagree about what a
+            // switch looks like (#37).
         } else {
             operands.push(a.clone());
         }
@@ -522,6 +541,57 @@ mod tests {
                 ("b".into(), TargetRole::Destination),
             ],
             "-S consumes .bak, which must not read as an operand"
+        );
+    }
+
+    /// cmd.exe switches are switches, not files. Measured before the fix:
+    /// `copy /Y backup.txt .env` reported `/Y` as a Source, and worse,
+    /// `copy /Y .env` reported `.env` as the DESTINATION - `/Y` filled the
+    /// source slot, so a command that only copies FROM .env would have
+    /// denied as if it wrote to it.
+    ///
+    /// Answered by `delete::is_flag`, which already decides this per command
+    /// and per shell, rather than by a second rule here (#37).
+    #[test]
+    fn a_cmd_switch_is_not_an_operand() {
+        assert_eq!(
+            roles("copy /Y backup.txt .env"),
+            vec![
+                (".env".into(), TargetRole::Destination),
+                ("backup.txt".into(), TargetRole::Source),
+            ]
+        );
+        assert_eq!(
+            roles("move /Y a b"),
+            vec![
+                ("a".into(), TargetRole::Removed),
+                ("b".into(), TargetRole::Destination),
+            ]
+        );
+        // One real operand names no destination, switches notwithstanding.
+        assert!(
+            roles("copy /Y .env").is_empty(),
+            "a switch must not fill the source slot and promote .env"
+        );
+        assert_eq!(
+            roles("copy /Y /Z a b"),
+            vec![
+                ("a".into(), TargetRole::Source),
+                ("b".into(), TargetRole::Destination),
+            ]
+        );
+
+        // CONTROL LEG, and the reason the rule matches SHAPE rather than a
+        // leading slash: on Unix an absolute path starts with one too, and
+        // losing it would be a silent under-report on the platform where
+        // `/etc` matters most.
+        assert_eq!(
+            roles("cp /etc/hosts backup"),
+            vec![
+                ("/etc/hosts".into(), TargetRole::Source),
+                ("backup".into(), TargetRole::Destination),
+            ],
+            "an absolute path is not a switch"
         );
     }
 


### PR DESCRIPTION
Two small corrections to 2.1, both about the extractor telling the truth.

## The reason line names the role

`mv .env /tmp/archive/` denied with *"Overwriting .env destroys credentials
that are not in the repo"* — correct verdict, wrong sentence. A move does not
overwrite its source; it **removes** it. The rule's reason text is written for
one case, and the role says which case this actually is. Reason lines now read:

  target `C:\Users\User\proj\.env` (removed) - Overwriting .env destroys...
  target `C:\Users\User\proj\.env` (written) - Overwriting .env destroys...

The role was already in the type; it just was not in the sentence the human
reads before approving. A prompt that requires knowing the verdict and the
explanation can diverge is not doing its job.

## cmd.exe switches are not files

The `cp`/`mv` grammar checked for a leading `-`, so cmd-family switches became
operands. Measured before the fix:

| command | extracted |
|---|---|
| `copy /Y backup.txt .env` | `/Y` as a **Source** |
| `move /Y a b` | `/Y` as **Removed** — a switch reported as a file destroyed |
| `copy /Y .env` | `.env` as the **Destination** |

The third is the real bug: `/Y` filled the source slot, so a command that only
copies **from** `.env` read as one that writes **to** it, and denied. Same
false-positive family as PR #27, third appearance. The other two are fabricated
entries in a target list, which is how a fabricated verdict starts.

Answered by `delete::is_flag`, which already decides this per command and per
shell, rather than by a second rule in the extractor (#37). That brings its
shape-matching with it, and the control leg proves why the rule cannot simply be
"starts with a slash":

  cp /etc/hosts backup  ->  /etc/hosts stays a Source

On Unix an absolute path starts with a slash too, and losing it would be a
silent under-report on the platform where `/etc` matters most. `delete.rs`
learned that from CI in an earlier release; reusing the function inherits the
lesson instead of repeating it.

`xcopy` and `robocopy` are now known to `is_flag` but still have no grammar of
their own, so they extract nothing. Better than extracting the wrong thing;
still a gap, and it belongs with the rest of known-limitations 0.9.

## Gate

| | before | after |
|---|---|---|
| Linux | 414 | 416 |
| Windows | 365 | 367 |

`cargo fmt --check` clean and `cargo clippy --all-targets` silent on both.