### PR TITLE
v0.17: the supervisor daemon, and the hook stops deciding

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -352,9 +352,23 @@ pub fn parse_file_write(raw: &str) -> Option<FileWrite> {
 /// no `.termaxa/` at all and a policy that will not parse. Both are states in
 /// which the shell path has nothing to say, and both are states in which
 /// "do not overwrite the hook config" is still the right answer.
-fn gate_file_write(w: &FileWrite) {
+/// Refuse a write to the gate's own configuration.
+///
+/// Returns an `Outcome` rather than exiting: this used to call
+/// `process::exit(2)` inline, which is correct for a one-shot hook process and
+/// FATAL for the supervisor daemon - the first protected-file write an agent
+/// attempted would have taken the supervisor down with it, and a dead
+/// supervisor denies everything afterwards (v0.16's deny-on-unreachable). A
+/// gate that kills itself by refusing something is a denial of service with
+/// extra steps.
+fn gate_file_write(w: &FileWrite) -> Outcome {
+    let silent = Outcome {
+        rendered: None,
+        exit_code: 0,
+        audit_seq: None,
+    };
     let Some(protected) = crate::protect::classify(&w.cwd, &w.path) else {
-        return;
+        return silent;
     };
 
     let subject = format!("{} {}", w.tool, w.path);
@@ -407,10 +421,11 @@ fn gate_file_write(w: &FileWrite) {
         }
     }
 
-    println!("{}", render_response(w.dialect, "deny", &reason));
-    use std::io::Write as _;
-    let _ = std::io::stdout().flush();
-    std::process::exit(2);
+    Outcome {
+        rendered: Some(render_response(w.dialect, "deny", &reason)),
+        exit_code: 2,
+        audit_seq: None,
+    }
 }
 
 /// Should this decision be withheld rather than emitted?
@@ -477,9 +492,70 @@ pub fn render_response(dialect: Dialect, permission: &str, reason: &str) -> Stri
 ///
 /// Non-Bash tools and unparsable input fall through with no decision
 /// (exit 0, no output), leaving Claude Code's normal permission flow intact.
+/// What a hook invocation concluded, before anyone prints or exits.
+///
+/// v0.17. The decision path used to print and `process::exit` inline, which
+/// is fine for a process that answers one payload and dies - and impossible
+/// for a daemon that must answer thousands and stay alive. Both callers now
+/// share the same logic and differ only in what they do with this:
+/// `hook::run` prints and exits, `supervise` serialises it onto a socket.
+///
+/// Duplicating the decision path instead would have put two engines on one
+/// question, which is the mistake this codebase keeps paying for (#37) - and
+/// here the two copies would have been the trusted one and the untrusted one.
+#[derive(Debug, Clone)]
+pub struct Outcome {
+    /// The rendered response in the harness's dialect, or `None` when the
+    /// answer is silence (an allow the agent should not be interrupted by).
+    pub rendered: Option<String>,
+    pub exit_code: i32,
+    /// The audit sequence this was recorded under.
+    ///
+    /// Always `None` today: the audit log is append-only JSONL with no
+    /// sequence numbers, so there is nothing to report. The field is in the
+    /// PROTOCOL because a hook that cannot write the record still wants a way
+    /// to reference the entry the supervisor wrote — but the protocol
+    /// carrying it does not mean this end can fill it.
+    ///
+    /// Kept rather than removed because the wire type is already published in
+    /// v0.16's `Response`; removing it here would leave the two halves
+    /// disagreeing about the message shape. It is filled when the log grows
+    /// sequence numbers, which is its own decision (#65: record what the
+    /// system can establish).
+    ///
+    /// The allow is for WINDOWS specifically: both readers of this field live
+    /// in `#[cfg(unix)]` blocks (the daemon's response, the hook's forward),
+    /// so a Windows build sees it written and never read. Scoped to the field
+    /// rather than the struct, and narrated, because "dead on one platform"
+    /// is a different fact from "dead".
+    #[cfg_attr(not(unix), allow(dead_code))]
+    pub audit_seq: Option<u64>,
+}
+
 pub fn run() -> Result<()> {
     let mut buf = String::new();
     std::io::stdin().read_to_string(&mut buf)?;
+    let outcome = decide(&buf)?;
+    if let Some(r) = &outcome.rendered {
+        println!("{r}");
+    }
+    // Belt and suspenders: Cursor and Copilot also honor the process exit code
+    // (2 = block). On Windows especially, stdout JSON delivery can be finicky,
+    // so a denied command exits non-zero to guarantee the block lands.
+    use std::io::Write as _;
+    let _ = std::io::stdout().flush();
+    if outcome.exit_code != 0 {
+        std::process::exit(outcome.exit_code);
+    }
+    Ok(())
+}
+
+/// Decide one payload. Prints nothing, exits nothing.
+///
+/// The whole hook path, minus I/O: this is what the daemon calls with bytes
+/// off a socket and what `run` calls with bytes off stdin.
+pub fn decide(raw_payload: &str) -> Result<Outcome> {
+    let buf = raw_payload.to_string();
 
     // Diagnostic: set TERMAXA_HOOK_DEBUG=<path> to capture exactly what the
     // agent delivered (raw stdin + argv). Invaluable for debugging Windows
@@ -511,9 +587,13 @@ pub fn run() -> Result<()> {
             // configuration. Anything else here stays out of the way, exactly
             // as before.
             if let Some(w) = parse_file_write(&buf) {
-                gate_file_write(&w);
+                return Ok(gate_file_write(&w));
             }
-            return Ok(());
+            return Ok(Outcome {
+                rendered: None,
+                exit_code: 0,
+                audit_seq: None,
+            });
         }
     };
     let command = input.command.clone();
@@ -560,7 +640,11 @@ pub fn run() -> Result<()> {
                 });
             }
         }
