### PR TITLE
v0.17: state files are private at creation, and the rig goes green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,20 +64,14 @@ jobs:
   # paths. This job creates a real account and has it TRY, asserting each
   # attempt fails at the OS.
   #
-  # continue-on-error is DELIBERATE and temporary, and it is not the same
-  # decision as the clippy one (#67). Two of the eighteen assertions currently
-  # FAIL, for a real reason recorded in the rig's own header: files the daemon
-  # writes after startup are created with default modes, so the audit log and
-  # backups are readable by path. Blocking every PR on a known gap would mean
-  # either fixing it under time pressure or deleting the assertion, and the
-  # second is how a rig becomes decorative.
-  #
-  # Remove continue-on-error when the rig is green. It is a v0.17 ship
-  # blocker, not a v0.16 one.
+  # BLOCKING as of this commit: the rig is 18/18. It was continue-on-error
+  # while two assertions failed for a real reason, on the argument that
+  # blocking every PR on a known gap means fixing it under time pressure or
+  # deleting the assertion. The gap is fixed, so the exemption goes with it -
+  # an allowance that outlives its reason is how a rig becomes decorative.
   boundary:
     name: privilege boundary (second real user)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -138,6 +138,35 @@ pub struct AuditLog {
     path: PathBuf,
 }
 
