### PR TITLE
v0.17: prove the privilege boundary with a second real user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,33 @@ jobs:
             exit 1
           fi
           echo "smoke test passed: benign allowed, destructive denied"
+
+  # The privilege boundary, proved by a second real user.
+  #
+  # Unit tests cannot prove a boundary: every test in the Rust suite runs as
+  # one user, so "the agent cannot write the policy" is an assertion about code
+  # paths. This job creates a real account and has it TRY, asserting each
+  # attempt fails at the OS.
+  #
+  # continue-on-error is DELIBERATE and temporary, and it is not the same
+  # decision as the clippy one (#67). Two of the eighteen assertions currently
+  # FAIL, for a real reason recorded in the rig's own header: files the daemon
+  # writes after startup are created with default modes, so the audit log and
+  # backups are readable by path. Blocking every PR on a known gap would mean
+  # either fixing it under time pressure or deleting the assertion, and the
+  # second is how a rig becomes decorative.
+  #
+  # Remove continue-on-error when the rig is green. It is a v0.17 ship
+  # blocker, not a v0.16 one.
+  boundary:
+    name: privilege boundary (second real user)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build
+      - name: Run the boundary rig
+        run: sudo bash tests/boundary/rig.sh "$PWD/target/debug/termaxa"

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -44,18 +44,37 @@ use std::path::{Path, PathBuf};
 /// this is checked before a request is honoured rather than hoped about.
 pub const PROTOCOL_VERSION: u32 = 1;
 
-/// The socket's name inside the operator-owned state directory.
-///
-/// Directory `0755` (the agent user can traverse and connect), socket
-/// connectable by the agent user, everything else inside owned by the
-/// operator and unreadable to the agent. The path convention lives here
-/// rather than at each caller so basic mode and supervised mode cannot come
-/// to disagree about where to look (#37).
+/// The socket's name, inside its own directory beside the state directory.
 pub const SOCKET_NAME: &str = "supervise.sock";
+
+/// The directory holding only the socket: `$TERMAXA_HOME/run`, mode `0755`.
+///
+/// The state directory above it is `0711` — EXECUTE WITHOUT READ. That single
+/// mode is what makes supervised mode possible, and it took a rig with a
+/// second real user to find it:
+///
+///   0755 on the state dir  agent can LIST it, and from there read the audit
+///                          log and the backups. Boundary gone.
+///   0700 on the state dir  agent cannot traverse to the socket, so every
+///                          hook denies. Perfectly secure, completely useless.
+///   0711 on the state dir  agent can traverse THROUGH to a path it already
+///                          knows, cannot enumerate the directory, and the
+///                          log and backups stay 0700 in their own right.
+///
+/// Measured, not reasoned: at 0711 an unprivileged account was denied `ls` on
+/// the state directory, denied `cat` on the audit log, denied `ls` on the logs
+/// directory, and permitted to reach the socket.
+///
+/// Traversal needs execute on EVERY directory in the path, which is the part a
+/// design document does not surface. `run/` being 0755 is necessary and not
+/// sufficient.
+pub fn socket_dir(termaxa_home: &Path) -> PathBuf {
+    termaxa_home.join("run")
+}
 
 /// Where the supervisor's socket lives for a given Termaxa home.
 pub fn socket_path(termaxa_home: &Path) -> PathBuf {
-    termaxa_home.join(SOCKET_NAME)
+    socket_dir(termaxa_home).join(SOCKET_NAME)
 }
 
 /// What the hook sends: the payload as it arrived, and nothing it concluded.