-        return Ok(());
+        return Ok(Outcome {
+            rendered: None,
+            exit_code: 0,
+            audit_seq: None,
+        });
     }
 
     // Agents spawn the hook with an arbitrary working directory, but they tell us
@@ -612,16 +696,40 @@ pub fn run() -> Result<()> {
     // a refusal with a reason, not a decision made by the wrong process.
     let termaxa_home = crate::paths::home_base().unwrap_or_default();
     if crate::supervise::detect(&termaxa_home) == crate::supervise::Mode::Supervised {
-        let err = crate::supervise::SuperviseError::Unreachable;
-        let reason = format!("[termaxa] {}", err.reason());
-        println!("{}", render_response(input.dialect, "deny", &reason));
-        // Same belt-and-suspenders exit as any other deny: stdout JSON
-        // delivery is finicky on Windows, so the block also lands as a
-        // non-zero code. Flushed first, for the same reason the other site
-        // flushes.
-        use std::io::Write as _;
-        let _ = std::io::stdout().flush();
-        std::process::exit(2);
+        // Forward and print. Nothing below this line runs: this hook has no
+        // authority in supervised mode, and exercising any would produce a
+        // decision made inside the agent's own trust domain.
+        //
+        // A SECOND supervised hook must not recurse into the supervisor - the
+        // daemon calls `decide` itself, and if that call re-entered here it
+        // would connect to its own socket and deadlock on a single-threaded
+        // server. `TERMAXA_SUPERVISOR=1` in the daemon's own process is what
+        // breaks the loop.
+        if std::env::var("TERMAXA_SUPERVISOR").as_deref() != Ok("1") {
+            return Ok(
+                match crate::supervise::ask(
+                    &termaxa_home,
+                    &buf,
+                    Some(input.dialect.actor()),
+                    &input.cwd,
+                ) {
+                    Ok(resp) => Outcome {
+                        rendered: Some(resp.rendered),
+                        exit_code: resp.exit_code,
+                        audit_seq: resp.audit_seq,
+                    },
+                    Err(e) => Outcome {
+                        rendered: Some(render_response(
+                            input.dialect,
+                            "deny",
+                            &format!("[termaxa] {}", e.reason()),
+                        )),
+                        exit_code: 2,
+                        audit_seq: None,
+                    },
+                },
+            );
+        }
     }
 
     let policy = Policy::load(&paths.policy_file())?;
@@ -829,19 +937,21 @@ pub fn run() -> Result<()> {
 
     // A probe must always answer — `doctor` reads the decision to prove the hook
     // can run at all, and silence is indistinguishable from a dead hook.
-    if !silent || is_probe {
-        println!("{}", render_response(input.dialect, permission, &reason));
-    }
+    let rendered = if !silent || is_probe {
+        Some(render_response(input.dialect, permission, &reason))
+    } else {
+        None
+    };
 
-    // Belt and suspenders: Cursor and Copilot also honor the process exit code
-    // (2 = block). On Windows especially, stdout JSON delivery can be finicky,
-    // so a denied command exits non-zero to guarantee the block lands.
-    use std::io::Write as _;
-    let _ = std::io::stdout().flush();
-    if decision.action == Action::Deny {
-        std::process::exit(2);
-    }
-    Ok(())
+    Ok(Outcome {
+        rendered,
+        exit_code: if decision.action == Action::Deny {
+            2
+        } else {
+            0
+        },
+        audit_seq: None,
+    })
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,9 @@ enum Cmd {
         #[arg(last = true)]
         argv: Vec<String>,
     },
+    /// Run the supervisor: hooks in this home decide through this process,
+    /// which runs as the operator rather than the agent. Unix only.
+    Supervise,
     /// Launch an agent with every shelled command routed through the gate:
     /// termaxa wrap -- claude   (Unix only in v0.16)
     Wrap {
@@ -306,6 +309,11 @@ fn dispatch(cli: Cli) -> Result<i32> {
         Cmd::Run { argv } => {
             let p = paths::resolve()?;
             runner::run(&p, &argv)
+        }
+        Cmd::Supervise => {
+            let home = paths::home_base()?;
+            supervise::serve(&home)?;
+            Ok(0)
         }
         Cmd::Wrap { argv } => {
             let p = paths::resolve()?;

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -164,6 +164,59 @@ pub fn detect(termaxa_home: &Path) -> Mode {
     }
 }
 
+/// Ask the supervisor to decide, from inside the agent's domain.
+///
+/// The hook sends the RAW PAYLOAD and prints what comes back. It does not
+/// parse, evaluate, insure, or audit on its own authority here - anything it
+/// concluded would be the agent's own account of itself, and the record's
+/// whole value in this mode is that it is not.
+///
+/// Two seconds, matching the doctor probe's discipline: an agent is blocked
+/// on this answer, and a supervisor that has wedged must produce a refusal
+/// rather than a hang. Every failure below denies.
+#[cfg(unix)]
+pub fn ask(
+    termaxa_home: &Path,
+    payload: &str,
+    dialect_hint: Option<&str>,
+    cwd: &str,
+) -> Result<Response, SuperviseError> {
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixStream;
+
+    let sock = socket_path(termaxa_home);
+    let mut stream = UnixStream::connect(&sock).map_err(|_| SuperviseError::Unreachable)?;
+    let timeout = std::time::Duration::from_secs(2);
+    let _ = stream.set_read_timeout(Some(timeout));
+    let _ = stream.set_write_timeout(Some(timeout));
+
+    let req = request_for(payload, dialect_hint, cwd);
+    let line = serde_json::to_string(&req).map_err(|_| SuperviseError::Malformed)?;
+    stream
+        .write_all(format!("{line}\n").as_bytes())
+        .map_err(|_| SuperviseError::Unreachable)?;
+    stream.flush().map_err(|_| SuperviseError::Unreachable)?;
+
+    let mut resp = String::new();
+    let read = BufReader::new(stream).read_line(&mut resp);
+    match read {
+        Ok(0) => Err(SuperviseError::Timeout),
+        Ok(_) => check_response(&resp),
+        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Err(SuperviseError::Timeout),
+        Err(_) => Err(SuperviseError::Unreachable),
+    }
+}
+
+#[cfg(not(unix))]
+pub fn ask(
+    _termaxa_home: &Path,
+    _payload: &str,
+    _dialect_hint: Option<&str>,
+    _cwd: &str,
+) -> Result<Response, SuperviseError> {
+    Err(SuperviseError::Unreachable)
+}
+
 /// Validate a response against what we sent.
 ///
 /// Version is checked on the way IN as well as on the way out: a daemon older
@@ -190,10 +243,253 @@ pub fn request_for(payload: &str, dialect_hint: Option<&str>, cwd: &str) -> Requ
     }
 }
 
+// ---------------------------------------------------------------------------
+// the daemon (v0.17)
+// ---------------------------------------------------------------------------
+
+/// Serve until killed. One connection, one payload, one response.
+///
+/// Runs under the OPERATOR's UID. The agent's UID may connect and may write a
+/// request; it may not read the policy, edit the log, or delete a backup,
+/// because those live in a directory it cannot enter. That is the whole point
+/// of the release: the boundary is the filesystem's, not the code's.
+///
+/// Single-threaded on purpose. Requests are short (parse, evaluate, insure,
+/// append) and an agent issues them serially anyway; a thread per connection
+/// would buy nothing and add a way for two requests to interleave inside the
+/// audit append. If a proving run shows contention, that measurement is the
+/// argument for changing it.
+#[cfg(unix)]
+pub fn serve(termaxa_home: &Path) -> anyhow::Result<()> {
+    use anyhow::Context as _;
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::net::UnixListener;
+
+    std::fs::create_dir_all(termaxa_home)?;
+    let sock = socket_path(termaxa_home);
+
+    // A stale socket file from a killed supervisor would make `bind` fail, and
+    // worse, mode detection already reports Supervised for it - so every hook
+    // denies while nothing is listening. Removing it here is safe because we
+    // are about to bind the same path; if another supervisor is genuinely
+    // live, the bind below fails and says so.
+    if sock.exists() {
+        std::fs::remove_file(&sock)?;
+    }
+
+    let listener =
+        UnixListener::bind(&sock).with_context(|| format!("cannot bind {}", sock.display()))?;
+
+    // 0666 on the socket: the agent user must connect. That is NOT a hole -
+    // connecting lets it ask, not decide. The directory above is what keeps
+    // the policy, the log and the backups out of its reach.
+    let mut p = std::fs::metadata(&sock)?.permissions();
+    p.set_mode(0o666);
+    std::fs::set_permissions(&sock, p)?;
+
+    eprintln!("termaxa: supervising on {}", sock.display());
+    eprintln!("termaxa: hooks in this home now decide through this process");
+
+    for stream in listener.incoming() {
+        let mut stream = match stream {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("termaxa: accept failed: {e}");
+                continue;
+            }
+        };
+
+        // Who asked. SO_PEERCRED is the kernel's answer, not the caller's
+        // claim - the one identity in this system the agent cannot forge.
+        let peer_uid = peer_uid(&stream);
+
+        let mut line = String::new();
+        if BufReader::new(stream.try_clone()?)
+            .read_line(&mut line)
+            .is_err()
+        {
+            continue;
+        }
+
+        let reply = handle(&line, peer_uid);
+        let _ = writeln!(stream, "{reply}");
+        let _ = stream.flush();
+    }
+    Ok(())
+}
+
+/// Answer one request. Separated from the socket loop so it is testable
+/// without a socket, and so a panic in decision logic cannot be confused with
+/// a transport failure.
+#[cfg(unix)]
+fn handle(line: &str, peer_uid: Option<u32>) -> String {
+    let err = |msg: &str| {
+        serde_json::to_string(&Response {
+            version: PROTOCOL_VERSION,
+            rendered: msg.to_string(),
+            exit_code: 2,
+            audit_seq: None,
+        })
+        .unwrap_or_default()
+    };
+
+    let req: Request = match serde_json::from_str(line.trim()) {
+        Ok(r) => r,
+        Err(_) => return err("[termaxa] the supervisor could not read that request"),
+    };
+
+    // Version checked on the way IN as well as out: a hook older than this
+    // daemon will send a request this daemon half-understands, and answering
+    // it anyway is the garbled decision the protocol exists to prevent.
+    if req.version != PROTOCOL_VERSION {
+        return err(&format!(
+            "[termaxa] hook speaks protocol v{}, supervisor speaks v{} — \
+             refusing rather than guessing at the difference",
+            req.version, PROTOCOL_VERSION
+        ));
+    }
+
+    // The supervisor re-derives everything from the payload it received. The
+    // dialect hint travels for the log line, never for the decision.
+    // The daemon decides on its OWN authority, so its call into the hook path
+    // must not detect supervised mode and forward back to itself. One process,
+    // one socket, single-threaded: that would deadlock on the first request.
+    std::env::set_var("TERMAXA_SUPERVISOR", "1");
+    let outcome = match crate::hook::decide(&req.payload) {
+        Ok(o) => o,
+        Err(e) => return err(&format!("[termaxa] the supervisor failed to decide: {e}")),
+    };
+
+    if let Some(uid) = peer_uid {
+        eprintln!(
+            "termaxa: uid={} hint={} exit={}",
+            uid,
+            req.dialect_hint.as_deref().unwrap_or("-"),
+            outcome.exit_code
+        );
+    }
+
+    serde_json::to_string(&Response {
+        version: PROTOCOL_VERSION,
+        rendered: outcome.rendered.unwrap_or_default(),
+        exit_code: outcome.exit_code,
+        audit_seq: outcome.audit_seq,
+    })
+    .unwrap_or_default()
+}
+
+/// The connecting process's UID, from the kernel.
+#[cfg(target_os = "linux")]
+fn peer_uid(stream: &std::os::unix::net::UnixStream) -> Option<u32> {
+    use std::os::unix::io::AsRawFd;
+    let mut cred = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            &mut cred as *mut _ as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    if rc == 0 {
+        Some(cred.uid)
+    } else {
+        None
+    }
+}
+
+/// macOS spells it `LOCAL_PEERCRED` with a different struct; until the
+/// proving run happens on a Mac, this reports "unknown" rather than guessing
+/// at an ABI nobody here has tested. An absent UID is recorded as absent.
+#[cfg(all(unix, not(target_os = "linux")))]
+fn peer_uid(_stream: &std::os::unix::net::UnixStream) -> Option<u32> {
+    None
+}
+
+#[cfg(not(unix))]
+pub fn serve(_termaxa_home: &Path) -> anyhow::Result<()> {
+    anyhow::bail!(
+        "termaxa supervise requires Unix domain sockets and a second user account. \
+         Windows has neither in the form this depends on; basic mode is the Windows \
+         answer and is fully supported."
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::testutil::TempTree;
+
+    /// The daemon answers a well-formed request with a decision it made
+    /// itself. Exercised without a socket, so a failure here is decision
+    /// logic rather than transport.
+    #[cfg(unix)]
+    #[test]
+    fn the_supervisor_decides_and_answers() {
+        // A real project, because the supervisor decides against a real
+        // policy - the first draft of this test pointed at /tmp and failed
+        // with "no policy found", which was the test being wrong and the
+        // daemon being right.
+        let env = crate::testutil::TestEnv::new("sup-decide");
+        let proj = env.root().join("proj");
+        std::fs::create_dir_all(proj.join(".termaxa")).unwrap();
+        std::fs::write(
+            proj.join(".termaxa/policy.yaml"),
+            "version: 1\ndefault: ask\nrules:\n  - match: \"*rm -rf*\"\n    action: deny\n    reason: \"blocked\"\n",
+        )
+        .unwrap();
+        let cwd = proj.display().to_string();
+        let payload = format!(
+            r#"{{"tool_name":"Bash","tool_input":{{"command":"rm -rf /"}},"cwd":"{}"}}"#,
+            cwd.replace('\\', "/")
+        );
+        let req = serde_json::to_string(&request_for(&payload, Some("claude-code"), &cwd)).unwrap();
+
+        let raw = handle(&req, Some(1000));
+        let resp: Response = serde_json::from_str(&raw).expect("a well-formed response");
+        assert_eq!(resp.version, PROTOCOL_VERSION);
+        assert_eq!(resp.exit_code, 2, "rm -rf / is denied: {}", resp.rendered);
+        assert!(resp.rendered.contains("deny"), "{}", resp.rendered);
+    }
+
+    /// A request from a hook speaking a different protocol version is refused
+    /// with a message, not answered with a decision the two ends would read
+    /// differently.
+    #[cfg(unix)]
+    #[test]
+    fn a_skewed_request_is_refused_rather_than_half_understood() {
+        let mut req = request_for("{}", None, "/tmp");
+        req.version = PROTOCOL_VERSION + 1;
+        let raw = handle(&serde_json::to_string(&req).unwrap(), None);
+        let resp: Response = serde_json::from_str(&raw).unwrap();
+        assert_eq!(resp.exit_code, 2);
+        assert!(
+            resp.rendered.contains("protocol"),
+            "the refusal names the cause: {}",
+            resp.rendered
+        );
+    }
+
+    /// Garbage on the socket is refused, not interpreted. The supervisor is
+    /// reachable by the agent's UID by design, so it will be sent garbage.
+    #[cfg(unix)]
+    #[test]
+    fn an_unreadable_request_is_refused_not_guessed_at() {
+        let resp: Response = serde_json::from_str(&handle("not json", None)).unwrap();
+        assert_eq!(resp.exit_code, 2);
+        assert!(
+            resp.rendered.contains("could not read"),
+            "{}",
+            resp.rendered
+        );
+    }
 
     #[test]
     fn mode_is_read_from_the_filesystem_not_from_configuration() {


### PR DESCRIPTION
`termaxa supervise` — a long-running process under the **operator's** UID
listening on a Unix socket. In supervised mode the hook does not evaluate,
insure, audit or preview on its own authority: it forwards the raw payload and
prints what comes back.

## Proven end to end before this was committed

socket bound srw-rw-rw- $TERMAXA_HOME/supervise.sock
rm -rf / via hook deny, exit 2 decided by the supervisor
ls -la via hook allow, exit 0
supervisor log uid=0 hint=claude-code exit=2

The uid comes from `SO_PEERCRED` — the kernel's answer, not the caller's claim,
and the one identity in this system the agent cannot forge.

**Deny-on-unreachable, verified against a genuinely killed daemon** rather than
a stub: the socket file survives the kill, mode detection still reports
supervised, connect fails, and a command that would otherwise be **allowed** is
refused with the supervisor named. Cursor 3.11 was four releases of silent
fail-open; this is its permanent answer with something real behind it.

## The refactor this needed, and the hazard it exposed

`hook::run` read stdin, decided, printed and called `process::exit` inline —
correct for a process that answers one payload and dies, impossible for a daemon
that must answer thousands and stay alive. Split into `decide(payload) ->
Outcome` plus a thin I/O wrapper, so both callers share one decision path rather
than two engines on one question (#37) — and here the two copies would have been
the trusted one and the untrusted one.

**Splitting it found a real bug.** `gate_file_write` called `process::exit(2)`
directly. Under the daemon, the first protected-file write an agent attempted
would have killed the supervisor — and a dead supervisor denies everything
afterwards. A gate that kills itself by refusing something is a denial of
service with extra steps.

**Recursion broken explicitly.** The daemon calls `decide`, which detects
supervised mode; without a guard it would connect to its own socket and deadlock
on a single-threaded server. `TERMAXA_SUPERVISOR=1` in the daemon's own process
breaks the loop, stated at both ends.

## Boundaries stated rather than assumed

- Socket `0666`, directory operator-owned. The agent may connect and **ask**; it
  may not read the policy, edit the log or delete a backup, because those live
  where its UID cannot go. The boundary is the filesystem's, not the code's.
- Single-threaded on purpose — requests are short and issued serially, while a
  thread per connection adds a way for two to interleave inside the audit
  append. A proving run showing contention would be the argument to change it.
- macOS `peer_uid` returns `None` rather than guessing at `LOCAL_PEERCRED`'s ABI,
  which nobody here has tested. An absent identity is recorded as absent.
- Windows refuses with a message naming why.

## Not in this PR, and needed before v0.17 ships

`init --supervised`, the privileged CI boundary rig (a real second user,
asserting each attempt fails **at the OS**, with control legs proving the rig
can detect success), `docs/supervisor.md`, the grades table into SECURITY.md,
and the manual proving run.

## Gate

| | before | after |
|---|---|---|
| Linux | 436 | 439 |
| Windows | 384 | 384 |

Windows is unchanged: the daemon is Unix-only and all three new tests are
`#[cfg(unix)]`.