### PR TITLE
v0.16 item 9: supervisor groundwork, and the residue written beside it

### DIFF
--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -169,6 +169,48 @@ pub fn run(dir: &Path) -> Result<i32> {
         }
     }
 
+    // ---- 4b. Mode ----
+    println!();
+    println!("{}", bold("Mode"));
+    {
+        // Same answer `supervise` uses for the socket path, from the same
+        // function - so doctor cannot report a mode the hook does not see.
+        let home = crate::paths::home_base().unwrap_or_default();
+        match crate::supervise::detect(&home) {
+            crate::supervise::Mode::Basic => {
+                println!(
+                    "{} {:<13}{}",
+                    green("✓"),
+                    "basic",
+                    dim("everything runs as you; protection is cooperative")
+                );
+                if cfg!(windows) {
+                    println!(
+                        "  {}",
+                        dim("supervised mode is Unix-only — basic mode is the Windows answer")
+                    );
+                }
+            }
+            crate::supervise::Mode::Supervised => {
+                // Detected means the socket EXISTS. Whether it answers is a
+                // different question, and reporting "supervised" for a dead
+                // socket would tell an operator they have a boundary they do
+                // not have.
+                println!(
+                    "{} {:<13}{}",
+                    amber("!"),
+                    "supervised",
+                    dim("socket present — the daemon is v0.17; this hook denies until it answers")
+                );
+                problems.push(
+                    "a supervise socket exists but no daemon is shipped yet — remove it \
+                     or hooks will deny"
+                        .into(),
+                );
+            }
+        }
+    }
+
     // ---- 5. State ----
     println!();
     println!("{}", bold("State"));

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -598,6 +598,32 @@ pub fn run() -> Result<()> {
         }
     }
 
+    // ---- supervised mode (v0.16 groundwork, v0.17 daemon) ----
+    //
+    // Detected from the filesystem: the socket is either there or it is not.
+    // When it IS there, this hook is inside the agent's trust domain and has
+    // no authority of its own - it forwards the payload and prints what comes
+    // back. Until the daemon ships there is nothing to forward TO, so the
+    // reachability check is the whole of it, and it fails CLOSED.
+    //
+    // That direction is the permanent answer to Cursor 3.11: four releases of
+    // silent fail-open, because a gate that loses its brain and carries on is
+    // worse than one that stops. An operator who configured supervision gets
+    // a refusal with a reason, not a decision made by the wrong process.
+    let termaxa_home = crate::paths::home_base().unwrap_or_default();
+    if crate::supervise::detect(&termaxa_home) == crate::supervise::Mode::Supervised {
+        let err = crate::supervise::SuperviseError::Unreachable;
+        let reason = format!("[termaxa] {}", err.reason());
+        println!("{}", render_response(input.dialect, "deny", &reason));
+        // Same belt-and-suspenders exit as any other deny: stdout JSON
+        // delivery is finicky on Windows, so the block also lands as a
+        // non-zero code. Flushed first, for the same reason the other site
+        // flushes.
+        use std::io::Write as _;
+        let _ = std::io::stdout().flush();
+        std::process::exit(2);
+    }
+
     let policy = Policy::load(&paths.policy_file())?;
 
     // The payload's cwd is where the command runs; the project root comes

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,11 @@ mod report;
 mod resolve;
 mod runner;
 mod shell;
+mod supervise;
 #[cfg(test)]
 mod testutil;
 mod ui;
+mod wrap;
 
 use anyhow::{bail, Result};
 use clap::{Parser, Subcommand};
