### PR TITLE
v0.16 (roadmap 2.6, #13): an audit chain that says what it can prove

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AuditEntry {
     /// Unix epoch milliseconds.
     pub ts_ms: u128,
@@ -43,6 +43,62 @@ pub struct AuditEntry {
     /// For "run": process exit code if the command executed.
     pub exit_code: Option<i32>,
     pub cwd: String,
+
+    // ---- hash chain (v0.16, issue #13) ----
+    //
+    // Serde-defaulted so every pre-chain line parses as None, per decision #7:
+    // the audit schema is append-only and backward compatible, and an upgrade
+    // must not make existing history unreadable.
+    /// Hash of the entry before this one, chaining the record together.
+    /// `None` on pre-chain entries and on the boundary entry itself.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prev: Option<String>,
+    /// This entry's own hash, over its content and `prev`. `None` on
+    /// pre-chain entries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+}
+
+impl AuditEntry {
+    /// The bytes this entry's hash covers: every field except `hash` itself,
+    /// in the serialized form that was actually written.
+    ///
+    /// Computed from the serialized line rather than a hand-built string, so
+    /// a field added later is covered automatically. A hand-built list is a
+    /// second place to remember, and the one that gets forgotten.
+    fn digest(&self) -> String {
+        let mut bare: AuditEntry = self.clone();
+        bare.hash = None;
+        let json = serde_json::to_string(&bare).unwrap_or_default();
+        crate::fingerprint::sha256_hex(json.as_bytes())
+    }
+
+    /// Was this entry written before the chain existed?
+    pub fn is_pre_chain(&self) -> bool {
+        self.hash.is_none()
+    }
+}
+
+/// What a verification pass found.
+///
+/// Reports rather than refuses. A log with a broken link still has a readable
+/// prefix and a readable suffix, and throwing all of it away because one line
+/// is corrupt would destroy more evidence than the corruption did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainReport {
+    /// Entries written before the chain existed. Readable, and explicitly not
+    /// vouched for - the record has two eras and says so.
+    pub pre_chain: usize,
+    /// Entries covered by an intact chain.
+    pub verified: usize,
+    /// 1-based positions where the chain does not hold.
+    pub breaks: Vec<usize>,
+}
+
+impl ChainReport {
+    pub fn is_intact(&self) -> bool {
+        self.breaks.is_empty()
+    }
 }
 
 pub struct AuditLog {
@@ -59,15 +115,100 @@ impl AuditLog {
         })
     }
 
+    /// Where this log lives. Used by tests that need to inspect or corrupt
+    /// the file directly, which is the only way to test that tampering is
+    /// detected.
+    #[cfg(test)]
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+
+    /// Append an entry, linking it to the one before it.
+    ///
+    /// The chain starts at the first entry written by a version that has one;
+    /// earlier entries keep `prev` and `hash` absent and are reported as
+    /// pre-chain rather than as broken. An upgrade does not invalidate a
+    /// record it was never able to protect.
     pub fn append(&self, entry: &AuditEntry) -> Result<()> {
+        let mut entry = entry.clone();
+        entry.prev = self.last_hash()?;
+        entry.hash = Some(entry.digest());
+
         let mut f = OpenOptions::new()
             .create(true)
             .append(true)
             .open(&self.path)
             .with_context(|| format!("cannot open {}", self.path.display()))?;
-        let line = serde_json::to_string(entry)?;
+        let line = serde_json::to_string(&entry)?;
         writeln!(f, "{}", line)?;
         Ok(())
+    }
+
+    /// The hash of the last entry, or `None` when the log is empty or its
+    /// tail predates the chain. A `None` here is what makes the first chained
+    /// entry the boundary: it has a hash of its own and no `prev`.
+    fn last_hash(&self) -> Result<Option<String>> {
+        if !self.path.exists() {
+            return Ok(None);
+        }
+        let raw = fs::read_to_string(&self.path)?;
+        Ok(raw
+            .lines()
+            .rev()
+            .find(|l| !l.trim().is_empty())
+            .and_then(|l| serde_json::from_str::<AuditEntry>(l).ok())
+            .and_then(|e| e.hash))
+    }
+
+    /// Verify the chain, reporting what holds and what does not.
+    ///
+    /// THREAT MODEL, stated here because the word "hash chain" promises more
+    /// than this delivers in basic mode: the hook writes this log as the
+    /// AGENT's own UID, so anything that can edit an entry can recompute the
+    /// chain over it. This is tamper-EVIDENT against corruption and
+    /// unsophisticated edits, not tamper-RESISTANT against a hostile process
+    /// with the same filesystem authority.
+    ///
+    /// That changes in supervised mode (v0.17), where the supervisor owns the
+    /// state directory and the agent's UID cannot reach it. The record
+    /// becomes trustworthy because the authority that writes it sits outside
+    /// the agent's trust domain - not because the hash got cleverer.
+    pub fn verify_chain(&self) -> Result<ChainReport> {
+        let mut report = ChainReport {
+            pre_chain: 0,
+            verified: 0,
+            breaks: Vec::new(),
+        };
+        if !self.path.exists() {
+            return Ok(report);
+        }
+        let raw = fs::read_to_string(&self.path)?;
+        let mut expected_prev: Option<String> = None;
+
+        for (i, line) in raw.lines().filter(|l| !l.trim().is_empty()).enumerate() {
+            let Ok(entry) = serde_json::from_str::<AuditEntry>(line) else {
+                // An unparseable line is a break, not a reason to stop: the
+                // entries after it are still readable and still chained to
+                // each other.
+                report.breaks.push(i + 1);
+                continue;
+            };
+            if entry.is_pre_chain() {
+                report.pre_chain += 1;
+                continue;
+            }
+            let content_ok = entry.hash.as_deref() == Some(entry.digest().as_str());
+            // The first chained entry is the boundary and has no predecessor
+            // to point at; after that, each entry must name the one before.
+            let link_ok = expected_prev.is_none() || entry.prev == expected_prev;
+            if content_ok && link_ok {
+                report.verified += 1;
+            } else {
+                report.breaks.push(i + 1);
+            }
+            expected_prev = entry.hash.clone();
+        }
+        Ok(report)
     }
 
     pub fn read_last(&self, n: usize) -> Result<Vec<AuditEntry>> {
@@ -101,6 +242,119 @@ pub fn now() -> (u128, String) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::TestEnv;
+
+    /// The chain links entries together and verifies clean.
+    #[test]
+    fn a_chain_verifies_and_each_entry_names_the_one_before_it() {
+        let env = TestEnv::new("chain-ok");
+        let log = AuditLog::new(env.root()).unwrap();
+        for i in 0..4 {
+            log.append(&entry(&format!("cmd {i}"))).unwrap();
+        }
+
+        let r = log.verify_chain().unwrap();
+        assert_eq!(r.verified, 4);
+        assert_eq!(r.pre_chain, 0);
+        assert!(r.is_intact(), "breaks: {:?}", r.breaks);
+
+        // Each entry after the first names its predecessor's hash - the
+        // property the whole thing rests on.
+        let raw = std::fs::read_to_string(log.path()).unwrap();
+        let entries: Vec<AuditEntry> = raw
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        assert!(entries[0].prev.is_none(), "the boundary has no predecessor");
+        for w in entries.windows(2) {
+            assert_eq!(w[1].prev, w[0].hash, "each entry names the one before");
+        }
+    }
+
+    /// MIGRATION: pre-chain entries stay READABLE and are reported as their
+    /// own count, not as breaks.
+    ///
+    /// An upgrade must not turn existing history into an error. The claim
+    /// Termaxa can make is "continuity from the boundary onward", and the
+    /// claim it cannot make is that it protected history it was not there
+    /// for. The report states both rather than collapsing them.
+    #[test]
+    fn pre_chain_history_is_readable_and_reported_separately() {
+        let env = TestEnv::new("chain-migrate");
+        let log = AuditLog::new(env.root()).unwrap();
+
+        // Two entries as an older version would have written them: no prev,
+        // no hash.
+        let mut old = entry("old one");
+        old.prev = None;
+        old.hash = None;
+        let line = serde_json::to_string(&old).unwrap();
+        std::fs::write(log.path(), format!("{line}\n{line}\n")).unwrap();
+
+        // Then two from this version.
+        log.append(&entry("new one")).unwrap();
+        log.append(&entry("new two")).unwrap();
+
+        let r = log.verify_chain().unwrap();
+        assert_eq!(r.pre_chain, 2, "old entries are pre-chain, not broken");
+        assert_eq!(r.verified, 2, "new entries verify");
+        assert!(r.is_intact(), "a migration boundary is not a break");
+
+        // And all four are still readable.
+        assert_eq!(log.read_last(10).unwrap().len(), 4);
+    }
+
+    /// An edited entry is detected, and the entries around it stay readable.
+    ///
+    /// One corrupt line must not make the whole record unreadable: that would
+    /// destroy more evidence than the corruption did.
+    #[test]
+    fn a_tampered_entry_is_named_and_the_rest_survives() {
+        let env = TestEnv::new("chain-tamper");
+        let log = AuditLog::new(env.root()).unwrap();
+        for i in 0..4 {
+            log.append(&entry(&format!("cmd {i}"))).unwrap();
+        }
+
+        // Rewrite entry 2's command, leaving its hash alone - the shape of an
+        // edit that tries to hide what was run.
+        let raw = std::fs::read_to_string(log.path()).unwrap();
+        let mut lines: Vec<String> = raw.lines().map(|s| s.to_string()).collect();
+        lines[1] = lines[1].replace("cmd 1", "innocent");
+        std::fs::write(log.path(), lines.join("\n") + "\n").unwrap();
+
+        let r = log.verify_chain().unwrap();
+        assert!(!r.is_intact());
+        assert!(
+            r.breaks.contains(&2),
+            "the edited entry is named: {:?}",
+            r.breaks
+        );
+        // The record is still readable - reporting, not refusing.
+        assert_eq!(log.read_last(10).unwrap().len(), 4);
+    }
+
+    /// Deleting an entry breaks the link that named it.
+    #[test]
+    fn a_removed_entry_leaves_a_gap_the_chain_reports() {
+        let env = TestEnv::new("chain-delete");
+        let log = AuditLog::new(env.root()).unwrap();
+        for i in 0..4 {
+            log.append(&entry(&format!("cmd {i}"))).unwrap();
+        }
+        let raw = std::fs::read_to_string(log.path()).unwrap();
+        let mut lines: Vec<String> = raw.lines().map(|s| s.to_string()).collect();
+        lines.remove(1); // the entry someone wanted gone
+        std::fs::write(log.path(), lines.join("\n") + "\n").unwrap();
+
+        let r = log.verify_chain().unwrap();
+        assert!(
+            !r.is_intact(),
+            "a hole in the chain is visible even though every remaining line \
+             is internally valid"
+        );
+    }
 
     use crate::testutil::TempTree;
 
@@ -123,6 +377,8 @@ mod tests {
             approved: None,
             exit_code: None,
             cwd: "/work".into(),
+            prev: None,
+            hash: None,
         }
     }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -199,6 +199,54 @@ pub fn run(dir: &Path) -> Result<i32> {
                         dim("set TERMAXA_HOOK_DEBUG=1 and check what arrives")
                     );
                 }
