### PR TITLE
v0.16 (roadmap 2.5): uninsurability strengthens a concern, never invents one

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use crate::policy::{Action, Decision};
+use crate::policy::{Action, Decision, DecisionSource};
 use std::process::Command;
 
 /// A signal the context engine noticed about the environment or the command.
@@ -73,6 +73,61 @@ pub fn gather(command: &str) -> Vec<Signal> {
 /// Escalation ladder: allow -> ask. `ask` and `deny` are never escalated further
 /// (a human is already in the loop, or it's already blocked), and context never
 /// downgrades a decision.
+/// Uninsurability AMPLIFIES an existing concern; it never creates one.
+///
+/// Roadmap 2.5. The preview has known since v0.13 whether a command destroys
+/// something the backup engine cannot copy aside first, and nothing could act
+/// on it - the strongest unused signal in the product.
+///
+/// The rule is `uninsurable + Ask -> Deny`, NOT `uninsurable -> Deny`, and the
+/// difference is the whole design. Measured on a realistic tree before writing
+/// this: `rm -rf node_modules` (9,330 files) exceeds the 5,000-file copy
+/// budget and reads as uninsurable. It is also the most routine destructive
+/// command in JavaScript work, and it destroys nothing that `npm install`
+/// cannot rebuild. A gate that denies it out of the box gets uninstalled, and
+/// the user who uninstalls it loses protection against the commands that
+/// actually matter (#48).
+///
+/// So uninsurability is a risk AMPLIFIER, not a risk signal. Something else -
+/// a policy rule, a context signal, the default - has to have already said
+/// "this is worth stopping for". Then uninsurability decides whether asking is
+/// safe, because an ask a human approves on a command with no net is a
+/// decision made without the fact that matters most.
+///
+/// This also means no regenerable-directory heuristic is needed. The existing
+/// signals establish concern; `rm -rf ~/Documents` is already Ask because it
+/// resolves to a user profile, and becomes Deny here. `rm -rf node_modules`
+/// has no other concern and keeps whatever verdict it had.
+pub fn apply_insurance(decision: Decision, uninsurable: bool) -> (Decision, bool) {
+    // The amplifier may STRENGTHEN an existing safety concern; it does not
+    // create one from an otherwise-unmatched command.
+    //
+    // `DecisionSource::Default` is the absence of an opinion, not a weak
+    // opinion, and the two are semantically different rather than different
+    // strengths of the same thing. Without this clause, a `default: ask`
+    // policy - which the starter policy is - turned every unmatched
+    // uninsurable command into a deny, including `rm -r node_modules`. That
+    // is `uninsurable -> deny` under another name, and it is the posture this
+    // design exists to avoid (#48).
+    let concerned = decision.source != DecisionSource::Default;
+    if uninsurable && concerned && decision.action == Action::Ask {
+        return (
+            Decision {
+                action: Action::Deny,
+                source: decision.source,
+                matched_rule: decision.matched_rule,
+                reason: format!(
+                    "{} — and nothing can be recovered afterwards, so this is \
+                     refused rather than asked",
+                    decision.reason
+                ),
+            },
+            true,
+        );
+    }
+    (decision, false)
+}
+
 pub fn apply(decision: Decision, signals: &[Signal]) -> (Decision, bool) {
     let should_escalate = signals.iter().any(|s| s.escalate);
     if should_escalate && decision.action == Action::Allow {
@@ -84,6 +139,10 @@ pub fn apply(decision: Decision, signals: &[Signal]) -> (Decision, bool) {
         return (
             Decision {
                 action: Action::Ask,
+                // A context signal CHOSE this ask; it is not the absence of
+                // an opinion. That distinction is what lets the insurance
+                // amplifier fire here but not on an unmatched command.
+                source: DecisionSource::Context,
                 matched_rule: decision.matched_rule,
                 reason: format!(
                     "{} — escalated to ask by context: {}",
@@ -116,6 +175,90 @@ fn current_git_branch() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn dec(action: Action, source: DecisionSource) -> Decision {
+        Decision {
+            action,
+            source,
+            matched_rule: None,
+            reason: "because".into(),
+        }
+    }
+
+    /// THE PRECEDENCE, pinned in every direction so it cannot be misread.
+    ///
+    /// The amplifier may STRENGTHEN an existing safety concern; it does not
+    /// create one from an otherwise-unmatched command.
+    ///
+    /// Measured before this was written: `rm -rf node_modules` (9,330 files)
+    /// exceeds the 5,000-file copy budget and reads as uninsurable. It is
+    /// also routine, and destroys nothing `npm install` cannot rebuild. The
+    /// first draft fired on any Ask, which under a `default: ask` policy
+    /// denied it - `uninsurable -> deny` under another name (#48).
+    #[test]
+    fn uninsurability_strengthens_a_concern_and_never_invents_one() {
+        // 1. Unmatched + default Ask + uninsurable -> Ask.
+        //    `rm -r node_modules`. The default is the ABSENCE of an opinion,
+        //    not a weak one, and nothing has said this is worth stopping for.
+        let (d, esc) = apply_insurance(dec(Action::Ask, DecisionSource::Default), true);
+        assert_eq!(
+            d.action,
+            Action::Ask,
+            "an unmatched command is not a concern"
+        );
+        assert!(!esc);
+
+        // 2. Explicit Ask + uninsurable -> Deny. A rule chose to stop here;
+        //    uninsurability says asking is not safe, because a human
+        //    approving a command with no net decides without the fact that
+        //    matters most.
+        let (d, esc) = apply_insurance(dec(Action::Ask, DecisionSource::ExplicitRule), true);
+        assert_eq!(d.action, Action::Deny);
+        assert!(esc, "the escalation must be reported, not silent");
+        assert!(
+            d.reason.contains("nothing can be recovered"),
+            "{}",
+            d.reason
+        );
+
+        // 3. Context-escalated Ask + uninsurable -> Deny. `rm -rf ~/Documents`
+        //    is Ask because it resolves to a user profile - a signal, not a
+        //    shrug.
+        let (d, esc) = apply_insurance(dec(Action::Ask, DecisionSource::Context), true);
+        assert_eq!(d.action, Action::Deny);
+        assert!(esc);
+
+        // 4. Explicit Allow + uninsurable -> Allow. The escape hatch holds:
+        //    an operator who wrote the rule outranks the amplifier.
+        for src in [DecisionSource::ExplicitRule, DecisionSource::Context] {
+            let (d, esc) = apply_insurance(dec(Action::Allow, src), true);
+            assert_eq!(d.action, Action::Allow, "an explicit allow is unchanged");
+            assert!(!esc);
+        }
+
+        // 5. Existing Deny + uninsurable -> Deny, and NOT re-escalated: a
+        //    second amplification would double the reason and claim a change
+        //    that did not happen.
+        let base = dec(Action::Deny, DecisionSource::ExplicitRule);
+        let (d, esc) = apply_insurance(base.clone(), true);
+        assert_eq!(d.action, Action::Deny);
+        assert!(!esc);
+        assert_eq!(d.reason, base.reason, "an existing deny is left alone");
+
+        // CONTROL LEG: with insurance available, nothing moves at all - so a
+        // failure above is about the amplifier, not about the plumbing.
+        for src in [
+            DecisionSource::Default,
+            DecisionSource::ExplicitRule,
+            DecisionSource::Context,
+        ] {
+            for act in [Action::Allow, Action::Ask, Action::Deny] {
+                let (d, esc) = apply_insurance(dec(act, src), false);
+                assert_eq!(d.action, act, "insured commands are untouched");
+                assert!(!esc);
+            }
+        }
+    }
 
     use crate::testutil::TestEnv;
     use std::path::{Path, PathBuf};
@@ -263,6 +406,7 @@ mod tests {
     fn decision(action: Action) -> Decision {
         Decision {
             action,
+            source: DecisionSource::ExplicitRule,
             matched_rule: Some("rule".into()),
             reason: "base".into(),
         }

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -65,6 +65,9 @@ pub fn preview_for(command: &str, project_root: Option<&Path>, cwd: &Path) -> Op
     let mut lines = Vec::new();
     let mut summary_parts: Vec<String> = Vec::new();
     let mut worst_first: Vec<String> = Vec::new();
+    // Roadmap 2.5: whether anything here is beyond the reach of insurance.
+    // Computed while the preview walks its targets; reported, not acted on.
+    let mut uninsurable = false;
 
     for raw in targets.iter().take(3) {
         let resolved = resolve_path_in(raw, cwd);
@@ -146,11 +149,13 @@ pub fn preview_for(command: &str, project_root: Option<&Path>, cwd: &Path) -> Op
                     fmt_num(MAX_FILES)
                 ));
                 worst_first.push("NOT recoverable".into());
+                uninsurable = true;
             }
             None => {
                 lines
                     .push("  ✗ insurance : no backup covers this command — NOT recoverable".into());
                 worst_first.push("NOT recoverable".into());
+                uninsurable = true;
             }
         }
 
@@ -172,6 +177,7 @@ pub fn preview_for(command: &str, project_root: Option<&Path>, cwd: &Path) -> Op
         title: "delete impact".into(),
         lines,
         summary,
+        uninsurable,
     })
 }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -438,6 +438,12 @@ fn hook_live(settings: &Path, dir: &Path) -> (HookState, Option<bool>) {
     // reported as its own softer diagnostic.
     match invoke(&cmd, &payload, dir, PROBE_TIMEOUT) {
         Some(out) => match parse_probe_decision(&out) {
+            // The probe's verdict is the POLICY's verdict: the hook exempts
+            // probes from the insurance amplifier, precisely so this question
+            // stays answerable. Doctor asks "does the configured policy deny
+            // anything", not "can the enforcement stack stop this command" -
+            // conflating them would make a policy with no rules look
+            // protective (roadmap 2.5).
             Some(decision) => {
                 let denies = decision == "deny";
                 (HookState::Live, Some(denies))

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -602,6 +602,10 @@ pub fn run() -> Result<()> {
         ) {
             decision = crate::policy::Decision {
                 action: Action::Deny,
+                // The breaker chose this deliberately, from history rather
+                // than from a rule - a Context decision in the sense that
+                // matters here: something formed an opinion.
+                source: crate::policy::DecisionSource::Context,
                 matched_rule: Some(crate::intent::BREAKER_RULE.to_string()),
                 reason,
             };
@@ -611,17 +615,44 @@ pub fn run() -> Result<()> {
     // Pass the project root so the delete preview can answer "is this target
     // outside the project?" — the process cwd can't supply it, because the
     // agent may spawn us from anywhere (the Cursor cwd bug).
-    let preview_summary = {
+    let (preview_summary, uninsurable) = {
         // A denied command must not cause a subprocess. The preview is still
         // generated — statically — so the denial reason keeps its detail.
         let live = decision.action != crate::policy::Action::Deny;
-        crate::preview::generate(
+        match crate::preview::generate(
             &command,
             paths.project_dir.parent(),
             std::path::Path::new(&input.cwd),
             live,
-        )
-        .map(|p| p.summary)
+        ) {
+            Some(p) => (Some(p.summary), p.uninsurable),
+            None => (None, false),
+        }
+    };
+
+    // Probe mode requires BOTH the env var and the sentinel session id — see
+    // the note at the audit-suppression site below for why. Computed here
+    // because the insurance amplifier needs it.
+    let is_probe = std::env::var("TERMAXA_HOOK_PROBE").as_deref() == Ok("1")
+        && input.session.as_deref() == Some(PROBE_SESSION);
+
+    // Roadmap 2.5: an ask on a command with no net becomes a deny. Applied
+    // after context escalation, so a signal that raised allow->ask can then
+    // be amplified to deny by uninsurability - the two compose in the order
+    // they are meant to: is this concerning, and if so, is asking safe?
+    //
+    // NOT for a probe. `doctor` asks "does the configured POLICY deny
+    // anything", which is a different question from "can the enforcement
+    // stack stop this command". Amplifying the probe would answer the second
+    // and print the first: a policy with no rules at all would look
+    // protective, because `rm -rf /` is uninsurable and the default is ask.
+    // That misreading gets worse with every safeguard added later, so the
+    // probe sees the policy verdict and enforcement sees the amplified one.
+    // One reader, two questions, answered separately (#37).
+    let (decision, uninsured_escalation) = if is_probe {
+        (decision, false)
+    } else {
+        crate::context::apply_insurance(decision, uninsurable)
     };
 
     // Insure before allowing: PreToolUse runs before execution, so a backup
@@ -644,9 +675,6 @@ pub fn run() -> Result<()> {
     // the sentinel session id, and `doctor` is the only thing that sends the
     // sentinel. An agent command cannot set its harness's env; a leaked env
     // var without the sentinel changes nothing.
-    let is_probe = std::env::var("TERMAXA_HOOK_PROBE").as_deref() == Ok("1")
-        && input.session.as_deref() == Some(PROBE_SESSION);
-
     let mut backup_id: Option<String> = None;
     if !is_probe && decision.action != Action::Deny {
         if let Ok(Some(rec)) =
@@ -670,7 +698,7 @@ pub fn run() -> Result<()> {
                 matched_rule: decision.matched_rule.clone(),
                 reason: decision.reason.clone(),
                 signals: signals.iter().map(|s| s.label.clone()).collect(),
-                escalated,
+                escalated: escalated || uninsured_escalation,
                 session: input.session.clone(),
                 backup: backup_id.clone(),
                 preview: preview_summary.clone(),
@@ -703,7 +731,12 @@ pub fn run() -> Result<()> {
     };
 
     let mut reason = format!("[termaxa] {}", decision.reason);
-    if escalated {
+    if uninsured_escalation {
+        // Named distinctly from context escalation: the record should say
+        // WHICH amplifier fired, or a later reader cannot tell a signal-driven
+        // ask from an uninsurable-driven deny.
+        reason.push_str(" (uninsurable — escalated to deny)");
+    } else if escalated {
         reason.push_str(" (context-escalated)");
     }
     if matches!(decision.action, Action::Ask | Action::Deny) {
@@ -758,11 +791,15 @@ mod tests {
 
         let no_opinion = Decision {
             action: Action::Allow,
+            // The typed form of the distinction this test already drew by
+            // hand: `Default` IS "no opinion" (v0.16, roadmap 2.5).
+            source: crate::policy::DecisionSource::Default,
             matched_rule: None,
             reason: "no rule matched; policy default is `allow`".into(),
         };
         let deliberate = Decision {
             action: Action::Allow,
+            source: crate::policy::DecisionSource::ExplicitRule,
             matched_rule: Some("git status*".into()),
             reason: "matched rule `git status*`".into(),
         };
@@ -788,6 +825,7 @@ mod tests {
         for action in [Action::Ask, Action::Deny] {
             let d = Decision {
                 action,
+                source: crate::policy::DecisionSource::Default,
                 matched_rule: None,
                 reason: "default".into(),
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,22 @@ fn dispatch(cli: Cli) -> Result<i32> {
             let signals = context::gather(&cmd);
             let (decision, escalated) = context::apply(base, &signals);
 
+            let root = resolved.as_ref().and_then(|p| p.project_dir.parent());
+            // The preview is generated BEFORE the decision is printed, because
+            // it carries the fact the insurance amplifier needs (roadmap 2.5).
+            // Printing first and amplifying after would show one verdict and
+            // enforce another - the shape of bug this release keeps finding.
+            let check_cwd =
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let pv = preview::generate(
+                &cmd,
+                root,
+                &check_cwd,
+                decision.action != policy::Action::Deny,
+            );
+            let uninsurable = pv.as_ref().is_some_and(|p| p.uninsurable);
+            let (decision, uninsured_escalation) = context::apply_insurance(decision, uninsurable);
+
             println!();
             println!("{}", ui::field("command", &cmd));
             println!(
@@ -216,6 +232,12 @@ fn dispatch(cli: Cli) -> Result<i32> {
                 };
                 println!("{}", ui::field("context", &ui::dim(&line)));
             }
+            if uninsured_escalation {
+                println!(
+                    "{}",
+                    ui::field("note", &ui::amber("uninsurable — escalated ask → deny"))
+                );
+            }
             if escalated {
                 println!(
                     "{}",
@@ -224,18 +246,7 @@ fn dispatch(cli: Cli) -> Result<i32> {
             }
 
             let mut preview_summary = None;
-            let root = resolved.as_ref().and_then(|p| p.project_dir.parent());
-            // `check` runs in the user's own shell, so the process cwd IS the
-            // base the command would resolve against — threaded explicitly so
-            // that reasoning is visible rather than ambient (v0.16 item 1).
-            let check_cwd =
-                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-            if let Some(pv) = preview::generate(
-                &cmd,
-                root,
-                &check_cwd,
-                decision.action != policy::Action::Deny,
-            ) {
+            if let Some(pv) = pv {
                 println!("\n{}", ui::bold(&pv.title));
                 for l in &pv.lines {
                     println!("{}", l);
@@ -255,7 +266,7 @@ fn dispatch(cli: Cli) -> Result<i32> {
                 matched_rule: decision.matched_rule.clone(),
                 reason: decision.reason.clone(),
                 signals: signals.iter().map(|s| s.label.clone()).collect(),
-                escalated,
+                escalated: escalated || uninsured_escalation,
                 session: None,
                 backup: None,
                 preview: preview_summary,

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -147,6 +147,10 @@ pub fn preview_for(command: &str, cwd: &std::path::Path, live: bool) -> Option<P
         }
     }
 
+    // Roadmap 2.5: the same question the delete preview asks, and it already
+    // had the answer - `plan` returning None IS uninsurable, and the line
+    // below has said so since v0.13 without anything able to act on it.
+    let uninsurable = crate::backup::plan(command, cwd).is_none();
     match crate::backup::plan(command, cwd) {
         Some(plan) => lines.push(format!("  insurance : {} (automatic on run/hook)", plan)),
         None => lines.push("  insurance : none — not reversible without a backup".into()),
@@ -160,6 +164,7 @@ pub fn preview_for(command: &str, cwd: &std::path::Path, live: bool) -> Option<P
         title: "postgres impact".into(),
         lines,
         summary: summary_parts.join("; "),
+        uninsurable,
     })
 }
 

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -195,6 +195,35 @@ pub struct Decision {
     pub action: Action,
     pub matched_rule: Option<String>,
     pub reason: String,
+    /// WHY this verdict, not just what it is.
+    ///
+    /// Roadmap 2.5. `Ask` from an explicit rule and `Ask` from an unmatched
+    /// command are not different strengths of the same thing - they are
+    /// different statements. The first says "stop and think about this"; the
+    /// second says "I have no opinion". Treating them alike made the
+    /// insurance amplifier fire on every unmatched command under a
+    /// `default: ask` policy, which is `uninsurable -> deny` wearing a
+    /// different name.
+    pub source: DecisionSource,
+}
+
+/// Where a verdict came from.
+///
+/// Carried rather than collapsed, for the same reason `ResolvedTarget` keeps
+/// its role: a downstream layer reasoning about a decision needs to know what
+/// kind of statement it is, and re-deriving that from the reason string would
+/// be parsing prose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DecisionSource {
+    /// No rule matched; this is the policy's default, i.e. the absence of an
+    /// opinion about this command.
+    #[default]
+    Default,
+    /// A rule matched and chose this action deliberately.
+    ExplicitRule,
+    /// A context signal raised the verdict - a production marker, a user
+    /// profile target, command substitution.
+    Context,
 }
 
 /// Every path this segment touches, resolved once: the redirect targets the
@@ -310,6 +339,10 @@ impl Policy {
         let (i, d) = worst.expect("segments nonempty");
         Decision {
             action: d.action,
+            // The compound's verdict is the worst segment's verdict, so it
+            // inherits that segment's source too - a compound denied because
+            // one segment matched a rule is still an explicit-rule decision.
+            source: d.source,
             matched_rule: d.matched_rule,
             reason: format!(
                 "segment {}/{} `{}` — {}",
@@ -408,6 +441,7 @@ impl Policy {
             (Some((_, rule, target, role)), _) if rule.action == Action::Deny => {
                 return Decision {
                     action: rule.action,
+                    source: DecisionSource::ExplicitRule,
                     matched_rule: Some(rule.label()),
                     // The role is in the sentence, not just in the type. A
                     // move that reported "overwriting .env" was correct in
@@ -442,6 +476,7 @@ impl Policy {
                 if base_sev < severity(Action::Deny) && base_sev > severity(Action::Allow) {
                     return Decision {
                         action: Action::Deny,
+                        source: DecisionSource::Context,
                         matched_rule: None,
                         reason: format!(
                             "target `{}` cannot be resolved and {} — refusing rather than \
@@ -457,6 +492,7 @@ impl Policy {
         match best {
             Some((_, rule)) => Decision {
                 action: rule.action,
+                source: DecisionSource::ExplicitRule,
                 matched_rule: Some(rule.label()),
                 reason: rule
                     .reason
@@ -466,6 +502,7 @@ impl Policy {
             None => Decision {
                 action: self.default,
                 matched_rule: None,
+                source: DecisionSource::Default,
                 reason: format!("no rule matched; policy default is `{}`", self.default),
             },
         }

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -14,6 +14,15 @@ pub struct Preview {
     pub lines: Vec<String>,
     /// One-line summary, embedded in the hook reason for Claude Code prompts.
     pub summary: String,
+    /// True when this command destroys something the backup engine cannot
+    /// copy aside first - either no backup covers the command, or the target
+    /// exceeds the copy budget.
+    ///
+    /// Roadmap 2.5. The preview has computed this since v0.13 and printed it
+    /// ("NOT recoverable"), but nothing could ACT on it: the strongest
+    /// unused signal in the product. Carried as a fact here so the decision
+    /// layer can amplify with it, without the preview deciding anything.
+    pub uninsurable: bool,
 }
 
 /// Generate a preview, optionally with knowledge of the project root.
@@ -109,6 +118,10 @@ fn git_push_preview(command: &str) -> Option<Preview> {
             // Case 3: nothing on the remote to compare against.
             let count = git(&["rev-list", "--count", "HEAD"])?;
             return Some(Preview {
+                // A push is insured by pinning the remote ref before it runs
+                // (`backup::plan` covers forced pushes), and a brand-new
+                // branch destroys nothing on the remote in any case.
+                uninsurable: false,
                 title: format!("push preview ({} -> new remote branch)", branch),
                 lines: vec![format!(
                     "entire branch is new to the remote: {} commit(s)",
@@ -144,6 +157,8 @@ fn git_push_preview(command: &str) -> Option<Preview> {
 
     if count == 0 && loss_count == 0 {
         return Some(Preview {
+            // Nothing to push destroys nothing.
+            uninsurable: false,
             title: format!("push preview ({} -> {})", branch, baseline),
             lines: vec!["nothing to push — remote is up to date".to_string()],
             summary: "nothing to push".to_string(),
@@ -186,6 +201,10 @@ fn git_push_preview(command: &str) -> Option<Preview> {
         summary = format!("remote LOSES {} commit(s); {}", loss_count, summary);
     }
     Some(Preview {
+        // Forced pushes are insured by pinning the remote ref before the
+        // push, which `backup::plan` does. The commits the remote would lose
+        // are recoverable from that pin.
+        uninsurable: false,
         title: format!("push preview ({} -> {})", branch, baseline),
         lines,
         summary,
@@ -238,6 +257,13 @@ fn terraform_preview(bin: &str, destroy: bool) -> Option<Preview> {
     ));
 
     Some(Preview {
+        // Roadmap 2.5. `backup::plan` pins local terraform state, so a
+        // rollback can restore the STATE FILE - it cannot restore a destroyed
+        // cloud resource. When the plan destroys nothing there is nothing to
+        // insure; when it destroys something, insurance does not reach it and
+        // saying otherwise would be the most expensive lie the tool could
+        // tell.
+        uninsurable: del > 0,
         title: format!("{} plan preview", bin),
         lines,
         summary: format!("plan: +{} ~{} -{}", add, change, del),


### PR DESCRIPTION
## Measured first, on a realistic tree

| directory | files | insurable? |
|---|---|---|
| `node_modules` | 9,330 | **no** — capped at 5,000 |
| `target` | 3,000 | yes |
| `dist` | 400 | yes |
| `src` | 120 | yes |

`rm -rf node_modules` is uninsurable *and* routine. `uninsurable -> deny`
would block it out of the box, the gate gets uninstalled, and the user loses
protection against the commands that matter (#48). The cap is not a latency
problem — 17ms against a 300ms budget — it is a copy-budget boundary and it
stays.

## The precedence

| decision | source | uninsurable | result |
|---|---|---|---|
| Ask | Default (unmatched) | yes | **Ask** — `rm -r node_modules` |
| Ask | ExplicitRule | yes | **Deny** |
| Ask | Context | yes | **Deny** — `rm -rf ~/Documents` |
| Allow | any | yes | **Allow** — operator outranks it |
| Deny | any | yes | **Deny**, not re-escalated |
| any | any | no | unchanged (control leg) |

The first draft fired on any `Ask`. Since the starter policy's default *is*
ask, that denied every unmatched uninsurable command — `uninsurable -> deny`
under another name. Caught by measurement, not review.

`Decision` now carries `DecisionSource` (Default / ExplicitRule / Context).
Ask-from-a-rule and Ask-from-no-rule are different statements, not different
strengths of one — the first says "stop and think", the second says "I have
no opinion".