### PR TITLE
v0.16 (roadmap 2.6): provenance the system can establish, and no more

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -44,6 +44,39 @@ pub struct AuditEntry {
     pub exit_code: Option<i32>,
     pub cwd: String,
 
+    // ---- provenance (v0.16, roadmap 2.6) ----
+    //
+    // Serde-defaulted, so pre-v0.16 lines parse as None (decision #7).
+    /// Which agent harness produced this event: claude-code, cursor, codex,
+    /// copilot. Absent for `run` and `check`, which are the human's own
+    /// surfaces and have no harness to name.
+    ///
+    /// The hook has always known this - it picks the response format from it -
+    /// and threw it away. With two harnesses active in one project the audit
+    /// could not say which caused an entry.
+    ///
+    /// NOT the OS user. In basic mode the hook runs as the agent's own UID, so
+    /// recording it would record the agent's claim about itself dressed as
+    /// provenance. Supervised mode (v0.17) gets a peer UID from SO_PEERCRED,
+    /// which is an identity the agent cannot forge, and that deserves its own
+    /// field when it exists rather than an empty half of a struct now.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<String>,
+    /// What determined the verdict: default (no rule matched), rule, context.
+    ///
+    /// Deliberately NOT called `source`, which on this struct already means
+    /// something else - which SURFACE invoked Termaxa (hook, run, check,
+    /// post). Two different questions, and one word for both would have made
+    /// the record ambiguous in a way no query could recover from.
+    ///
+    /// This is `DecisionSource` persisted, not a second representation of the
+    /// same fact. A silent default-allow is then a JOIN of fields that already
+    /// exist - source=hook, decided_by=default, decision=allow - rather than a
+    /// `silent_default_allow: bool` that would duplicate the information and
+    /// eventually drift from it (#37).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decided_by: Option<String>,
+
     // ---- hash chain (v0.16, issue #13) ----
     //
     // Serde-defaulted so every pre-chain line parses as None, per decision #7:
@@ -244,6 +277,86 @@ mod tests {
     use super::*;
     use crate::testutil::TestEnv;
 
+    /// Roadmap 2.6. Provenance the system can actually establish.
+    ///
+    /// `actor` is the harness; `decided_by` is what determined the verdict.
+    /// The pair answers "which agent caused this, and why did it go that way"
+    /// without either field guessing.
+    #[test]
+    fn an_entry_records_the_harness_and_what_decided_it() {
+        let env = TestEnv::new("provenance");
+        let log = AuditLog::new(env.root()).unwrap();
+
+        let mut hook = entry("rm -rf x");
+        hook.source = "hook".into();
+        hook.actor = Some("claude-code".into());
+        hook.decided_by = Some("rule".into());
+        log.append(&hook).unwrap();
+
+        // `check` is the human's own surface: no harness produced it, and
+        // naming one would be false provenance.
+        let mut check = entry("ls -la");
+        check.source = "check".into();
+        check.actor = None;
+        check.decided_by = Some("default".into());
+        log.append(&check).unwrap();
+
+        let back = log.read_last(10).unwrap();
+        assert_eq!(back[0].actor.as_deref(), Some("claude-code"));
+        assert_eq!(back[0].decided_by.as_deref(), Some("rule"));
+        assert_eq!(back[1].actor, None, "no harness, no actor");
+        assert_eq!(back[1].decided_by.as_deref(), Some("default"));
+    }
+
+    /// A SILENT DEFAULT ALLOW is a join of fields that already exist, not a
+    /// field of its own.
+    ///
+    /// `source = hook` + `decided_by = default` + `decision = allow` is the
+    /// interesting case: an agent ran something, no rule had an opinion, and
+    /// the human was never told. A `silent_default_allow: bool` would
+    /// duplicate that and eventually drift from it (#37).
+    #[test]
+    fn a_silent_default_allow_is_reconstructible_without_its_own_field() {
+        let env = TestEnv::new("silent-join");
+        let log = AuditLog::new(env.root()).unwrap();
+
+        let mut silent = entry("whatever-unmatched");
+        silent.source = "hook".into();
+        silent.decision = "allow".into();
+        silent.decided_by = Some("default".into());
+        log.append(&silent).unwrap();
+
+        // Near misses that must NOT match the same join.
+        let mut by_rule = entry("ls -la");
+        by_rule.source = "hook".into();
+        by_rule.decision = "allow".into();
+        by_rule.decided_by = Some("rule".into());
+        log.append(&by_rule).unwrap();
+
+        let mut human = entry("ls -la");
+        human.source = "check".into();
+        human.decision = "allow".into();
+        human.decided_by = Some("default".into());
+        log.append(&human).unwrap();
+
+        let all = log.read_last(10).unwrap();
+        let silent: Vec<&AuditEntry> = all
+            .iter()
+            .filter(|e| {
+                e.source == "hook"
+                    && e.decided_by.as_deref() == Some("default")
+                    && e.decision == "allow"
+            })
+            .collect();
+
+        assert_eq!(
+            silent.len(),
+            1,
+            "exactly one entry is a silent default allow"
+        );
+        assert_eq!(silent[0].command, "whatever-unmatched");
+    }
+
     /// The chain links entries together and verifies clean.
     #[test]
     fn a_chain_verifies_and_each_entry_names_the_one_before_it() {
@@ -364,6 +477,8 @@ mod tests {
             ts_ms,
             ts,
             source: "test".into(),
+            actor: None,
+            decided_by: None,
             command: command.into(),
             decision: "allow".into(),
             matched_rule: None,

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -63,6 +63,20 @@ fn normalize_uri_path(p: &str) -> String {
     p.to_string()
 }
 
+impl Dialect {
+    /// Stable name for the audit record. Written to disk, so it is a wire
+    /// format: changing one of these strings rewrites what past entries mean,
+    /// and a reader comparing across versions would silently miscount.
+    pub fn actor(self) -> &'static str {
+        match self {
+            Dialect::ClaudeCode => "claude-code",
+            Dialect::Cursor => "cursor",
+            Dialect::Codex => "codex",
+            Dialect::Copilot => "copilot",
+        }
+    }
+}
+
 pub fn parse_input(raw: &str) -> Option<ParsedHook> {
     // Cursor (and some Windows shells) prepend a UTF-8 BOM; strip it or the
     // JSON parse fails on the leading bytes.
@@ -361,6 +375,14 @@ fn gate_file_write(w: &FileWrite) {
                 ts_ms,
                 ts,
                 source: "hook".into(),
+                actor: Some(w.dialect.actor().to_string()),
+                // A protected-path refusal is the write matcher's own rule,
+                // not the policy's - an explicit decision either way.
+                decided_by: Some(
+                    crate::policy::DecisionSource::ExplicitRule
+                        .as_str()
+                        .to_string(),
+                ),
                 command: subject.clone(),
                 decision: "deny".into(),
                 matched_rule: Some(protected.what.to_string()),
@@ -513,6 +535,10 @@ pub fn run() -> Result<()> {
                     ts_ms,
                     ts,
                     source: "post".into(),
+                    actor: Some(input.dialect.actor().to_string()),
+                    // A receipt records that a command RAN. Nothing decided
+                    // anything here, and naming a decider would invent one.
+                    decided_by: None,
                     command: command.clone(),
                     decision: "executed".into(),
                     matched_rule: None,
@@ -701,6 +727,8 @@ pub fn run() -> Result<()> {
                 ts_ms,
                 ts,
                 source: "hook".into(),
+                actor: Some(input.dialect.actor().to_string()),
+                decided_by: Some(decision.source.as_str().to_string()),
                 command: command.clone(),
                 decision: decision.action.to_string(),
                 matched_rule: decision.matched_rule.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,6 +261,9 @@ fn dispatch(cli: Cli) -> Result<i32> {
                 ts_ms,
                 ts,
                 source: "check".into(),
+                // `check` is the human asking, not an agent acting.
+                actor: None,
+                decided_by: Some(decision.source.as_str().to_string()),
                 command: cmd.clone(),
                 decision: decision.action.to_string(),
                 matched_rule: decision.matched_rule.clone(),

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -226,6 +226,19 @@ pub enum DecisionSource {
     Context,
 }
 
+impl DecisionSource {
+    /// Stable name for the audit record. Same wire-format caution as
+    /// `Dialect::actor`: these strings are written to disk and a reader
+    /// comparing across versions depends on them not moving.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DecisionSource::Default => "default",
+            DecisionSource::ExplicitRule => "rule",
+            DecisionSource::Context => "context",
+        }
+    }
+}
+
 /// Every path this segment touches, resolved once: the redirect targets the
 /// splitter already found, plus whatever the delete extractor recognises.
 ///

--- a/src/report.rs
+++ b/src/report.rs
@@ -544,6 +544,8 @@ mod tests {
             ts_ms: 0,
             ts: "2026-01-01T00:00:00Z".into(),
             source: "hook".into(),
+            actor: None,
+            decided_by: None,
             command: command.into(),
             decision: decision.into(),
             matched_rule: None,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -106,6 +106,10 @@ pub fn run(paths: &crate::paths::Paths, argv: &[String]) -> Result<i32> {
         ts_ms,
         ts,
         source: "run".into(),
+        // `run` is the human's own surface: no agent harness produced it, so
+        // naming one would be false provenance.
+        actor: None,
+        decided_by: Some(decision.source.as_str().to_string()),
         command,
         decision: decision.action.to_string(),
         matched_rule: decision.matched_rule,


### PR DESCRIPTION
The schema pass, measured before it was designed. It came out smaller than the
roadmap assumed, and one of its three items is **dropped rather than built**.

## Model ID: dropped, with the evidence

Examined all 23 captured hook payloads across Claude Code, Cursor, Codex and
Copilot. The complete field vocabulary is:

hook_event_name, cwd, tool_name, tool_input, command, file_path,
content, session_id, conversation_id, toolName, toolArgs

**None supplies a model identifier.** A `model: Option<String>` would be
structurally always `None` — a schema field recording nothing, which is worse
than an absent one because it implies the data exists and someone forgot to
fill it.

Recorded here rather than silently omitted, so the next person knows it was
examined rather than forgotten.

## The v0.16 schema

| field | meaning |
|---|---|
| `actor` | harness that produced the event — `claude-code`, `cursor`, `codex`, `copilot` |
| `decided_by` | the existing `DecisionSource` — `default`, `rule`, `context` |
| `source` | invocation surface, unchanged — `hook`, `run`, `check`, `post` |
| `model` | **not present**, dropped after payload measurement |
| peer UID | **v0.17**, when supervised mode creates a real second identity |

**`actor` is the harness and only the harness.** The hook always knew which
dialect it was answering — it picks the response format from it — and threw
that away, so with two harnesses active in one project the audit could not say
which caused an entry. Absent for `run` and `check`: those are the human's own
surfaces, and naming a harness there would be false provenance.

Deliberately not the OS user, and not a struct with a `uid` half. In basic mode
the hook runs as the agent's own UID, so recording it would record the agent's
claim about itself dressed as provenance. An empty half of a struct is not
future-proofing — it is a placeholder for information the system cannot
currently establish.

## `decided_by`, and the collision it avoids

`source` on this struct already means *which surface invoked Termaxa*.
`DecisionSource` means *what determined the verdict*. Same word, two questions —
reusing it would have made the record ambiguous in a way no query recovers from.
Caught before writing rather than after.

**A silent default-allow is now a join, not a field:**

source = hook AND decided_by = default AND decision = allow

An agent ran something, no rule had an opinion, and the human was never told.
A `silent_default_allow: bool` would duplicate information already present and
eventually drift from it (#37). Verified against a real log, including the near
misses that must *not* match: allowed-by-rule, and the same default allow from
`check` rather than a hook.

Both fields are serde-defaulted, so pre-v0.16 lines parse as `None` (#7), and
both carry stable wire names with the caution stated in place: these strings are
written to disk, and moving one rewrites what past entries mean.

## Gate

| | before | after |
|---|---|---|
| Linux | 425 | 427 |
| Windows | 376 | 378 |