### PR TITLE
docs: supervised mode, the grades table, and what is not yet proven

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ notify:                          # optional
 | `termaxa` | what this is, and what to try next |
 | `termaxa init [--claude-code]` | scaffold `.termaxa/`, detect tools, install the hook |
 | `termaxa wrap -- <agent>` | launch an agent with shelled commands routed through the gate (Unix) |
+| `termaxa supervise` | run the decision daemon as yourself; hooks decide through it (Unix) |
+| `termaxa init --supervised` | print the supervised-mode setup — prints, never executes |
 | `termaxa doctor` | is the gate wired up? binary, policy, agents, tools, state |
 | `termaxa check "<cmd>"` | dry-run: verdict + preview (exit 0/3/4) |
 | `termaxa run -- <cmd>` | gated execution: preview → approve → backup → run |
@@ -352,7 +354,7 @@ Colour is on when output is a terminal and off when it isn't. `NO_COLOR`, `TERMA
 
 Termaxa is pre-1.0. It's real and tested, and it is not magic. Specifically:
 
-- **Hooks advise; they don't enforce.** Termaxa gates commands an agent submits through the Claude Code or Cursor hook. Those agents are *cooperative* — they respect a `deny` and propose an alternative, which is what makes the gate work. An agent running in full-auto mode could, in principle, retry a blocked action through a different command or shell; the circuit breaker raises the cost of that, but a hook is an *integration* point for visibility and policy, not an *enforcement* boundary. `termaxa wrap -- <agent>` (Unix, v0.16) widens this: commands the agent runs *through a shell* pass through the gate even without a hook, though a caller naming `/bin/sh` by absolute path still does not. True enforcement means owning the execution path — that's the supervisor, next release. For hard guarantees today, pair Termaxa with OS-level sandboxing.
+- **Hooks advise; they don't enforce.** Termaxa gates commands an agent submits through the Claude Code or Cursor hook. Those agents are *cooperative* — they respect a `deny` and propose an alternative, which is what makes the gate work. An agent running in full-auto mode could, in principle, retry a blocked action through a different command or shell; the circuit breaker raises the cost of that, but a hook is an *integration* point for visibility and policy, not an *enforcement* boundary. `termaxa wrap -- <agent>` (Unix, v0.16) widens this: commands the agent runs *through a shell* pass through the gate even without a hook, though a caller naming `/bin/sh` by absolute path still does not. **Supervised mode** (Unix, v0.17) goes further and moves the *authority*: a daemon under your user decides, and the agent runs as a different account that cannot read the audit log, edit the backups, or stop the supervisor — proved by a rig that creates a second real user and has it try. See [docs/supervisor.md](docs/supervisor.md), which is also honest that no real agent session has run under it yet. For hard guarantees today, pair Termaxa with OS-level sandboxing.
 - **Native agent tools bypass the gate.** The hook sees *shell* commands. An agent's own built-in file/edit tools don't go through the shell — observed in live testing, a Cursor agent switched to its native file-delete tool and removed files Termaxa never saw. Non-shell tool calls need OS-level isolation underneath.
 - **Cooperative, not a sandbox.** Termaxa governs commands that flow through the agent hook or `termaxa run`. An agent with raw, unhooked shell access is *not* contained — that needs OS-level sandboxing, a complementary layer. The threat model is *agents making expensive mistakes*, not a malicious agent actively evading you.
 - **Shell parsing is good, not perfect.** It splits on `&&`, `||`, `;`, `|`
@@ -373,7 +375,7 @@ See [SECURITY.md](SECURITY.md) for the full threat model.
 
 ## Contributing
 