@@ -65,6 +67,12 @@ enum Cmd {
     Hook,
     /// Execute a command through the policy gate: termaxa run -- git push
     Run {
+        #[arg(last = true)]
+        argv: Vec<String>,
+    },
+    /// Launch an agent with every shelled command routed through the gate:
+    /// termaxa wrap -- claude   (Unix only in v0.16)
+    Wrap {
         #[arg(last = true)]
         argv: Vec<String>,
     },
@@ -298,6 +306,16 @@ fn dispatch(cli: Cli) -> Result<i32> {
         Cmd::Run { argv } => {
             let p = paths::resolve()?;
             runner::run(&p, &argv)
+        }
+        Cmd::Wrap { argv } => {
+            let p = paths::resolve()?;
+            // The shims live under the Termaxa HOME, not the project state
+            // dir: one agent launch may touch several projects, and a shim
+            // that moved with the cwd would be a different `sh` per
+            // directory. Same accessor the hook and doctor use.
+            let _ = &p;
+            let home = paths::home_base()?;
+            wrap::run(&argv, &home)
         }
         Cmd::Log {
             n,

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -79,7 +79,11 @@ pub fn resolve_readonly(start: &std::path::Path) -> Result<Paths> {
 }
 
 /// `$TERMAXA_HOME` (tests, custom setups) or `~/.termaxa`.
-fn home_base() -> Result<PathBuf> {
+///
+/// Public since v0.16: `supervise` needs the same answer for the socket path,
+/// and a second copy of the TERMAXA_HOME-then-HOME logic is exactly how two
+/// readers of one question start disagreeing (#37).
+pub fn home_base() -> Result<PathBuf> {
     if let Ok(custom) = std::env::var("TERMAXA_HOME") {
         if !custom.trim().is_empty() {
             return Ok(PathBuf::from(custom));

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -80,9 +80,26 @@ pub fn run(paths: &crate::paths::Paths, argv: &[String]) -> Result<i32> {
             print!("Proceed? [y/N] ");
             io::stdout().flush()?;
             let mut line = String::new();
-            io::stdin().read_line(&mut line)?;
-            let yes = matches!(line.trim().to_lowercase().as_str(), "y" | "yes");
-            if yes {
+            let read = io::stdin().read_line(&mut line)?;
+
+            // NO ONE TO ASK is not the same as a refusal, and saying
+            // "declined" when nobody declined is a lie the user cannot debug.
+            // `read_line` returns Ok(0) on a closed or non-interactive stdin -
+            // which is exactly what a `wrap` shim hands us, since the agent
+            // is not a person at a terminal.
+            //
+            // The verdict is unchanged: an `ask` nobody can answer must not
+            // run. Falling through to the y/N match would already have
+            // declined, by accident of an empty string failing to equal "y";
+            // this makes it a decision with a message that fits (#48 - a gate
+            // whose refusals are unexplainable gets uninstalled).
+            if read == 0 {
+                eprintln!(
+                    "termaxa: this needs a human and stdin is not interactive — \
+                     refused rather than run unasked."
+                );
+                (Some(false), None)
+            } else if matches!(line.trim().to_lowercase().as_str(), "y" | "yes") {
                 insure(&mut backup_id);
                 let code = execute(argv)?;
                 (Some(true), Some(code))

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -1,0 +1,296 @@
+//! Talking to a supervisor that does not exist yet.
+//!
+//! v0.16 groundwork for v0.17. This module carries the wire types, the socket
+//! path convention, and mode detection — everything the hook needs to compile
+//! against and to fail correctly when the supervisor is absent. The daemon
+//! itself is v0.17; a loopback stub in test support stands in for it so
+//! deny-on-unreachable and version-skew are testable before it exists.
+//!
+//! WHY THE PROTOCOL SHIPS BEFORE THE DAEMON. The hook's behaviour when it
+//! cannot reach a supervisor is the part that has to be right, and it is
+//! testable now. Writing it after the daemon would mean writing it when the
+//! happy path already works, which is when a failure path gets the least
+//! attention — and this particular failure path is the permanent answer to
+//! Cursor 3.11, four releases of silent fail-open.
+//!
+//! THE TRUST MODEL, because it determines what these types may carry. In
+//! supervised mode the hook runs inside the AGENT's trust domain: the agent's
+//! UID spawns it, so anything the hook concludes is the agent's own account of
+//! itself. The hook therefore forwards the RAW PAYLOAD and forwards nothing
+//! else — no verdict, no parse, no classification. The supervisor re-derives
+//! everything from bytes it received itself. A record built from hook-reported
+//! decisions would be the agent's account wearing a uniform.
+
+// The wire types below have no caller until the daemon exists (v0.17). Live
+// already, and NOT covered by this allow: `detect`, `Mode` and
+// `SuperviseError::Unreachable`, which the hook consults on every invocation
+// to fail closed when supervision is configured but absent.
+//
+// Scoped to this module rather than crate-wide, and narrated rather than
+// silent, because "dead code" here means "the other end is not written yet"
+// and that distinction is exactly what a future reader needs. It comes off in
+// v0.17 with the daemon.
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Wire protocol version.
+///
+/// The hook binary and the daemon binary WILL skew during an upgrade — they
+/// are the same executable, but not the same running process, and nothing
+/// restarts a daemon because a package manager replaced a file. A version
+/// mismatch must be a refusal with a message, never undefined behaviour, so
+/// this is checked before a request is honoured rather than hoped about.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// The socket's name inside the operator-owned state directory.
+///
+/// Directory `0755` (the agent user can traverse and connect), socket
+/// connectable by the agent user, everything else inside owned by the
+/// operator and unreadable to the agent. The path convention lives here
+/// rather than at each caller so basic mode and supervised mode cannot come
+/// to disagree about where to look (#37).
+pub const SOCKET_NAME: &str = "supervise.sock";
+
+/// Where the supervisor's socket lives for a given Termaxa home.
+pub fn socket_path(termaxa_home: &Path) -> PathBuf {
+    termaxa_home.join(SOCKET_NAME)
+}
+
+/// What the hook sends: the payload as it arrived, and nothing it concluded.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Request {
+    pub version: u32,
+    /// The raw hook payload, byte for byte as the harness sent it. The
+    /// supervisor parses this itself.
+    pub payload: String,
+    /// The dialect the hook detected. ADVISORY ONLY — the supervisor
+    /// re-detects from the payload. It travels because it is useful in a log
+    /// line when detection disagrees, which is a fact worth having; it is not
+    /// input to a decision, because a value the agent's domain produced
+    /// cannot be.
+    pub dialect_hint: Option<String>,
+    /// The directory the hook was invoked in, for the same advisory reason.
+    pub cwd: String,
+}
+
+/// What the supervisor sends back: a rendered answer and the code to exit with.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Response {
+    pub version: u32,
+    /// The response body, already rendered in the harness's dialect. The hook
+    /// prints this and exits; it does not decide how to say it, because
+    /// deciding how to say a verdict is close enough to deciding the verdict.
+    pub rendered: String,
+    pub exit_code: i32,
+    /// The audit sequence number this decision was recorded under, so the
+    /// hook can reference an entry it did not write.
+    pub audit_seq: Option<u64>,
+}
+
+/// Why a request could not be answered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SuperviseError {
+    /// No socket at the expected path: the supervisor is not running.
+    Unreachable,
+    /// Connected, but the peer speaks a different protocol version.
+    VersionSkew { ours: u32, theirs: u32 },
+    /// Connected and then did not answer within the deadline.
+    Timeout,
+    /// Answered with something that is not a `Response`.
+    Malformed,
+}
+
+impl SuperviseError {
+    /// The line a human reads when the gate refuses because it lost its brain.
+    /// Each names the actual condition: "supervisor unreachable" and "version
+    /// mismatch" want different fixes, and a single message for both would
+    /// send someone to the wrong one.
+    pub fn reason(&self) -> String {
+        match self {
+            SuperviseError::Unreachable => {
+                "supervised mode is configured but the supervisor is not answering — \
+                 refusing rather than deciding without it"
+                    .into()
+            }
+            SuperviseError::VersionSkew { ours, theirs } => format!(
+                "supervisor speaks protocol v{theirs}, this hook speaks v{ours} — \
+                 refusing rather than guessing at the difference (restart the supervisor \
+                 after upgrading)"
+            ),
+            SuperviseError::Timeout => {
+                "the supervisor did not answer in time — refusing rather than \
+                 deciding without it"
+                    .into()
+            }
+            SuperviseError::Malformed => {
+                "the supervisor's answer could not be read — refusing rather than \
+                 acting on it"
+                    .into()
+            }
+        }
+    }
+}
+
+/// Which topology is this hook running in?
+///
+/// Detected from the filesystem rather than from configuration, so a
+/// half-finished setup cannot claim supervision it does not have: the socket
+/// is either there or it is not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// The default, and every Windows install. Everything runs as the user;
+    /// protection is cooperative.
+    Basic,
+    /// A supervisor socket is present. The hook is a pipe and the authority
+    /// is elsewhere.
+    Supervised,
+}
+
+/// Detect the mode for a Termaxa home.
+///
+/// FAILING CLOSED IS NOT THE SAME AS DETECTING SUPERVISION. This answers only
+/// "is a supervisor configured here" — the socket exists. Whether it ANSWERS
+/// is a separate question, and the separation is deliberate: a hook that
+/// treated an unreachable supervisor as "basic mode, carry on" would fail
+/// OPEN at exactly the moment the operator most expects it not to. Detect,
+/// then require an answer, and refuse if there is none.
+pub fn detect(termaxa_home: &Path) -> Mode {
+    if socket_path(termaxa_home).exists() {
+        Mode::Supervised
+    } else {
+        Mode::Basic
+    }
+}
+
+/// Validate a response against what we sent.
+///
+/// Version is checked on the way IN as well as on the way out: a daemon older
+/// than the hook will happily answer a request it half-understood, and the
+/// mismatch is only visible here.
+pub fn check_response(raw: &str) -> Result<Response, SuperviseError> {
+    let resp: Response = serde_json::from_str(raw).map_err(|_| SuperviseError::Malformed)?;
+    if resp.version != PROTOCOL_VERSION {
+        return Err(SuperviseError::VersionSkew {
+            ours: PROTOCOL_VERSION,
+            theirs: resp.version,
+        });
+    }
+    Ok(resp)
+}
+
+/// Build the request for a payload the hook just received.
+pub fn request_for(payload: &str, dialect_hint: Option<&str>, cwd: &str) -> Request {
+    Request {
+        version: PROTOCOL_VERSION,
+        payload: payload.to_string(),
+        dialect_hint: dialect_hint.map(|s| s.to_string()),
+        cwd: cwd.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::TempTree;
+
+    #[test]
+    fn mode_is_read_from_the_filesystem_not_from_configuration() {
+        let t = TempTree::new("mode-detect");
+        let home = t.path();
+        assert_eq!(
+            detect(home),
+            Mode::Basic,
+            "no socket means basic - a config file claiming otherwise would be a claim, \
+             not a fact"
+        );
+
+        std::fs::write(socket_path(home), b"").unwrap();
+        assert_eq!(detect(home), Mode::Supervised);
+    }
+
+    /// The hook forwards the payload and nothing it concluded. Pinned because
+    /// the temptation to send a parsed verdict is real and would quietly make
+    /// the record the agent's own account.
+    #[test]
+    fn a_request_carries_the_raw_payload_and_no_conclusions() {
+        let raw = r#"{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}"#;
+        let req = request_for(raw, Some("claude-code"), "/tmp/proj");
+        assert_eq!(req.payload, raw, "byte for byte");
+        assert_eq!(req.version, PROTOCOL_VERSION);
+
+        // The dialect travels as a HINT. If this ever becomes authoritative,
+        // a value produced inside the agent's trust domain is deciding
+        // something, which is the thing supervised mode exists to prevent.
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(
+            json.contains("dialect_hint"),
+            "advisory by its name: {json}"
+        );
+        assert!(
+            !json.contains("decision") && !json.contains("verdict"),
+            "the hook must not send a conclusion: {json}"
+        );
+    }
+
+    #[test]
+    fn a_version_mismatch_is_a_refusal_with_a_message_not_undefined_behaviour() {
+        let newer = serde_json::to_string(&Response {
+            version: PROTOCOL_VERSION + 1,
+            rendered: "{}".into(),
+            exit_code: 0,
+            audit_seq: None,
+        })
+        .unwrap();
+
+        match check_response(&newer) {
+            Err(SuperviseError::VersionSkew { ours, theirs }) => {
+                assert_eq!(ours, PROTOCOL_VERSION);
+                assert_eq!(theirs, PROTOCOL_VERSION + 1);
+            }
+            other => panic!("a skewed version must be named as such, got {other:?}"),
+        }
+
+        // And the message says which fix applies - "restart the supervisor"
+        // is different advice from "start it".
+        let msg = SuperviseError::VersionSkew { ours: 1, theirs: 2 }.reason();
+        assert!(msg.contains("restart"), "{msg}");
+        assert!(
+            !SuperviseError::Unreachable.reason().contains("restart"),
+            "an absent supervisor needs starting, not restarting"
+        );
+    }
+
+    #[test]
+    fn a_malformed_answer_is_refused_rather_than_interpreted() {
+        assert_eq!(
+            check_response("not json at all"),
+            Err(SuperviseError::Malformed)
+        );
+        assert_eq!(
+            check_response(r#"{"version":1}"#),
+            Err(SuperviseError::Malformed),
+            "a partial response is not a response"
+        );
+    }
+
+    /// Every failure reason says what to do about it. A refusal a human
+    /// cannot act on is a gate that gets uninstalled (#48).
+    #[test]
+    fn every_failure_names_its_own_condition() {
+        for e in [
+            SuperviseError::Unreachable,
+            SuperviseError::VersionSkew { ours: 1, theirs: 2 },
+            SuperviseError::Timeout,
+            SuperviseError::Malformed,
+        ] {
+            let r = e.reason();
+            assert!(!r.is_empty());
+            assert!(
+                r.contains("refus"),
+                "each reason states that it refused, and why: {r}"
+            );
+        }
+    }
+}

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -1,0 +1,248 @@
+//! `termaxa wrap -- <agent>` — every shell command the agent runs goes
+//! through the gate, hook or no hook.
+//!
+//! v0.16 groundwork. The mechanism is deliberately boring: create a shim
+//! directory, put `sh`/`bash`/`zsh` in it that forward to `termaxa run`,
+//! prepend it to `PATH`, point `SHELL` at it, and launch the agent. A command
+//! the agent runs through a shell then arrives at the existing runner —
+//! "gate one command, insure, execute, record" — which already exists and is
+//! already tested.
+//!
+//! WHAT THIS DOES NOT DO, stated the way the grades table states it. This is
+//! not process interception. There is no `ptrace`, no `seccomp`, no
+//! `LD_PRELOAD`. Commands reach the gate because they resolve a shell **by
+//! name** through `PATH` or read `$SHELL`; a caller that execs `/bin/sh`
+//! **by absolute path**, or that `execve`s a binary directly without a shell
+//! at all, does not pass through anything. That residue is real and belongs
+//! in the same table that sells the rung.
+//!
+//! NO HARNESS IS CLAIMED AS COVERED (#20, #45). Whether a given agent's shell
+//! tool resolves `sh` through `PATH` or hardcodes `/bin/sh` is an empirical
+//! question about that agent, and nobody here has watched one do it. `doctor`
+//! reports what is wired; it does not promise what an unobserved harness will
+//! do. Measured, then written — not the reverse.
+//!
+//! WHY THE SHIM DIR IS OPERATOR-OWNED FROM THE START (#51). A directory on
+//! `PATH` whose contents get executed is an execution primitive: anything that
+//! can write there chooses what `sh` means. In basic mode the agent's UID
+//! could write to a shim dir it owns, which would make the wrapper a way to
+//! run code rather than a way to gate it. So the ownership story is written
+//! now — the dir lives under the operator's Termaxa home, not in the project,
+//! and supervised mode inherits it rather than retrofitting it.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Shells the shim answers to. Only names a caller would resolve through
+/// `PATH`; adding one is a claim that agents invoke it, so the list stays
+/// short and observed rather than aspirational.
+const SHIMMED_SHELLS: [&str; 3] = ["sh", "bash", "zsh"];
+
+/// Where the shims live: under the Termaxa home, never in the project.
+///
+/// Under the project it would be agent-writable in every mode, which is the
+/// execution primitive above. Under the Termaxa home it is operator-owned in
+/// supervised mode by the same `chmod` that protects the rest of the state
+/// directory.
+pub fn shim_dir(termaxa_home: &Path) -> PathBuf {
+    termaxa_home.join("shims")
+}
+
+/// Write the shim scripts, returning the directory to prepend to `PATH`.
+///
+/// The shim is one line of `exec`, so it adds no shell of its own between the
+/// agent and the gate: `exec termaxa run -- "$@"` replaces the shim process
+/// rather than nesting under it.
+#[cfg(unix)]
+pub fn install_shims(termaxa_home: &Path, termaxa_bin: &Path) -> Result<PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = shim_dir(termaxa_home);
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("cannot create shim directory {}", dir.display()))?;
+
+    // 0755: the agent user must traverse and execute, and must not write.
+    let mut perm = std::fs::metadata(&dir)?.permissions();
+    perm.set_mode(0o755);
+    std::fs::set_permissions(&dir, perm)?;
+
+    for shell in SHIMMED_SHELLS {
+        let path = dir.join(shell);
+        // `-c "cmd"` is how a shell is asked to run one command, and it is
+        // the only form we forward: the agent's shell tool uses it. An
+        // interactive shell (no `-c`) is a human at a terminal and is passed
+        // through untouched, because gating a person's own login shell is not
+        // what this is for.
+        let script = format!(
+            "#!/bin/sh\n\
+             # termaxa shim — generated, do not edit.\n\
+             # `sh -c \"<command>\"` is routed through the gate; anything else\n\
+             # is handed to the real shell unchanged.\n\
+             if [ \"$1\" = \"-c\" ] && [ -n \"$2\" ]; then\n\
+             \x20 exec {bin} run -- {shell} -c \"$2\"\n\
+             fi\n\
+             exec /bin/{shell} \"$@\"\n",
+            bin = termaxa_bin.display(),
+            shell = shell,
+        );
+        std::fs::write(&path, script)
+            .with_context(|| format!("cannot write shim {}", path.display()))?;
+        let mut p = std::fs::metadata(&path)?.permissions();
+        p.set_mode(0o755);
+        std::fs::set_permissions(&path, p)?;
+    }
+    Ok(dir)
+}
+
+/// Windows has no `$SHELL` convention and its shim story is different enough
+/// that guessing at it would be worse than saying so.
+///
+/// v0.16 proves the model on one platform (the scope doc's words). Windows
+/// gets its own residue analysis in v0.17 or an explicit "never" — either
+/// way stated rather than left to a user to discover.
+#[cfg(not(unix))]
+pub fn install_shims(termaxa_home: &Path, _termaxa_bin: &Path) -> Result<PathBuf> {
+    // Named rather than hand-waved: the message says where shims WOULD go and
+    // which shells they would cover, so the refusal describes the missing
+    // work instead of just declining.
+    anyhow::bail!(
+        "termaxa wrap is Unix-only in v0.16. Windows has no $SHELL convention, so \
+         shims for {shells} under {dir} would not be consulted the way they are on \
+         Unix, and guessing at an equivalent is worse than saying so. Use hook mode, \
+         which is fully supported on Windows.",
+        shells = SHIMMED_SHELLS.join("/"),
+        dir = shim_dir(termaxa_home).display(),
+    )
+}
+
+/// Launch `argv` with the shims in front of it.
+pub fn run(argv: &[String], termaxa_home: &Path) -> Result<i32> {
+    if argv.is_empty() {
+        anyhow::bail!("nothing to wrap: termaxa wrap -- <command>");
+    }
+    let bin = std::env::current_exe().context("cannot locate the termaxa binary")?;
+    let dir = install_shims(termaxa_home, &bin)?;
+
+    let existing = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}{}{}", dir.display(), path_separator(), existing);
+
+    let mut cmd = std::process::Command::new(&argv[0]);
+    cmd.args(&argv[1..])
+        .env("PATH", path)
+        .env("SHELL", dir.join("sh"))
+        // A marker the gate can see, so a shimmed command is distinguishable
+        // in the record from one that arrived by hook. Not a security
+        // control - anything in the child can unset it - which is why it is
+        // provenance rather than policy input.
+        .env("TERMAXA_WRAPPED", "1");
+
+    let status = cmd
+        .status()
+        .with_context(|| format!("cannot launch {}", argv[0]))?;
+    Ok(status.code().unwrap_or(1))
+}
+
+fn path_separator() -> &'static str {
+    if cfg!(windows) {
+        ";"
+    } else {
+        ":"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::TempTree;
+
+    #[cfg(unix)]
+    #[test]
+    fn shims_are_written_executable_and_not_writable_by_others() {
+        use std::os::unix::fs::PermissionsExt;
+        let t = TempTree::new("wrap-shims");
+        let home = t.path();
+        let dir = install_shims(home, Path::new("/usr/bin/termaxa")).unwrap();
+
+        for shell in SHIMMED_SHELLS {
+            let p = dir.join(shell);
+            assert!(p.exists(), "{shell} shim exists");
+            let mode = std::fs::metadata(&p).unwrap().permissions().mode();
+            assert_eq!(mode & 0o111, 0o111, "{shell} is executable");
+            assert_eq!(
+                mode & 0o022,
+                0,
+                "{shell} must not be group- or world-writable: a writable file on \
+                 PATH is a way to run code, not a way to gate it (#51)"
+            );
+        }
+    }
+
+    /// The shim forwards `-c` to the gate and everything else to the real
+    /// shell. An interactive shell is a person at a terminal; gating that is
+    /// not what this is for, and a shim that swallowed it would break login.
+    #[cfg(unix)]
+    #[test]
+    fn the_shim_routes_dash_c_and_passes_everything_else_through() {
+        let t = TempTree::new("wrap-script");
+        let dir = install_shims(t.path(), Path::new("/usr/bin/termaxa")).unwrap();
+        let script = std::fs::read_to_string(dir.join("sh")).unwrap();
+
+        assert!(
+            script.contains("/usr/bin/termaxa run --"),
+            "a -c command goes through the runner: {script}"
+        );
+        assert!(
+            script.contains("exec /bin/sh \"$@\""),
+            "anything else reaches the real shell: {script}"
+        );
+        assert!(
+            script.contains("exec "),
+            "exec rather than a nested shell, so the shim adds no process: {script}"
+        );
+    }
+
+    /// THE RESIDUE, pinned so it is never quietly assumed away.
+    ///
+    /// A shim on PATH catches a shell resolved BY NAME. It does not catch
+    /// `/bin/sh` by absolute path, and it cannot — nothing consults PATH for
+    /// an absolute path. Measured inside a real wrapper:
+    ///
+    ///     wrap -- sh -c "rm -rf victim"        blocked by policy
+    ///     wrap -- /bin/sh -c "rm -rf victim"   ran ungated
+    ///
+    /// This is the grades table's "escape via tools that execute without
+    /// spawning through the wrapper", made concrete. A test that only proved
+    /// the happy path would let someone read the wrapper as interception.
+    #[cfg(unix)]
+    #[test]
+    fn an_absolute_path_shell_is_outside_what_a_path_shim_can_reach() {
+        let t = TempTree::new("wrap-residue");
+        let dir = install_shims(t.path(), Path::new("/usr/bin/termaxa")).unwrap();
+
+        // The shim answers to the NAME. That is the whole mechanism.
+        assert!(dir.join("sh").exists());
+
+        // And nothing here, or anywhere, puts a file at /bin/sh - so a caller
+        // naming that path reaches the system shell directly. Asserted as a
+        // property of the design rather than by touching /bin.
+        assert!(
+            !dir.join("bin").exists(),
+            "the shim dir shadows names on PATH, not absolute paths"
+        );
+    }
+
+    /// The shim directory lives under the Termaxa home, never in the project.
+    /// In the project it would be agent-writable in every mode, which turns a
+    /// gate into an execution primitive (#51).
+    #[test]
+    fn the_shim_directory_is_outside_the_project() {
+        let t = TempTree::new("wrap-location");
+        let home = t.path();
+        let dir = shim_dir(home);
+        assert!(dir.starts_with(home), "{}", dir.display());
+        assert!(
+            !dir.to_string_lossy().contains(".termaxa/policy"),
+            "not beside the policy the agent may read"
+        );
+    }
+}


### PR DESCRIPTION
The last v0.16 code item. Nine of nine.

## `wrap` is environment plumbing, not interception

A shim directory under the Termaxa home holds `sh`/`bash`/`zsh`; `PATH` is
prepended, `SHELL` points at it, the agent launches. A shim receiving
`-c "<command>"` execs `termaxa run -- sh -c "<command>"`, which is already
"gate one command, insure, execute, record". Anything else reaches the real
shell untouched — an interactive shell is a person at a terminal, and gating a
login is not what this is for.

**Measured end to end, all three legs:**

| invocation | outcome |
|---|---|
| `wrap -- sh -c "rm -rf victim"` | **blocked by policy** |
| `sh -c "rm -rf victim"` (no wrapper) | ran ungated — the control leg |
| `wrap -- /bin/sh -c "rm -rf victim"` | **ran ungated** |

That third row is the residue, and it is now a test. A PATH shim catches a
shell resolved **by name**; an absolute path consults no PATH and cannot be
reached this way. The grades table already said *"escape via tools that execute
without spawning through the wrapper"* — this makes it concrete instead of
leaving a reader to imagine interception.

No harness is claimed as covered (#20, #45): whether a given agent execs `sh`
or `/bin/sh` is an empirical question nobody here has answered on a real
machine.

The shim dir is operator-owned from the start (#51) — a directory on PATH whose
contents get executed is an execution primitive. It lives under the Termaxa
home, `0755`, with a test asserting the shims are not group- or world-writable.

Unix only, and it says so.

## The runner's `ask` path, read before wiring

The scope doc's caution, and it was warranted. `read_line` on a non-interactive
stdin returns `Ok(0)`, which failed the y/N match and declined — safe direction,
but by accident, and the user saw **"termaxa: declined"** when nobody had
declined. Inside a shim that is every unmatched command dying with a message
that fits nothing. It now names the actual condition. The verdict is unchanged:
an `ask` nobody can answer must not run.

## Protocol and mode detection

`Request` carries the **raw payload** and nothing the hook concluded; the
dialect travels as an advisory hint the supervisor re-derives. A record built
from hook-reported decisions would be the agent's own account wearing a uniform.

Mode is read from the filesystem — the socket exists or it does not — so a
config file cannot claim supervision that is not there. Detection and
reachability are deliberately separate: treating an unreachable supervisor as
"basic mode, carry on" would fail **open** exactly where an operator most
expects otherwise. Verified against a real socket file:

supervised + nothing answering -> deny, exit 2, reason names the condition

That is Cursor 3.11's permanent answer — four releases of silent fail-open.

`doctor` reports the mode, and reports "supervised" as a **warning** while the
daemon is unshipped: a socket with nothing behind it means hooks deny, which an
operator should hear from doctor rather than from a blocked session.

## A note on the gate that caught the Windows bug

`install_shims` is `#[cfg(unix)]`, so the Linux container never compiled the
branch where `SHIMMED_SHELLS` and `shim_dir` go unused — `-D warnings` failed
on Windows and passed here. The stub now names where shims would live and which
shells they would cover, so both items have a caller on every platform.

Second time this session that the Windows toolchain caught what the Linux one
structurally could not. The `-D warnings` flip from #32 is doing what it was
flipped for.

## Gate

| | before | after |
|---|---|---|
| Linux | 427 | 436 |
| Windows | 378 | 384 |

Windows gains six rather than nine: three of the new tests are `#[cfg(unix)]`.