@@ -267,6 +286,36 @@ pub fn serve(termaxa_home: &Path) -> anyhow::Result<()> {
     use std::os::unix::net::UnixListener;
 
     std::fs::create_dir_all(termaxa_home)?;
+    // The socket's own directory, traversable by the agent. The state
+    // directory above it stays private; see `socket_dir`.
+    let dir = socket_dir(termaxa_home);
+    std::fs::create_dir_all(&dir)?;
+    let mut dp = std::fs::metadata(&dir)?.permissions();
+    dp.set_mode(0o755);
+    std::fs::set_permissions(&dir, dp)?;
+
+    // 0711 on the state directory: traversable, not listable. See `socket_dir`
+    // for why this exact mode and not 0700 or 0755.
+    let mut hp = std::fs::metadata(termaxa_home)?.permissions();
+    hp.set_mode(0o711);
+    std::fs::set_permissions(termaxa_home, hp)?;
+
+    // 0711 gives TRAVERSAL, so everything private must be private in its own
+    // right rather than by hiding behind the parent. The rig proved the
+    // difference: with only the parent locked down, the agent could not LIST
+    // the state directory and could still `cat` the audit log and a backup by
+    // full path - paths it can guess, since they are documented.
+    //
+    // Belt and braces on every launch rather than once at init: a directory
+    // created later, or loosened by hand, is re-tightened by the process that
+    // owns the boundary.
+    for private in ["projects", "backups", "logs"] {
+        let p = termaxa_home.join(private);
+        if p.exists() {
+            harden(&p)?;
+        }
+    }
+
     let sock = socket_path(termaxa_home);
 
     // A stale socket file from a killed supervisor would make `bind` fail, and
@@ -315,6 +364,29 @@ pub fn serve(termaxa_home: &Path) -> anyhow::Result<()> {
         let reply = handle(&line, peer_uid);
         let _ = writeln!(stream, "{reply}");
         let _ = stream.flush();
+    }
+    Ok(())
+}
+
+/// Make a directory and everything under it operator-only.
+///
+/// Recursive because the state directory nests: `projects/<hash>/logs/` holds
+/// the audit log, and a permissive directory anywhere on that path is a way in.
+#[cfg(unix)]
+fn harden(dir: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut p = std::fs::metadata(dir)?.permissions();
+    p.set_mode(0o700);
+    std::fs::set_permissions(dir, p)?;
+    for entry in std::fs::read_dir(dir)?.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            harden(&path)?;
+        } else {
+            let mut fp = std::fs::metadata(&path)?.permissions();
+            fp.set_mode(0o600);
+            std::fs::set_permissions(&path, fp)?;
+        }
     }
     Ok(())
 }
@@ -502,6 +574,7 @@ mod tests {
              not a fact"
         );
 
+        std::fs::create_dir_all(socket_dir(home)).unwrap();
         std::fs::write(socket_path(home), b"").unwrap();
         assert_eq!(detect(home), Mode::Supervised);
     }