+                // ---- chain (v0.16, #13) ----
+                //
+                // Two states reported separately, because they are different
+                // claims. "Continuity from the boundary onward" is provable;
+                // "we protected the history before that" is not, and an
+                // upgrade should not pretend otherwise.
+                if let Ok(chain) =
+                    crate::audit::AuditLog::new(&p.state_dir).and_then(|l| l.verify_chain())
+                {
+                    if chain.verified > 0 && chain.is_intact() {
+                        let first = chain.pre_chain + 1;
+                        let last = chain.pre_chain + chain.verified;
+                        println!(
+                            "  {} {}",
+                            green("✓"),
+                            dim(&format!("chain valid: entries {first}–{last}"))
+                        );
+                    }
+                    if chain.pre_chain > 0 {
+                        println!(
+                            "  {} {}",
+                            amber("!"),
+                            dim(&format!(
+                                "{} earlier entries are pre-chain",
+                                chain.pre_chain
+                            ))
+                        );
+                    }
+                    if !chain.is_intact() {
+                        let which = chain
+                            .breaks
+                            .iter()
+                            .map(|b| b.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        let plural = if chain.breaks.len() == 1 { "y" } else { "ies" };
+                        println!(
+                            "  {} audit chain broken at entr{} {}",
+                            red("✗"),
+                            plural,
+                            which
+                        );
+                        problems.push(
+                            "the audit chain does not verify — an entry was edited or removed"
+                                .into(),
+                        );
+                    }
+                }
             } else {
                 println!("  {}", dim("no audit log yet — nothing has been evaluated"));
             }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -374,6 +374,10 @@ fn gate_file_write(w: &FileWrite) {
                 approved: None,
                 exit_code: None,
                 cwd: w.cwd.clone(),
+                // Filled by `append`, which links each entry to the one
+                // before it.
+                prev: None,
+                hash: None,
             });
         }
         if let Ok(policy) = Policy::load(&paths.policy_file()) {
@@ -523,6 +527,10 @@ pub fn run() -> Result<()> {
                     approved: Some(true),
                     exit_code: None,
                     cwd: input.cwd.clone(),
+                    // Filled by `append`, which links each entry to the one
+                    // before it.
+                    prev: None,
+                    hash: None,
                 });
             }
         }