-Issues and PRs welcome. `cargo test` must pass; CI runs on Linux, macOS, and Windows. The codebase is dependency-light Rust: ~9,500 lines of production code in `src/`, plus ~10,500 lines of tests (unit tests live beside the code they test; `tests/` holds the integration ones). More test than product, on purpose — `src/policy.rs` and `src/preview.rs` are the best places to start reading, and the test module at the bottom of each file explains what the code is defending against.
+Issues and PRs welcome. `cargo test` must pass; CI runs on Linux, macOS, and Windows. The codebase is dependency-light Rust: ~10,200 lines of production code in `src/`, plus ~10,600 lines of tests (unit tests live beside the code they test; `tests/` holds the integration ones). More test than product, on purpose — `src/policy.rs` and `src/preview.rs` are the best places to start reading, and the test module at the bottom of each file explains what the code is defending against.
 
 If you can make an agent get past the gate in a way that isn't already documented above, that's the most useful contribution you can make: [open an issue](https://github.com/termaxa/termaxa/issues) or email security@termaxa.com.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -140,6 +140,25 @@ Stated plainly, so a changelog line reading "hash-chained audit log" is not mist
 | basic (default, all platforms) | the agent's own user | corruption and casual edits are visible |
 | supervised (Unix, v0.17) | the supervisor, outside the agent's reach | the record is one the agent cannot rewrite |
 
+## Four grades, and what each one leaves open
+
+Supervised mode (v0.17) is not a switch from "unsafe" to "safe". It is one of four topologies, each with a different authority story and a different residue. No grade claims containment, and the bottom row's honest limits are in the same table that sells it.
+
+| grade | routing | authority | what the agent's domain can still do |
+|---|---|---|---|
+| **hook** (basic, default, all platforms) | the harness invokes the hook | the agent's own user | edit the policy and hook configs (advised against by the self-defence rules and the write matcher), delete the record, bypass via any non-hooked execution path |
+| **hook + modes** (Unix, no daemon) | same | the agent's user, but policy and configs operator-owned | delete or edit the record and the backups; bypass via non-hooked paths |
+| **wrapped** (`termaxa wrap -- <agent>`) | every command run *through a shell* reaches the gate, hooked or not | the agent's user | tamper with the record; escape via tools that execute without spawning through the wrapper — an absolute `/bin/sh`, or a direct `execve` |
+| **supervised** (wrap + daemon + modes) | wrapped | **the operator's user** | attempt commands, each of which is denied and recorded; social-engineer the human; anything root-adjacent the OS itself permits |
+
+Two things worth reading off that table rather than around it.
+
+**Every grade is bypassable by an agent that is trying.** The top three are bypassable by an agent that is merely resourceful. The fourth narrows the agent's domain to "ask and be refused", but an agent that can talk to a human can still ask the human, and an OS misconfiguration is still an OS misconfiguration.
+
+**The improvement between rows three and four is privilege, not cleverness.** Wrapped mode routes more commands through the same code; supervised mode moves *who runs that code*. That is the only step in the table that changes what the record is worth, which is why the audit chain section above draws its line exactly there.
+
+Setup, the credential tradeoff, and what supervised mode has and has not been proved against: [docs/supervisor.md](docs/supervisor.md). It is honest about the last part — the boundary is proved by an automated rig with a second real user, and not yet by a real agent session.
+
 **Migration.** Entries written before v0.16 have no hash. They stay readable and are reported as pre-chain rather than as breaks: Termaxa can prove continuity from the boundary onward, and does not retroactively claim to have protected history it was not there for. A broken link names the entry and leaves the rest of the record readable, because one corrupt line making the whole log unreadable would destroy more evidence than the corruption did.
 
 ## Reporting a vulnerability

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -1,0 +1,157 @@
+# Supervised mode
+
+**Unix only. Not available on Windows** — it needs Unix domain sockets and a second user account in the form this depends on. Basic mode is the Windows answer and is fully supported there; `termaxa doctor` says so rather than hinting.
+
+**Status: the boundary is proved by an automated rig, not yet by a real agent session.** See [What is not yet proven](#what-is-not-yet-proven) before relying on this in anger. That section is not boilerplate — it names specific things nobody has watched happen.
+
+---
+
+## What it changes
+
+In basic mode — the default everywhere — the hook runs as **your own user**. It reads the policy, decides, writes the audit log and takes backups, all with the same filesystem authority the agent has. That is enough for the threat model Termaxa is built for (see [SECURITY.md](../SECURITY.md)): an agent making expensive mistakes, in the open, through the shell.
+
+It is not enough for one specific claim. In basic mode, **the audit log is the agent's own account of itself**. Anything that can edit an entry can recompute the hash chain over it. The record is tamper-evident, not tamper-resistant.
+
+Supervised mode moves the authority. A small daemon runs as **you**; the agent runs as a **different user**; and the two talk over a socket:
+
+```
+  agent user                          operator (you)
+  ----------                          --------------
+  claude ──▶ termaxa hook ──socket──▶ termaxa supervise
+                                        │
+                                        ├── reads the policy
+                                        ├── decides
+                                        ├── takes the backup
+                                        └── writes the audit log
+```
+
+The hook forwards the **raw payload** and prints what comes back. It does not evaluate, insure, audit or preview on its own authority — anything it concluded would be a conclusion reached inside the agent's trust domain, which is the thing this mode exists to stop relying on.
+
+What that buys, concretely:
+
+| asset | basic mode | supervised mode |
+|---|---|---|
+| policy file | agent-writable; self-defence rules advise against it | operator-owned, `0644` — agent reads, cannot write |
+| hook configs | same | same — operator-owned, read-only to the agent |
+| audit log | the hook appends directly, as the agent's user | **the supervisor appends; the agent's user has no path to it** |
+| backups | the hook writes them directly | **the supervisor writes and holds them; the agent cannot read, edit or delete them** |
+| the supervisor | — | the agent cannot stop it |
+
+Every row of that table is asserted by `tests/boundary/rig.sh`, which creates a real second account and has it **try**. 18 assertions, each with a control leg proving the operator *can* do the thing — so a refusal means "blocked", not "impossible for everyone".
+
+---
+
+## Setup
+
+`termaxa init --supervised` prints the commands and **runs none of them**. Creating a user and chowning a directory tree need root, and a tool that asks for root to set things up for you is asking to be trusted with exactly the authority this mode exists to bound.
+
+```bash
+cd your-project
+termaxa init --supervised     # prints; does not execute
+```
+
+It prints, roughly:
+
+```bash
+# 1. an account for the agent to run as
+useradd --system --create-home --shell /bin/bash termaxa-agent
+
+# 2. the policy: the agent reads it, and cannot change it
+chown you:you .termaxa/policy.yaml
+chmod 0644 .termaxa/policy.yaml
+
+# 3. the state directory: traversable, not listable
+chown -R you:you ~/.termaxa
+chmod 0711 ~/.termaxa
+
+# 4. run it
+termaxa supervise &
+sudo -u termaxa-agent termaxa wrap -- claude
+```
+
+Then:
+
+```bash
+termaxa doctor
+```
+
+which reports what those commands actually produced rather than assuming you typed them correctly.
+
+### Why `0711` and not `0700` or `0755`
+
+This is the one number worth understanding, because both obvious choices are wrong and neither is obviously wrong.
+
+```
+0755   the agent can LIST the state directory — and from there read the
+       audit log and the backups it is supposed to be unable to reach
+0700   the agent cannot traverse to the socket, so every hook invocation
+       denies. Perfectly secure, completely useless.
+0711   traverse without enumerate: the agent reaches a socket path it
+       already knows, and cannot list the directory or anything in it
+```
+
+Traversal needs execute permission on **every** directory in the path, which is the part a design sketch does not surface. The socket lives in `~/.termaxa/run/` at `0755`, containing nothing but the socket; the state directory above it is `0711`; the log and backup directories inside are `0700` in their own right, because `0711` grants traversal and anything private must be private itself rather than hiding behind its parent.
+
+All three of those numbers came from running the rig with a second real user, not from reasoning about them. The first two designs were plausible on paper and both failed.
+
+---
+
+## Failure direction: it denies
+
+If the socket is present and the supervisor does not answer — not running, wedged, or a version mismatch — **the hook denies**, with a reason naming the cause:
+
+```
+[termaxa] supervised mode is configured but the supervisor is not answering
+          — refusing rather than deciding without it
+```
+
+This is deliberate and it is the permanent answer to a real incident: Cursor 3.11 renamed its hook events, Termaxa silently stopped gating it, and four releases shipped with the gate quietly open. A gate that loses its brain must not carry on as if it had one.
+
+The practical consequence: **if you stop the supervisor, the agent stops working.** That is the intended trade. Stop the agent first, or remove the socket to return to basic mode.
+
+Protocol version mismatches deny too, with their own message — the hook binary and the daemon binary *will* skew during an upgrade, because nothing restarts a daemon when a package manager replaces a file.
+
+---
+
+## Credentials: a named tradeoff, not a solved problem
+
+The agent account is a different user. It has none of your git config, SSH keys, npm tokens or cloud credentials. That is the point — and it is also the part most likely to make supervised mode annoying.
+
+Three ways out, none free:
+
+| approach | what it costs |
+|---|---|
+| **shared HOME** | easiest. Dilutes the boundary you just built: the agent user can now read whatever your home directory holds. |
+| **copied credentials** | works. You now have two copies of every secret to rotate, and a second place they can leak from. |
+| **curated per launch** | most honest, most friction. Give the agent account only the credentials the task needs — a deploy key for one repo rather than your SSH agent. |
+
+The default recommendation is curated-per-launch, and the honest caveat is that nobody has dissolved this problem, including us. An agent that cannot push is an agent that cannot finish half its work; an agent with your full credential set is a boundary in name.
+
+Decide deliberately, and write down what you chose.
+
+---
+
+## What is not yet proven
+
+Everything above is verified by an automated rig and by end-to-end tests with synthetic payloads. **No real agent has run a real session under this topology.** Until that happens, these are the specific things nobody has watched:
+
+- **Whether a real agent can work at all under a separate account.** Credentials are the obvious risk. The first `git push` is where this gets tested for real.
+- **Previews in supervised mode.** Static analysis runs supervisor-side; live introspection subprocesses (`psql`, `git`, `terraform show`) run hook-side in the agent's domain and travel as an *agent-observed annotation*, never as the gate's own observation. Where that leaves a preview thinner than in basic mode, the output is supposed to say so. Nobody has compared them side by side.
+- **Latency and contention.** Every command makes a socket round-trip to a single-threaded server with a two-second timeout. An agent issuing commands rapidly may expose queuing the design assumed away.
+- **`SO_PEERCRED` on macOS.** Linux reports the connecting UID. macOS spells it differently (`LOCAL_PEERCRED`, different struct), and rather than guess at an untested ABI, `peer_uid` returns `None` there — so the audit records an absent identity rather than a wrong one.
+- **Daemon lifecycle.** `termaxa supervise &` is the documented start. systemd user units and launchd plists are recipes to write, not managed magic, and neither has been exercised.
+
+When the proving run happens it will be published as a field report — including whatever it breaks. Every real bug this project has found came from running the thing rather than reasoning about it, and this document will be updated to say what changed.
+
+---
+
+## Returning to basic mode
+
+Stop the supervisor and remove the socket:
+
+```bash
+pkill -f "termaxa supervise"
+rm ~/.termaxa/run/supervise.sock
+```
+
+Mode is detected from the filesystem — the socket is either there or it is not — so removing it returns the hook to deciding locally. A configuration file claiming supervision would be a claim; the socket is a fact.


### PR DESCRIPTION
`docs/supervisor.md`, the grades table into SECURITY.md, and the README caught
up with two releases it never mentioned. Docs only — 440 tests, boundary rig
18/18, all gates clean.

## The unproven claim is marked as unproven

In its own section, not a footnote. The boundary is verified by an automated rig
that creates a second real account and has it *try* — 18 assertions, each with a
control leg — and by end-to-end tests with synthetic payloads. **No real agent
has run a real session under this topology.**

The doc names five specific things nobody has watched:

- whether a real agent can work at all under a separate account — the
  credential question, and the first `git push` is where it gets answered
- previews in supervised mode: static analysis supervisor-side, live
  introspection hook-side as an *agent-observed annotation*, and nobody has
  compared the two outputs side by side
- latency and contention: every command is a socket round-trip to a
  single-threaded server with a two-second timeout
- `SO_PEERCRED` on macOS, where `peer_uid` returns `None` rather than guessing
  at `LOCAL_PEERCRED`'s untested ABI
- daemon lifecycle: `supervise &` is documented; systemd and launchd are recipes
  to write, not exercised

"Not yet proven on a real agent session" is more useful than either shipping the
claim unmarked or holding the docs until the run happens.

## Why 0711 is explained rather than stated

Both obvious choices are wrong, and neither is obviously wrong:

0755 the agent can LIST the state dir — and read the log and backups inside
0700 the agent cannot traverse to the socket, so every command denies
0711 traverse without enumerate — the only mode that satisfies both

All three numbers came from running the rig, not from reasoning about them. The
first two designs were plausible on paper and both failed.

## The grades table

Lands in SECURITY.md with each row's residue stated in the same table that sells
it. Two readings called out explicitly: **every grade is bypassable by an agent
that is trying**, and the improvement from wrapped to supervised is **privilege,
not cleverness** — which is why the audit-chain section draws its line exactly
there.

## README

- The enforcement bullet said the supervisor was "next release". It has shipped.
- `supervise` and `init --supervised` added to the command table.
- Line count was stale by ~1,500 lines.

**One correction mid-commit:** I wrote "~10,800 lines of tests" as a rounding of
a number I had just measured at 10,639, then fixed it to ~10,600. Production is
~10,163. In a paragraph whose point is *more test than product*, the ratio is
the claim and it should not be approximated upward.