### PR TITLE
release: v0.16.0 — targets are things, not strings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Format check
         run: cargo fmt --all -- --check
+      # Blocking, matching CI since v0.16. The `continue-on-error` here said
+      # "matches CI: clippy non-fatal (for now)" and stopped matching the
+      # moment CI flipped - which made the RELEASE gate weaker than the PR
+      # gate, exactly backwards for the job whose own comment says a tag that
+      # cannot pass checks must never publish.
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
-        continue-on-error: true   # matches CI: clippy non-fatal (for now)
       - name: Tests
-        run: cargo test
+        run: cargo test --all
 
   build:
     name: ${{ matrix.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,38 +2,132 @@
 
 All notable changes to Termaxa. Format loosely follows [Keep a Changelog](https://keepachangelog.com/); this project is pre-1.0, so minor versions may include breaking changes to the policy schema or CLI.
 
-## Unreleased
+## v0.16.0 — targets are things, not strings
+
+v0.15 stopped treating **commands** as strings. v0.16 stops treating three more
+things as text: **targets** (decide on the resolved path, not the spelling),
+**the grammar** (one scanner; the labelled duplicate deleted), and **the
+record** (a hash chain that says what it can prove).
+
+Seventeen commits, thirteen pull requests. **436 tests on Linux, 384 on
+Windows** — quote both figures or neither; four integration files are
+`#![cfg(unix)]` and run zero tests there.
+
+### Security
+
+- **An escaped quote could bypass anchored deny rules — v0.7.0 through
+  v0.15.0.** `echo \" ; terraform destroy -auto-approve` collapsed into a
+  single segment, because the escaped quote opened a quote state and the `;`
+  never split. A prefix-anchored rule (`terraform destroy*`) then never saw a
+  segment starting with `terraform`, and the line matched `echo *` instead.
+  Two of three tested cases resolved to a **silent allow** — no prompt, nothing
+  for a human to intercept.
+
+  Affected versions verified by compiling v0.7.0's splitter and reproducing the
+  single-segment result. Fixed here: escapes outside single quotes are literal,
+  as a shell reads them. **If you are on any release before v0.16.0, upgrade.**
+  Advisory to follow.
+
+### Added
+
+- **`match_path:` rules match a command's RESOLVED targets**, not its spelling.
+  `> .env` and `> ./.env` are one file rather than two strings, and no number
+  of added string patterns could have achieved that — the next spelling is
+  always one edit away. Path patterns match component by component, so
+  `*/.env` catches a bare `.env`, a nested one, and `C:\proj\.env` alike, and
+  does not catch `prod.env` or `.env.sample`.
+- **A rule needs at least one matcher, and neither is mandatory.** `match:`,
+  `match_path:`, or both. Enforced at parse time, because a rule with no
+  matcher can never fire — a policy that says nothing while looking like it
+  says something.
+- **Overwrite previews.** A write now reports what the file loses before it
+  happens, the way deletes have since v0.13:
+
+  ```
+  overwrite impact
+    target      : /proj/config.json
+    loses       : 38 B of existing content
+    insurance   : copy 1 path(s) to .termaxa/backups before they are overwritten
+  ```
+
+- **`cp`, `mv`, `tee` and `dd` destinations are extracted**, each by its own
+  argument grammar, and every target carries the role the command gives it:
+  a copy's source is **read**, its destination **written**, and a move's source
+  is **removed**. `cp a b c dir/` has three sources and one destination; a
+  guess at "the last path-looking argument" would have reported `b` as at risk.
+- **A hash-chained audit log (#13).** Each entry carries the hash of the one
+  before it, so an edited or removed entry is detectable. `doctor` reports what
+  it can verify and says so precisely — `chain valid: entries 3-5`, `2 earlier
+  entries are pre-chain`, `audit chain broken at entry 4`. **Read SECURITY.md
+  before treating this as a security boundary:** in basic mode it is
+  tamper-evident, not tamper-resistant.
+- **Provenance in the audit record:** `actor` (which harness produced the
+  event) and `decided_by` (default, rule, or context). A silent default-allow
+  is now a join of fields that already exist rather than a field of its own.
+- **`termaxa wrap -- <agent>`** (Unix): every command the agent runs *through a
+  shell* passes through the gate, hook or no hook. Shim directory, `PATH`,
+  `SHELL` — not process interception, and the residue is stated: a caller
+  naming `/bin/sh` by absolute path, or exec'ing a binary directly, does not
+  pass through anything.
+- **Mode detection and deny-on-unreachable.** When a supervisor socket exists
+  and nothing answers, the hook **denies** with a reason naming the condition.
+  A gate that loses its brain does not fail open.
 
 ### Changed
 
 - **Path resolution takes an explicit cwd.** A hook runs in whatever directory
   the harness spawned it in, which is not the directory the agent's command
   runs in, so a relative target resolved against the process cwd found nothing
-  and took no backup — silently, because "no such file" and "nothing to
-  insure" are the same answer (#15). `resolve_path_in(raw, cwd)` replaces
-  `resolve_path`; the hook passes the payload cwd, and the ambient fallback is
-  deleted rather than deprecated — with every call site threaded, the compiler
-  reported the old form as dead code, which is the proof nothing resolves
-  ambiently any more.
+  and took no backup — silently, because "no such file" and "nothing to insure"
+  are the same answer (#15). The ambient fallback is deleted rather than
+  deprecated: with every call site threaded, the compiler reported the old form
+  as dead code, which is the proof nothing resolves ambiently any more.
+- **One scanner for one grammar.** Segments and their redirect targets come
+  from the same walk; `shell::redirect_targets` is deleted. Comparing the two
+  walks before removing one surfaced both the escaped-quote bypass above and a
+  second disagreement: `>|` was split at its `|`, so the clobber was invisible
+  to intent and policy while backup, re-scanning the raw string, insured it.
+- **One answer to "what command is this?"** The classifier, the delete
+  extractor and the insurance layer share one head resolution, so `sudo rm`,
+  `/bin/rm`, `env rm`, `doas rm` and `C:\Windows\System32\del.exe` are
+  classified and insured alike. Every one of those was previously classified as
+  **nothing** — no intent, no breaker pressure. `git clean --force` counts too:
+  one flag, two spellings, one meaning.
+- **Uninsurability escalates an existing concern to deny, and never creates
+  one.** An `ask` that a rule or a context signal chose, on a command nothing
+  can recover, becomes a refusal. An unmatched command under a `default: ask`
+  policy does **not** — `rm -rf node_modules` exceeds the copy budget and is
+  routine, and a gate that denies routine work gets uninstalled.
+- **The reason line names what happens to the target**: `(written)` for a copy,
+  `(removed)` for a move.
+- **Clippy is blocking in CI** (`-D warnings`).
 
-- **One scanner for one grammar.** Segments and their redirect targets now
-  come from the same walk: `split_segments` returns `Segment` values carrying
-  the `Overwrite`s found in them, and `shell::redirect_targets` is deleted.
-  Two parsers over the same input had already produced three bugs and, once
-  their outputs were compared, two measurable disagreements: `>|` was split at
-  its `|`, so the clobber was invisible to intent and policy (which split
-  first) while backup, re-scanning the raw string, insured it; and the walks
-  read `\"` differently outside quotes. `backup` now consumes per-segment
-  redirects instead of re-scanning the raw command.
+### Fixed
 
-  Stated behavior change: **escapes outside single quotes are literal**, as a
-  shell reads them. `echo \" ; rm -rf x` is now two segments — previously the
-  escaped quote opened a quote, the `;` never split, and the whole line
-  (including the `rm` the shell runs as its own command) could match a single
-  permissive rule. Escaped separators (`\;`, `\&`) no longer split, because
-  the shell runs one command there, and an escaped space in a redirect target
-  keeps the filename whole. Each change is pinned by a labeled test with a
-  control leg.
+- **`is_inside` reported not-yet-created targets as outside the project** when
+  any ancestor was a symlink — which macOS `/tmp` and `/var` are. `canonicalize`
+  fails on a path that does not exist, so the root canonicalized and the child
+  did not, and the two were compared in different forms. Affected the
+  outside-the-project warning in every prior release.
+- **`backup::plan` and `backup::take` disagreed about overwrites** since v0.15:
+  `take` insured them, `plan` had no overwrite branch, so every preview of a
+  truncating redirect said "NOT recoverable" while the backup was in fact taken.
+- **An `ask` with no interactive stdin said "declined"** when nobody had
+  declined. It now names the condition and still refuses.
+- **A `.env` path rule denied ordinary reads.** The rule carried a string
+  pattern purely to satisfy the schema, and that pattern fired on its own:
+  `cat .env`, `grep KEY .env`, even `vim .env.sample` were denied. Reading a
+  file destroys nothing.
+
+### Known limitations
+
+- The target machinery is only as wide as its extractors. `truncate`, `xcopy`,
+  `robocopy` and any other command that destroys a file by a route without a
+  grammar produce no targets and reach their ordinary verdict.
+- `termaxa wrap` is Unix-only, and catches a shell resolved by name. Absolute
+  paths and direct `execve` are outside what a `PATH` shim can reach.
+- Four integration files remain `#![cfg(unix)]`, so 32 tests — including all
+  the hook-dialect ones — do not run on Windows.
 
 ## v0.15.0 — stop treating commands as strings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "termaxa"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termaxa"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "A cooperative gate for the shell commands AI coding agents run — command previews, automatic backups, allow/ask/deny policy, and audit logging."
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ See [SECURITY.md](SECURITY.md) for the full threat model.
 
 ## Contributing
 
-Issues and PRs welcome. `cargo test` must pass; CI runs on Linux, macOS, and Windows. The codebase is ~10,700 lines of dependency-light Rust — `src/policy.rs` and `src/preview.rs` are the best places to start reading.
+Issues and PRs welcome. `cargo test` must pass; CI runs on Linux, macOS, and Windows. The codebase is dependency-light Rust: ~9,500 lines of production code in `src/`, plus ~10,500 lines of tests (unit tests live beside the code they test; `tests/` holds the integration ones). More test than product, on purpose — `src/policy.rs` and `src/preview.rs` are the best places to start reading, and the test module at the bottom of each file explains what the code is defending against.
 
 If you can make an agent get past the gate in a way that isn't already documented above, that's the most useful contribution you can make: [open an issue](https://github.com/termaxa/termaxa/issues) or email security@termaxa.com.
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,12 @@ rules:
     action: deny
     reason: "DROP TABLE is blocked. Archive or rename instead."
 
+  # match_path matches the RESOLVED target, not the spelling. `> .env` and
+  # `> ./.env` are one file, and a rule needs only one of the two matchers.
+  - match_path: "*/.env"
+    action: deny
+    reason: "Overwriting .env destroys credentials that are not in the repo."
+
 circuit_breaker:                 # optional (on by default)
   enabled: true
   threshold: 2                   # trip on the 3rd repeated destructive attempt
@@ -328,6 +334,7 @@ notify:                          # optional
 |---|---|
 | `termaxa` | what this is, and what to try next |
 | `termaxa init [--claude-code]` | scaffold `.termaxa/`, detect tools, install the hook |
+| `termaxa wrap -- <agent>` | launch an agent with shelled commands routed through the gate (Unix) |
 | `termaxa doctor` | is the gate wired up? binary, policy, agents, tools, state |
 | `termaxa check "<cmd>"` | dry-run: verdict + preview (exit 0/3/4) |
 | `termaxa run -- <cmd>` | gated execution: preview → approve → backup → run |
@@ -345,18 +352,19 @@ Colour is on when output is a terminal and off when it isn't. `NO_COLOR`, `TERMA
 
 Termaxa is pre-1.0. It's real and tested, and it is not magic. Specifically:
 
-- **Hooks advise; they don't enforce.** Termaxa gates commands an agent submits through the Claude Code or Cursor hook. Those agents are *cooperative* — they respect a `deny` and propose an alternative, which is what makes the gate work. An agent running in full-auto mode could, in principle, retry a blocked action through a different command or shell; the circuit breaker raises the cost of that, but a hook is an *integration* point for visibility and policy, not an *enforcement* boundary. True enforcement means owning the execution path — that's **Termaxa Runtime**, on the roadmap. For hard guarantees today, pair Termaxa with OS-level sandboxing.
+- **Hooks advise; they don't enforce.** Termaxa gates commands an agent submits through the Claude Code or Cursor hook. Those agents are *cooperative* — they respect a `deny` and propose an alternative, which is what makes the gate work. An agent running in full-auto mode could, in principle, retry a blocked action through a different command or shell; the circuit breaker raises the cost of that, but a hook is an *integration* point for visibility and policy, not an *enforcement* boundary. `termaxa wrap -- <agent>` (Unix, v0.16) widens this: commands the agent runs *through a shell* pass through the gate even without a hook, though a caller naming `/bin/sh` by absolute path still does not. True enforcement means owning the execution path — that's the supervisor, next release. For hard guarantees today, pair Termaxa with OS-level sandboxing.
 - **Native agent tools bypass the gate.** The hook sees *shell* commands. An agent's own built-in file/edit tools don't go through the shell — observed in live testing, a Cursor agent switched to its native file-delete tool and removed files Termaxa never saw. Non-shell tool calls need OS-level isolation underneath.
 - **Cooperative, not a sandbox.** Termaxa governs commands that flow through the agent hook or `termaxa run`. An agent with raw, unhooked shell access is *not* contained — that needs OS-level sandboxing, a complementary layer. The threat model is *agents making expensive mistakes*, not a malicious agent actively evading you.
 - **Shell parsing is good, not perfect.** It splits on `&&`, `||`, `;`, `|`
-  and flags `$(...)`. Subshells `( )`, deeply nested quoting, and
-  variable-expanded commands are judged conservatively, not deeply
-  understood. A path built from a variable (`rm -rf ~/x/$SID`) is evaluated
-  as written: the delete preview will report the blast radius of
-  `~/x/$SID` literally, and if the variable expands to empty at runtime the
-  real target is the parent. Termaxa cannot see the caller's environment.
+  and flags `$(...)`. Subshells `( )` and deeply nested quoting are judged
+  conservatively, not deeply understood. A path built from a variable
+  (`rm -rf ~/x/$SID`) is **not** resolved — Termaxa cannot see the caller's
+  environment, and expanding it here would be guessing. Since v0.16 that
+  target is carried as *unresolved* rather than resolved-wrongly, which lets
+  the policy layer treat it as its own kind of risk instead of pretending to
+  know where it points.
 - **Previews are best-effort.** No database connection → static analysis only. Terraform previews shell out to `terraform plan`. Remote Terraform state is versioned by its backend, not by Termaxa.
-- **Backups have edges.** `rm` insurance keys on the literal `rm` command. Postgres backups use `pg_dump`/`psql` and must be on your PATH. No retention/pruning yet — backups accumulate.
+- **Backups have edges.** Since v0.16 delete insurance resolves the command head, so `sudo rm`, `/bin/rm` and `env rm` are covered — but a delete expressed some other way (a script, a language runtime) is not, and a target too large to copy is reported as *not recoverable* rather than silently uninsured. Postgres backups use `pg_dump`/`psql` and must be on your PATH. No retention/pruning yet — backups accumulate.
 - **The format may still change.** Pre-1.0 means the policy schema and CLI can shift between minor versions. Pin a release.
 - **Claude Code and Cursor are live-tested.** Both are exercised end-to-end, including the circuit breaker tripping under a real Cursor session. Codex and Copilot dialects parse each agent's format but aren't verified end-to-end yet. Help validating them is welcome.
 - **Windows PowerShell 5.1 mangles redirected Unicode.** `termaxa report > out.txt` writes UTF-16 and garbles the box-drawing glyphs. That's the shell, not Termaxa — use PowerShell 7, or `termaxa report --md | Out-File -Encoding utf8 report.md`.


### PR DESCRIPTION
Release prep. Three commits, docs and CI only — 436 Linux / 384 Windows,
unchanged.

## The CHANGELOG is written from `git log`, not from the PRs

Seventeen commits, thirteen pull requests, and the notes say what landed rather
than what was planned.

**The Security section leads deliberately.** A user reading these notes on v0.9
needs to learn their release has a live bypass before they read about
`match_path`. It states the affected range (v0.7.0–v0.15.0, verified by
compiling v0.7.0's splitter), notes that two of three tested cases went to a
silent allow, and says to upgrade.

If you'd rather the notes stay quiet until the GHSA publishes, that section can
move — but a changelog that buries it is the wrong shape.

## The release gate was weaker than the PR gate

`release.yml`'s clippy step ran `-D warnings` and then set
`continue-on-error: true`, commented *"matches CI: clippy non-fatal (for now)"*.
CI flipped to fatal in #32, so that comment stopped being true — and the release
build, the one that reaches crates.io and four platform binaries, quietly became
the more permissive of the two. For the job whose own header reads *"a tag on a
commit that can't pass checks must never publish."*

Now blocking. `cargo test` → `cargo test --all` for symmetry; measured as
identical here (9 targets either way, single crate), so that half is cosmetic.

## The README's line count was five thousand lines stale

It claimed ~10,700 — the v0.15.0 figure, never moved. Measured and split,
because one total was hiding the thing worth knowing:

| | lines |
|---|---|
| `src/` production | ~9,500 |
| `src/` tests (beside the code they test) | ~8,300 |
| `tests/` integration | ~2,300 |
| **total** | **~20,000** |

More test than product, which is the honest headline and not an accident.

Two of its "honest limitations" were also overtaken by v0.16 and are corrected
rather than deleted, so a reader who remembers the old text can see it changed:
variable-expanded paths are now carried as *unresolved* rather than reported
literally, and `rm` insurance resolves the command head rather than keying on
the literal `rm`. `match_path:` is in the policy example and `wrap` is in the
command table — the README had never mentioned either.

## Not in this PR

The project docs (known-limitations, decisions, INDEX) and the security
advisory. The advisory needs a tag to name as fixed, and this PR is what makes
that tag possible.