--- a/tests/boundary/rig.sh
+++ b/tests/boundary/rig.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# The privilege boundary, proved by a second real user.
+#
+# Unit tests cannot prove a privilege boundary. Every test in the Rust suite
+# runs as one user, so "the agent cannot write the policy" is, at best, an
+# assertion about code paths. This rig creates a real second account and has
+# it TRY — write the policy, edit the log, delete a backup, kill the
+# supervisor — and asserts each attempt fails at the OS.
+#
+# EVERY ASSERTION HAS A CONTROL LEG. `the_probe_writes_nothing` is the lesson:
+# a test that cannot detect success passes vacuously, and a misconfigured rig
+# that silently proves nothing is worse than no rig, because it reports green.
+# So for each "the agent cannot X", the rig also proves the OPERATOR can X.
+# If a control leg fails, the rig is broken, not the boundary.
+#
+# Runs as root, in a container. Not on a developer machine: it creates and
+# deletes a user account.
+#
+# CURRENT STATUS: 16 of 18 pass. Two fail, and they are REAL GAPS, not rig
+# bugs: an agent can `cat` the audit log and a backup by full path. The
+# supervisor hardens directories when it starts, but files the daemon writes
+# AFTERWARDS are created with the default mode, so anything appended or copied
+# during a session is readable by anyone who knows the path — and the paths are
+# documented.
+#
+# Left failing on purpose. A rig tuned until it is green reports what its
+# author wanted; a rig left red reports what is true, and these two are exactly
+# what v0.17 must close before it ships. The fix belongs in `audit.rs` and
+# `backup.rs` — create at 0600 rather than harden after — with this rig as the
+# acceptance test.
+
+set -uo pipefail
+
+BIN="${1:?usage: rig.sh /path/to/termaxa}"
+AGENT_USER="termaxa-agent"
+OPERATOR_HOME="$(mktemp -d)"
+# mktemp -d creates at 0700. A real install has TERMAXA_HOME under a 0755 home
+# directory; without this the AGENT cannot traverse the operator's temp dir and
+# every socket assertion below fails for a reason that has nothing to do with
+# the boundary being tested. The rig spent three rounds on that before the
+# measurement said so — a test fixture standing in for a real environment has
+# to reproduce the parts the test depends on.
+chmod 0755 "$OPERATOR_HOME"
+PROJECT="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+say()  { printf '\n\033[1m%s\033[0m\n' "$*"; }
+ok()   { printf '  \033[32mPASS\033[0m %s\n' "$*"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$*"; FAIL=$((FAIL+1)); }
+
+# as_agent CMD... — run as the unprivileged account.
+as_agent() { sudo -u "$AGENT_USER" -- "$@" >/dev/null 2>&1; }
+
+# denied "label" CMD...   the agent must NOT be able to do this
+denied() {
+  local label="$1"; shift
+  if as_agent "$@"; then
+    bad "$label — the agent SUCCEEDED; the boundary is not there"
+  else
+    ok "$label — refused by the OS"
+  fi
+}
+
+# allowed "label" CMD...  the operator MUST be able to do this
+# This is the control leg: it proves the action is possible at all, so a
+# `denied` pass means "blocked" rather than "impossible for everyone".
+allowed() {
+  local label="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    ok "control: $label — the operator can, so the refusal above is a boundary"
+  else
+    bad "control: $label — the OPERATOR could not either. THE RIG IS BROKEN: \
+the assertion above proves nothing"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+say "Setup"
+# ---------------------------------------------------------------------------
+id -u "$AGENT_USER" >/dev/null 2>&1 || useradd -m "$AGENT_USER"
+echo "  agent uid: $(id -u "$AGENT_USER"), operator uid: $(id -u)"
+
+export TERMAXA_HOME="$OPERATOR_HOME/.termaxa"
+mkdir -p "$TERMAXA_HOME"
+cd "$PROJECT" || exit 1
+TERMAXA_HOME="$TERMAXA_HOME" "$BIN" init >/dev/null 2>&1
+
+# The topology the architecture describes: the state directory is the
+# operator's and the agent has no path into it. 0700 is what makes the audit
+# log and the backups unreachable rather than merely unwritable.
+#
+# The socket cannot live in here — see `supervise::socket_dir`. This rig is
+# what proved that: at 0755 the agent could list the state dir and read the
+# log; at 0700 the socket became unreachable and supervised mode denied
+# everything. The socket has its own 0755 directory holding nothing else.
+# 0711: traversable, not listable. The agent reaches the socket by a path it
+# knows and cannot enumerate anything else. 0700 here breaks supervised mode
+# entirely; 0755 hands over the log and the backups. The daemon sets this
+# itself; the rig sets it too so the assertions below run against the same
+# topology whether or not the daemon has started yet.
+chmod 0711 "$TERMAXA_HOME"
+chmod 0755 "$PROJECT"
+chmod 0644 "$PROJECT/.termaxa/policy.yaml"
+chmod 0755 "$PROJECT/.termaxa"
+
+# The project must be traversable by the agent — it works there.
+chown -R root:root "$PROJECT"
+
+echo "  state dir: $TERMAXA_HOME ($(stat -c %a "$TERMAXA_HOME"))"
+echo "  policy:    $PROJECT/.termaxa/policy.yaml ($(stat -c %a "$PROJECT/.termaxa/policy.yaml"))"
+
+# ---------------------------------------------------------------------------
+say "1. The policy file — agent reads, cannot write"
+# ---------------------------------------------------------------------------
+POLICY="$PROJECT/.termaxa/policy.yaml"
+if as_agent cat "$POLICY"; then
+  ok "the agent CAN read the policy (it must — that is not the boundary)"
+else
+  bad "the agent cannot read the policy; it needs to"
+fi
+denied  "write the policy"        sh -c "echo 'default: allow' > '$POLICY'"
+denied  "truncate the policy"     sh -c ": > '$POLICY'"
+denied  "delete the policy"       rm -f "$POLICY"
+allowed "operator writes the policy" sh -c "cp '$POLICY' '$POLICY.bak' && mv '$POLICY.bak' '$POLICY'"
+
+# ---------------------------------------------------------------------------
+say "2. The audit log — the agent has no path to it"
+# ---------------------------------------------------------------------------
+LOG="$(find "$TERMAXA_HOME" -name audit.jsonl 2>/dev/null | head -1)"
+if [ -z "$LOG" ]; then
+  # `init` alone may not have written one; make a decision so it exists.
+  TERMAXA_HOME="$TERMAXA_HOME" "$BIN" check "ls -la" >/dev/null 2>&1
+  LOG="$(find "$TERMAXA_HOME" -name audit.jsonl 2>/dev/null | head -1)"
+fi
+if [ -n "$LOG" ]; then
+  echo "  log: $LOG"
+  denied  "read the audit log"    cat "$LOG"
+  denied  "append to the log"     sh -c "echo '{}' >> '$LOG'"
+  denied  "delete the log"        rm -f "$LOG"
+  denied  "list the state dir"    ls "$TERMAXA_HOME"
+  allowed "operator reads the log" cat "$LOG"
+else
+  bad "no audit log was produced; the log assertions could not run"
+fi
+
+# ---------------------------------------------------------------------------
+say "3. Backups — the agent cannot read, edit or delete them"
+# ---------------------------------------------------------------------------
+mkdir -p "$TERMAXA_HOME/backups/b-rig"
+echo "insured contents" > "$TERMAXA_HOME/backups/b-rig/file.txt"
+BK="$TERMAXA_HOME/backups/b-rig/file.txt"
+denied  "read a backup"           cat "$BK"
+denied  "overwrite a backup"      sh -c "echo tampered > '$BK'"
+denied  "delete a backup"         rm -rf "$TERMAXA_HOME/backups/b-rig"
+allowed "operator reads a backup" cat "$BK"
+
+# ---------------------------------------------------------------------------
+say "4. The supervisor process — the agent cannot stop it"
+# ---------------------------------------------------------------------------
+TERMAXA_HOME="$TERMAXA_HOME" "$BIN" supervise >/dev/null 2>&1 &
+SUP_PID=$!
+sleep 1
+if kill -0 "$SUP_PID" 2>/dev/null; then
+  echo "  supervisor pid: $SUP_PID"
+  denied  "kill the supervisor"     kill -9 "$SUP_PID"
+  sleep 0.3
+  if kill -0 "$SUP_PID" 2>/dev/null; then
+    ok "the supervisor is still running after the attempt"
+  else
+    bad "the supervisor DIED — the agent stopped it"
+  fi
+
+  # The socket must remain connectable: the agent asks, it does not decide.
+  SOCK="$TERMAXA_HOME/run/supervise.sock"
+  if [ -S "$SOCK" ]; then
+    if as_agent test -w "$SOCK"; then
+      ok "the agent CAN connect to the socket (it must — asking is its job)"
+    else
+      bad "the agent cannot reach the socket; supervised mode would deny everything"
+    fi
+  else
+    bad "no socket at $SOCK"
+  fi
+
+  allowed "operator kills the supervisor" kill -9 "$SUP_PID"
+else
+  bad "the supervisor did not start; assertions 4 could not run"
+fi
+
+# ---------------------------------------------------------------------------
+say "Result"
+# ---------------------------------------------------------------------------
+rm -rf "$PROJECT" "$OPERATOR_HOME"
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Unit tests cannot prove a privilege boundary. Every test in the Rust suite runs
as one user, so "the agent cannot write the policy" is an assertion about code
paths. This rig creates a real account and has it **try**.

## Result: 16 of 18 hold. Two fail, and they stay failing.

| asset | result |
|---|---|
| policy | read OK; write, truncate, delete **refused by the OS** |
| audit log | append **refused**, delete **refused**, state dir not listable |
| backups | overwrite **refused**, delete **refused** |
| supervisor | kill **refused**, still running afterwards |
| socket | agent **can** connect — asking is its job |
| **audit log** | **FAILING — agent can `cat` it by full path** |
| **backups** | **FAILING — agent can `cat` one by full path** |

Every assertion has a **control leg** proving the operator *can* do the thing,
so a refusal means "blocked" rather than "impossible for everyone" — the lesson
of `the_probe_writes_nothing` applied to privilege. All four control legs pass.

## The rig killed two plausible designs immediately

0755 on the state dir agent can LIST it, then read the log and backups
0700 on the state dir agent cannot traverse to the socket, so every hook
denies — perfectly secure, completely useless
0711 on the state dir traverse without enumerate. Measured: ls DENIED,
cat of the log DENIED, socket REACHABLE

Traversal needs execute on every directory in the **path**, which a design
document does not surface and a second user finds in one attempt. The
architecture said "dir 0755, socket connectable"; that cannot hold, and only
running it showed why.

## The two failures are real gaps, not rig bugs

The supervisor hardens directories at startup; files it writes *afterwards* get
default modes, so anything appended or copied during a session is readable by
anyone who knows the path — and the paths are documented. Fix belongs in
`audit.rs` and `backup.rs` (create at `0600` rather than harden after), with
this rig as the acceptance test.

**Left red on purpose.** A rig tuned until it is green reports what its author
wanted; a rig left red reports what is true. The CI job is `continue-on-error`
— deliberately, and *not* the same decision as #67's clippy flip: blocking every
PR on a known gap means fixing it under time pressure or deleting the
assertion, and the second is how a rig becomes decorative. Remove
`continue-on-error` when it is green. **v0.17 ship blocker.**

## Gate

439 Linux / 384 Windows, unchanged — the rig is a shell script, not a cargo
test. clippy clean under `-D warnings`, fmt clean.