@@ -706,6 +714,10 @@ pub fn run() -> Result<()> {
                 approved: None,
                 exit_code: None,
                 cwd: input.cwd.clone(),
+                // Filled by `append`, which links each entry to the one
+                // before it.
+                prev: None,
+                hash: None,
             });
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,6 +276,9 @@ fn dispatch(cli: Cli) -> Result<i32> {
                 cwd: std::env::current_dir()
                     .map(|p| p.display().to_string())
                     .unwrap_or_default(),
+                // Filled by `append`, which links each entry to the one before it.
+                prev: None,
+                hash: None,
             })?;
 
             // Exit codes make `termaxa check` scriptable: 0 allow, 3 ask, 4 deny.

--- a/src/report.rs
+++ b/src/report.rs
@@ -557,6 +557,8 @@ mod tests {
             approved: None,
             exit_code: None,
             cwd: "/work/proj".into(),
+            prev: None,
+            hash: None,
         }
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -121,6 +121,9 @@ pub fn run(paths: &crate::paths::Paths, argv: &[String]) -> Result<i32> {
         cwd: std::env::current_dir()
             .map(|p| p.display().to_string())
             .unwrap_or_default(),
+        // Filled by `append`, which links each entry to the one before it.
+        prev: None,
+        hash: None,
     })?;
 
     Ok(exit_code.unwrap_or(1))


### PR DESCRIPTION
## What doctor reports

    ✓ chain valid: entries 3–5
    ! 2 earlier entries are pre-chain
    ✗ audit chain broken at entry 4

Three separate claims, kept separate. Termaxa can prove continuity from the
migration boundary onward; it cannot retroactively claim to have protected
history it was not there for. An upgrade does not turn that history into an
error.

A break names the entry and leaves the record readable — one corrupt line
making the whole log unreadable would destroy more evidence than the
corruption did.

## Threat model — read this before calling it a security feature

In **basic mode** the hook writes this log as the *agent's own UID*. Anything
that can edit an entry can recompute the chain over it. This is
tamper-**evident** against corruption and unsophisticated edits; it is not
tamper-**resistant** against a hostile process with the same filesystem
authority.

That changes in **supervised mode** (v0.17), where the supervisor owns the
state directory and the agent's UID cannot reach it. The record becomes
trustworthy because the authority that writes it sits outside the agent's
trust domain — not because the hash got cleverer.

#13 is a v0.16/v0.17 dependency, not a solution to the adversarial-agent
problem.

## Gate

| | before | after |
|---|---|---|
| Linux | 417 | 421 |
| Windows | 368 | 372 |