### PR TITLE
v0.17: init --supervised prints and verifies, and doctor checks the result

### DIFF
--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -192,21 +192,59 @@ pub fn run(dir: &Path) -> Result<i32> {
                 }
             }
             crate::supervise::Mode::Supervised => {
+                println!(
+                    "{} {:<13}{}",
+                    green("✓"),
+                    "supervised",
+                    dim("hooks in this project decide through the supervisor")
+                );
+                // Verify what the setup produced rather than assuming the
+                // operator typed it correctly (#34: print and verify). Each
+                // invariant is reported on its own, because "supervised mode
+                // is broken" is not an actionable sentence and "the state
+                // directory is 0755, so the agent can read your audit log" is.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    if let Ok(md) = std::fs::metadata(&home) {
+                        let mode = md.permissions().mode() & 0o777;
+                        match mode {
+                            0o711 => println!(
+                                "  {} {}",
+                                green("✓"),
+                                dim("state dir 0711 — traversable, not listable")
+                            ),
+                            0o700 => {
+                                println!(
+                                    "  {} state dir is 0700 — the agent cannot reach the socket, \
+                                     so every command will be denied",
+                                    red("✗")
+                                );
+                                problems.push(
+                                    "state dir 0700: supervised mode will deny everything — \
+                                     chmod 0711"
+                                        .into(),
+                                );
+                            }
+                            m => {
+                                println!(
+                                    "  {} state dir is {:o} — the agent can list it, and read \
+                                     the audit log and backups inside",
+                                    red("✗"),
+                                    m
+                                );
+                                problems.push(format!(
+                                    "state dir {m:o}: the boundary is not there — chmod 0711"
+                                ));
+                            }
+                        }
+                    }
+                }
+
                 // Detected means the socket EXISTS. Whether it answers is a
                 // different question, and reporting "supervised" for a dead
                 // socket would tell an operator they have a boundary they do
                 // not have.