+/// Open for append, creating at `0600` when it does not exist.
+///
+/// PRIVATE AT CREATION TIME, which is the invariant. The supervisor used to
+/// harden the state directory when it started, and the boundary rig showed why
+/// that is not enough: a daemon runs for hours and the interesting files are
+/// the ones it writes DURING that time. A log created mid-session inherited the
+/// process umask and was readable by any account that knew the path - and the
+/// paths are documented.
+///
+/// Applied in basic mode too. There the agent shares the user, so `0600`
+/// protects nothing from it; what it does protect is the record from OTHER
+/// accounts on a shared machine. The audit log belongs to whoever runs
+/// Termaxa, and no other account should read it by default.
+///
+/// `.mode()` only exists on Unix. Windows has a different permission model
+/// entirely and pretending otherwise would be a claim the OS does not back;
+/// there the file is created with the default ACL and the boundary story for
+/// Windows is basic mode, stated in SECURITY.md.
+fn private_append(path: &Path) -> std::io::Result<std::fs::File> {
+    let mut opts = OpenOptions::new();
+    opts.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    opts.open(path)
+}
+
 impl AuditLog {
     /// Log lives at `<termaxa_dir>/logs/audit.jsonl`.
     pub fn new(termaxa_dir: &Path) -> Result<Self> {
@@ -167,10 +196,7 @@ impl AuditLog {
         entry.prev = self.last_hash()?;
         entry.hash = Some(entry.digest());
 
-        let mut f = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)
+        let mut f = private_append(&self.path)
             .with_context(|| format!("cannot open {}", self.path.display()))?;
         let line = serde_json::to_string(&entry)?;
         writeln!(f, "{}", line)?;

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -415,6 +415,7 @@ fn backup_files(
 fn copy_recursive(src: &Path, dst: &Path) -> Result<()> {
     if src.is_dir() {
         fs::create_dir_all(dst)?;
+        make_private(dst, true)?;
         for entry in fs::read_dir(src)? {
             let entry = entry?;
             copy_recursive(&entry.path(), &dst.join(entry.file_name()))?;
@@ -422,8 +423,34 @@ fn copy_recursive(src: &Path, dst: &Path) -> Result<()> {
     } else {
         if let Some(parent) = dst.parent() {
             fs::create_dir_all(parent)?;
+            make_private(parent, true)?;
         }
         fs::copy(src, dst)?;
+        // `fs::copy` PRESERVES the source's permission bits, so a
+        // world-readable file stays world-readable once copied aside. That is
+        // the wrong default for a backup: the copy lives in the state
+        // directory and is the record's private property, whatever the
+        // original was. Set after the copy because `fs::copy` writes the mode
+        // itself.
+        make_private(dst, false)?;
+    }
+    Ok(())
+}
+
+/// `0600` for a file, `0700` for a directory. No-op on Windows, which has a
+/// different permission model that this cannot express - see SECURITY.md for
+/// what that means for the Windows boundary story.
+fn make_private(path: &Path, is_dir: bool) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut p = fs::metadata(path)?.permissions();
+        p.set_mode(if is_dir { 0o700 } else { 0o600 });
+        fs::set_permissions(path, p)?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (path, is_dir);
     }
     Ok(())
 }

--- a/tests/boundary/rig.sh
+++ b/tests/boundary/rig.sh
@@ -16,18 +16,9 @@
 # Runs as root, in a container. Not on a developer machine: it creates and
 # deletes a user account.
 #
-# CURRENT STATUS: 16 of 18 pass. Two fail, and they are REAL GAPS, not rig
-# bugs: an agent can `cat` the audit log and a backup by full path. The
-# supervisor hardens directories when it starts, but files the daemon writes
-# AFTERWARDS are created with the default mode, so anything appended or copied
-# during a session is readable by anyone who knows the path — and the paths are
-# documented.
-#
-# Left failing on purpose. A rig tuned until it is green reports what its
-# author wanted; a rig left red reports what is true, and these two are exactly
-# what v0.17 must close before it ships. The fix belongs in `audit.rs` and
-# `backup.rs` — create at 0600 rather than harden after — with this rig as the
-# acceptance test.
+# STATUS: 18 of 18. The two failures this rig shipped with are closed — state
+# files are now created at 0600 rather than hardened afterwards, which is the
+# invariant a long-running daemon needs. The CI job is blocking.
 
 set -uo pipefail
 
@@ -147,12 +138,28 @@ fi
 # ---------------------------------------------------------------------------
 say "3. Backups — the agent cannot read, edit or delete them"
 # ---------------------------------------------------------------------------
-mkdir -p "$TERMAXA_HOME/backups/b-rig"
-echo "insured contents" > "$TERMAXA_HOME/backups/b-rig/file.txt"
-BK="$TERMAXA_HOME/backups/b-rig/file.txt"
+# Take a REAL backup through the real code path, rather than fabricating one
+# with `echo >`. A fixture that bypasses the code under test cannot test it:
+# the first version of this rig hand-made a backup file, so `make_private`
+# never ran on it and the assertion below failed against a file Termaxa had
+# never written.
+mkdir -p "$PROJECT/doomed" && echo "insured contents" > "$PROJECT/doomed/file.txt"
+# `rm -r`, not `rm -rf`: the starter policy DENIES the forced form, and a
+# denied command correctly takes no backup - so asking for one with `-rf`
+# produced nothing and the assertions below tested a path that did not exist.
+# The control leg caught that; without it this rig would have reported three
+# passes against /nonexistent.
+( cd "$PROJECT" && printf 'y\n' | TERMAXA_HOME="$TERMAXA_HOME" "$BIN" run -- rm -r doomed ) >/dev/null 2>&1
+BK="$(find "$TERMAXA_HOME" -path '*backups*' -name 'file.txt' 2>/dev/null | head -1)"
+if [ -z "$BK" ]; then
+  bad "no backup was produced through the real path; the backup assertions could not run"
+  BK="/nonexistent"
+else
+  echo "  backup: $BK ($(stat -c %a "$BK"))"
+fi
 denied  "read a backup"           cat "$BK"
 denied  "overwrite a backup"      sh -c "echo tampered > '$BK'"
-denied  "delete a backup"         rm -rf "$TERMAXA_HOME/backups/b-rig"
+denied  "delete a backup"         rm -f "$BK"
 allowed "operator reads a backup" cat "$BK"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The two gaps the boundary rig shipped with are closed. **18 of 18.**

## Creation time is the invariant

The supervisor hardened directories when it started, and that cannot be enough:
a daemon runs for hours and the interesting files are the ones it writes
*during* that time. A log line appended mid-session inherited the process
umask; a backup copied aside inherited the **source file's** mode, so insuring
a world-readable file produced a world-readable copy inside the state directory.

| file | fix |
|---|---|
| `audit.rs` | `OpenOptions::mode(0o600)` at create |
| `backup.rs` | `make_private` after `fs::copy` (which preserves source bits), `0700` on directories created along the way |

Applied in **basic mode too**. There the agent shares the user, so `0600`
protects nothing from it — what it protects is the record from other accounts
on a shared machine. No compatibility contract breaks: nobody should have been
relying on a second Unix account reading Termaxa's private state.

Windows takes the `cfg(not(unix))` path and does nothing rather than pretending
Unix permission semantics exist there.

## The rig caught two bugs in itself

**First:** the backup assertions tested a file the rig had fabricated with
`echo >`, so `make_private` never ran on it. A fixture that bypasses the code
under test cannot test it.

**Second, and the one worth reading:** after switching to a real backup, the rig
used `rm -rf doomed` — which the starter policy **denies**, so nothing ran,
nothing was insured, and three assertions were testing `/nonexistent`. The
control leg fired:

FAIL control: operator reads a backup — the OPERATOR could not either.
THE RIG IS BROKEN: the assertion above proves nothing

Without control legs this commit would have reported green while proving
nothing — exactly the failure `the_probe_writes_nothing` was written about.
`rm -r` is the permitted form and takes a real backup.

## CI

`continue-on-error` removed from the boundary job. It was there while two
assertions failed for a real reason; the reason is gone, so the exemption goes
with it. An allowance that outlives its justification is how a rig becomes
decorative.

## Gate

439 Linux / 384 Windows unchanged (rig is a shell script). Boundary rig: 18/18.