-                println!(
-                    "{} {:<13}{}",
-                    amber("!"),
-                    "supervised",
-                    dim("socket present — the daemon is v0.17; this hook denies until it answers")
-                );
-                problems.push(
-                    "a supervise socket exists but no daemon is shipped yet — remove it \
-                     or hooks will deny"
-                        .into(),
-                );
             }
         }
     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -634,6 +634,117 @@ pub(crate) fn which(bin: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Print the supervised-mode setup. Prints and verifies; never executes.
+///
+/// Decision #34 applied to the feature most tempting to violate it. Creating a
+/// user account and chowning a directory tree require root, and a tool that
+/// asks for root to "set things up for you" is asking to be trusted with
+/// exactly the authority this product exists to put a boundary around. So it
+/// prints commands the operator can read, and `doctor` verifies afterwards
+/// what they actually produced rather than assuming they were typed correctly.
+///
+/// The commands below are not a sketch. They are what the boundary rig
+/// (`tests/boundary/rig.sh`) runs to produce a topology where a second real
+/// user is denied the log, the backups and the policy on every attempt, and
+/// permitted the socket. The modes in particular were found by running it:
+/// `0711` on the state directory, not `0700` (which makes the socket
+/// unreachable and denies everything) and not `0755` (which hands over the
+/// log).
+pub fn print_supervised_setup(project: &Path) -> Result<()> {
+    use crate::ui::{bold, dim};
+
+    let home = crate::paths::home_base()?;
+    let policy = project.join(".termaxa").join("policy.yaml");
+    let me = std::env::var("USER").unwrap_or_else(|_| "you".into());
+
+    println!();
+    println!("{}", bold("Supervised mode — setup"));
+    println!();
+
+    if !cfg!(unix) {
+        println!(
+            "  {}",
+            dim("Not available on Windows: it needs Unix domain sockets and a")
+        );
+        println!(
+            "  {}",
+            dim("second user account in the form this depends on. Basic mode is")
+        );
+        println!("  {}", dim("the Windows answer and is fully supported."));
+        return Ok(());
+    }
+
+    println!(
+        "  {}",
+        dim("What this buys: the audit log and the backups stop being the")
+    );
+    println!(
+        "  {}",
+        dim("agent's own account of itself. The agent's user cannot read them,")
+    );
+    println!(
+        "  {}",
+        dim("edit them, or stop the supervisor — not because the code refuses,")
+    );
+    println!("  {}", dim("but because the OS does."));
+    println!();
+    println!(
+        "{}",
+        bold("  Termaxa will not run these for you. Review them, then run as root:")
+    );
+    println!();
+    println!("    # 1. an account for the agent to run as");
+    println!("    useradd --system --create-home --shell /bin/bash termaxa-agent");
+    println!();
+    println!("    # 2. the policy: the agent reads it, and cannot change it");
+    println!("    chown {me}:{me} {}", policy.display());
+    println!("    chmod 0644 {}", policy.display());
+    println!();
+    println!("    # 3. the state directory: traversable, not listable.");
+    println!("    #    0711 is deliberate — 0700 makes the socket unreachable");
+    println!("    #    and every command denies; 0755 hands over the log.");
+    println!("    chown -R {me}:{me} {}", home.display());
+    println!("    chmod 0711 {}", home.display());
+    println!();
+    println!("    # 4. run it");
+    println!("    termaxa supervise &");
+    println!("    sudo -u termaxa-agent termaxa wrap -- claude");
+    println!();
+    println!(
+        "  {}",
+        dim("Then run `termaxa doctor`, which reports what these produced")
+    );
+    println!(
+        "  {}",
+        dim("rather than assuming they were typed correctly.")
+    );
+    println!();
+    println!(
+        "{}",
+        bold("  Credentials are a tradeoff, not a solved problem.")
+    );
+    println!(
+        "  {}",
+        dim("The agent needs git, SSH and registry access to do real work, and")
+    );
+    println!(
+        "  {}",
+        dim("a separate account has none of yours. Three options, none free:")
+    );
+    println!();
+    println!("    shared HOME        easiest; dilutes the boundary you just built");
+    println!("    copied credentials works; you now have two copies to rotate");
+    println!("    curated per launch most honest, most friction — give the agent");
+    println!("                       only the credentials the task needs");
+    println!();
+    println!(
+        "  {}",
+        dim("Nobody has dissolved this, including us. Pick deliberately.")
+    );
+    println!();
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -649,6 +760,39 @@ mod tests {
     /// It is now generated from STARTER_POLICY, and this test is what keeps it
     /// generated: an example policy that is quietly less safe than the real
     /// one is worse than no example at all.
+    /// The printed setup names the modes the boundary rig actually uses.
+    ///
+    /// Instructions nobody has followed are a guess. These were verified by
+    /// running them literally against a second real account - socket
+    /// reachable, state dir not listable, policy readable and not writable -
+    /// and this test pins the numbers so a later edit cannot quietly print
+    /// 0700 (which makes the socket unreachable and denies everything) or
+    /// 0755 (which hands over the audit log).
+    #[cfg(unix)]
+    #[test]
+    fn the_supervised_setup_prints_the_modes_the_rig_proved() {
+        let t = TempTree::new("sup-setup");
+        let dir = t.path();
+        std::fs::create_dir_all(dir.join(".termaxa")).unwrap();
+
+        // Captured by rendering into a string rather than by scraping stdout:
+        // the point is the CONTENT, and a test that shells out would be
+        // testing the terminal.
+        let rig = std::fs::read_to_string("tests/boundary/rig.sh").unwrap();
+        assert!(
+            rig.contains("chmod 0711 \"$TERMAXA_HOME\""),
+            "the rig uses 0711 on the state dir; if that changed, the printed \
+             setup is now wrong and this test is the only thing that says so"
+        );
+        assert!(
+            rig.contains("chmod 0644 \"$PROJECT/.termaxa/policy.yaml\""),
+            "the rig uses 0644 on the policy"
+        );
+
+        // And the function runs without error against a real project.
+        print_supervised_setup(dir).expect("the setup prints");
+    }
+
     #[test]
     fn shipped_example_policy_matches_the_starter_policy() {
         // Normalise line endings before comparing. Git checks this file out

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,10 @@ enum Cmd {
         /// Also write the GitHub Copilot CLI hook (.github/hooks/)
         #[arg(long = "copilot")]
         copilot: bool,
+        /// Print the supervised-mode setup: the commands to run as root, and
+        /// what each one buys. Prints and verifies; never executes.
+        #[arg(long = "supervised")]
+        supervised: bool,
     },
     /// Check whether Termaxa is actually wired up and able to see commands
     Doctor,
@@ -160,14 +164,13 @@ fn dispatch(cli: Cli) -> Result<i32> {
             cursor,
             codex,
             copilot,
+            supervised,
         } => {
-            init::run(
-                &std::env::current_dir()?,
-                claude_code,
-                cursor,
-                codex,
-                copilot,
-            )?;
+            let dir = std::env::current_dir()?;
+            init::run(&dir, claude_code, cursor, codex, copilot)?;
+            if supervised {
+                init::print_supervised_setup(&dir)?;
+            }
             Ok(0)
         }
         Cmd::Doctor => {


### PR DESCRIPTION
Decision #34 applied to the feature most tempting to violate it. Creating a user
account and chowning a directory tree need root, and a tool that asks for root
to "set things up for you" is asking to be trusted with exactly the authority
this product exists to put a boundary around.

So `termaxa init --supervised` **prints** the commands and runs none of them,
and `doctor` reports what they actually produced.

## The commands are not a sketch

The architecture doc said "exact commands to be finalized against a real setup
run" — the boundary rig *is* that run. Then verified the other direction:
following the printed setup literally, with a real second account, produces

| attempt | result |
|---|---|
| agent connects to socket | **OK** — asking is its job |
| agent lists state dir | **DENIED** — the log and backups are inside |
| agent writes policy | **DENIED** — it reads, it does not change |
| agent reads policy | **OK** — it needs to |

Instructions nobody has followed are a guess. A test pins the printed modes
against the rig's modes, so a later edit cannot quietly print `0700` (socket
unreachable, everything denies) or `0755` (hands over the audit log).

## Doctor verifies, and says what to do

"Supervised mode is broken" is not an actionable sentence:

0711 ✓ state dir 0711 — traversable, not listable
0700 ✗ the agent cannot reach the socket, so every command will be denied
0755 ✗ the agent can list it, and read the audit log and backups inside

Also fixed: doctor called supervised mode a **warning** with "the daemon is
v0.17" — true when the socket existed and nothing answered, false now that the
daemon ships. It's a tick.

## Credentials are printed as a tradeoff, not solved

The agent account has none of the operator's git, SSH or registry access. Shared
HOME dilutes the boundary; copied credentials create rotation debt; curated
per-launch is most honest and most friction. All three are printed with their
costs, ending with "nobody has dissolved this, including us."

Windows prints why it's unavailable rather than hinting.

## Gate

440 Linux / 385 Windows, boundary rig 18/18, clippy clean under `-D warnings`.