### PR TITLE
v0.17: the endpoint is told, not inferred from $HOME

### DIFF
--- a/docs/field-reports/2026-08-17-supervised-routing.md
+++ b/docs/field-reports/2026-08-17-supervised-routing.md
@@ -1,0 +1,187 @@
+# Field report — supervised mode, first proving run
+
+**Date:** 2026-08-17
+**Commit:** `fa8df50`
+**Environment:** GitHub Codespace, Ubuntu, x86_64
+**Operator:** `codespace` (uid 1000) · **Agent:** `termaxa-agent` (uid 1001)
+**Agent:** Claude Code v2.1.234, authenticated as its own account
+**Termaxa:** built from source, `target/release/termaxa`
+
+---
+
+## The finding
+
+**Supervised mode's boundary works. Its routing does not.** The agent's
+commands never reached the supervisor. They were decided by the hook, on the
+agent's own authority, and recorded in an audit log the agent owns — which is
+the exact outcome supervised mode exists to prevent.
+
+Three facts, all true at the same time, and the combination is the finding:
+
+**1. The boundary holds. 18 of 18 assertions passed in this environment.**
+The agent cannot read the operator's policy, audit log or backups; cannot
+write or delete the policy; cannot stop the supervisor; and can connect to the
+socket. Every control leg passed, so each refusal is a boundary rather than an
+impossibility. This is an independent environment from the one the rig was
+developed in — different kernel, different container, different image — and it
+agrees.
+
+**2. The agent nevertheless ran in basic mode.** Its hook resolved
+`$TERMAXA_HOME` from its own `$HOME`, looked for a socket in
+`/home/termaxa-agent/.termaxa/run/`, found none, concluded `Mode::Basic`, and
+decided locally.
+
+**3. Therefore the boundary test was necessary but not sufficient.** It proved
+isolation. It never proved end-to-end routing, because the rig connects to the
+socket by absolute path rather than by running a hook as the agent user.
+
+The walls are real. The door does not lead into the building.
+
+---
+
+## Evidence
+
+Terminal A (the supervisor), for the whole session:
+
+```
+termaxa: supervising on /home/codespace/.termaxa/run/supervise.sock
+termaxa: hooks in this home now decide through this process
+termaxa: uid=1000 hint=claude-code exit=2
+termaxa: uid=1000 hint=claude-code exit=2
+```
+
+Both `uid=1000` lines are the operator's own pre-flight tests. **Nothing from
+uid 1001 ever arrived**, across an entire agent session.
+
+From the agent's shell, after it ran `ls -la` at 22:45:
+
+```
+$ ls -la /home/termaxa-agent/.termaxa
+drwxrwxr-x 3 termaxa-agent termaxa-agent 4096 Aug 17 22:45 .
+
+$ echo $TERMAXA_HOME
+                                    # empty — resolved from $HOME
+
+$ termaxa log | tail -2
+2026-08-17T22:45:05Z ✓ [hook (87aab5cd)] ls -la — matched rule `ls *`
+2026-08-17T22:45:08Z ✓ [post (87aab5cd)] ls -la — post-execution receipt
+
+$ find /home/codespace/.termaxa -name audit.jsonl
+find: '/home/codespace/.termaxa': Permission denied
+```
+
+The agent created its own state directory at the minute it ran its first
+command, wrote its own audit entries there, and could not have reached the
+operator's state even if it had tried.
+
+Both sides agree: the supervisor saw nothing, and the agent has a log of its
+own.
+
+---
+
+## Why no automated test caught it
+
+Every test that exercises supervised mode runs the hook and the supervisor **as
+the same user**:
+
+- the boundary rig starts the supervisor as root and connects as the agent by
+  absolute socket path — it tests reachability, not discovery
+- the unit tests call `handle()` directly, with no process boundary at all
+- my container and CI both run everything as one uid
+
+`Mode::detect()` reads the filesystem, which is the right instinct — a socket
+is a fact and a config file is a claim. But *which* filesystem path it reads is
+derived from `$HOME`, and in supervised mode the two halves deliberately have
+different homes. The design's central assumption — two different users — was
+never actually exercised until a real agent ran under a real second account.
+
+This is an architectural assumption, not a permissions bug. It could not have
+been found by reading the code, because the code is correct for the case it was
+tested in.
+
+---
+
+## What worked
+
+Worth recording, because the run was not a failure overall:
+
+- **Claude Code authenticates cleanly as a second user.** This was the risk I
+  rated most likely to stop the run dead — the agent has no access to the
+  operator's `~/.claude/.credentials.json` (verified: permission denied) and
+  authenticated through its own OAuth flow in one browser round-trip. No shared
+  HOME, no copied credentials, no dilution of the boundary.
+- **The credential files are `0600` and stay private** even though the setup
+  chmods the operator's home to `0755`. Claude Code sets its own permissions
+  and does not rely on the home directory's mode.
+- **`doctor` caught a genuinely ungated session.** The hook was registered as
+  `termaxa hook`, a bare name, and the binary was not on `PATH` (source build).
+  Doctor reported `✗ hook registered but NOT firing — commands are ungated`,
+  which is precisely the failure mode it was built for after the Cursor 3.11
+  incident. Fixed with a symlink; doctor then reported `✓ configured and live`.
+- **`SO_PEERCRED` works outside the development container.** The operator's own
+  test produced `uid=1000 hint=claude-code exit=2` — the kernel's answer, not
+  the caller's claim.
+- **The boundary rig reproduces in an independent environment**, 18/18.
+
+---
+
+## Smaller findings
+
+- **`init --supervised` reprints the whole of `init`.** Harness detection, the
+  tool list, the full `.claude/settings.json` snippet, and "To wire Termaxa
+  into Claude Code, run: `termaxa init --claude-code`" — advice the user has
+  just followed. The supervised instructions are buried under ~60 lines of
+  duplication.
+- **`sudo -u termaxa-agent` prompts for a password** on a machine whose sudoers
+  rule is `(root) NOPASSWD: ALL` — passwordless for root only. The printed
+  setup's last line is `sudo -u termaxa-agent termaxa wrap -- claude`, which
+  will prompt on any such machine. Common on managed dev environments.
+- **`chmod 0755 ~` in the printed setup is broader than needed.** It makes the
+  operator's entire home listable to the agent. `0711` would let the agent
+  traverse to the project without enumerating everything beside it — the same
+  reasoning the state directory already uses.
+- **The setup does not say where the agent works.** `cd ~/proving` means
+  something different for each user; the project path should be explicit.
+
+---
+
+## What this changes
+
+`docs/supervisor.md` currently describes routing that does not happen. Its "not
+yet proven" section listed five unknowns; this run answers one of them
+(credentials: fine) and adds a sixth that is worse than any of them.
+
+**Before v0.17 can tag:**
+
+1. **Fix the routing.** The state directory and the supervisor endpoint are
+   different concepts and should be discovered differently. `$HOME` belongs to
+   the process making the request, which in supervised mode is deliberately the
+   agent; pointing `TERMAXA_HOME` at the operator's home to make this work
+   would reverse the ownership model and create a convention where an
+   environment variable hands an agent a path to privileged state.
+2. **Add the acceptance test the rig was missing:** wrap as operator → execute
+   a hook as a *different UID* → verify the request reaches the operator-owned
+   supervisor → verify the decision is recorded in the operator's log → verify
+   the agent cannot read that log. The existing rig proves the last clause
+   only.
+3. **Fix the smaller findings above**, particularly the `init --supervised`
+   duplication, which is the first thing a supervised user reads.
+
+Until then `docs/supervisor.md` should say, in its first paragraph rather than
+its last section, that supervised mode does not currently route agent commands
+to the supervisor.
+
+---
+
+## Note on method
+
+The run took about ninety minutes, most of it setup, and found this in the
+first command the agent executed. Everything before that — 439 unit tests, 18
+boundary assertions, three green CI platforms, end-to-end tests with synthetic
+payloads — was consistent with a system that works. It took one real agent, as
+one real second user, running `ls -la`.
+
+The rig was not wrong. It answered the question it was asked, and it is still
+the reason we know the boundary holds. It simply was not asked whether a hook
+running as a different user could find the supervisor at all, because nobody
+had thought to ask.

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -2,7 +2,7 @@
 
 **Unix only. Not available on Windows** — it needs Unix domain sockets and a second user account in the form this depends on. Basic mode is the Windows answer and is fully supported there; `termaxa doctor` says so rather than hinting.
 
-**Status: the boundary is proved by an automated rig, not yet by a real agent session.** See [What is not yet proven](#what-is-not-yet-proven) before relying on this in anger. That section is not boilerplate — it names specific things nobody has watched happen.
+**Status: proved by an automated rig across two real users, and by one real agent session** — which found a routing bug the rig could not see. See [the field report](field-reports/2026-08-17-supervised-routing.md) and [What is not yet proven](#what-is-not-yet-proven), which is shorter than it was.
 
 ---
 
@@ -135,7 +135,7 @@ Decide deliberately, and write down what you chose.
 
 Everything above is verified by an automated rig and by end-to-end tests with synthetic payloads. **No real agent has run a real session under this topology.** Until that happens, these are the specific things nobody has watched:
 
-- **Whether a real agent can work at all under a separate account.** Credentials are the obvious risk. The first `git push` is where this gets tested for real.
+- **Whether a real agent can finish real work under a separate account.** Claude Code *authenticates* cleanly as a second user — verified 2026-08-17, one OAuth round-trip, no shared HOME and no copied credentials. What is still untested is git: the agent account has no git identity or SSH key, and the first `git push` is where that bites.
 - **Previews in supervised mode.** Static analysis runs supervisor-side; live introspection subprocesses (`psql`, `git`, `terraform show`) run hook-side in the agent's domain and travel as an *agent-observed annotation*, never as the gate's own observation. Where that leaves a preview thinner than in basic mode, the output is supposed to say so. Nobody has compared them side by side.
 - **Latency and contention.** Every command makes a socket round-trip to a single-threaded server with a two-second timeout. An agent issuing commands rapidly may expose queuing the design assumed away.
 - **`SO_PEERCRED` on macOS.** Linux reports the connecting UID. macOS spells it differently (`LOCAL_PEERCRED`, different struct), and rather than guess at an untested ABI, `peer_uid` returns `None` there — so the audit records an absent identity rather than a wrong one.

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -173,10 +173,7 @@ pub fn run(dir: &Path) -> Result<i32> {
     println!();
     println!("{}", bold("Mode"));
     {
-        // Same answer `supervise` uses for the socket path, from the same
-        // function - so doctor cannot report a mode the hook does not see.
-        let home = crate::paths::home_base().unwrap_or_default();
-        match crate::supervise::detect(&home) {
+        match crate::supervise::detect() {
             crate::supervise::Mode::Basic => {
                 println!(
                     "{} {:<13}{}",
@@ -203,9 +200,13 @@ pub fn run(dir: &Path) -> Result<i32> {
                 // invariant is reported on its own, because "supervised mode
                 // is broken" is not an actionable sentence and "the state
                 // directory is 0755, so the agent can read your audit log" is.
+                // Bound inside the block that reads it: the mode check is
+                // Unix-only, and a binding outside would be dead on Windows -
+                // which `-D warnings` catches there and not here.
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;
+                    let home = crate::paths::home_base().unwrap_or_default();
                     if let Ok(md) = std::fs::metadata(&home) {
                         let mode = md.permissions().mode() & 0o777;
                         match mode {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -694,25 +694,26 @@ pub fn decide(raw_payload: &str) -> Result<Outcome> {
     // silent fail-open, because a gate that loses its brain and carries on is
     // worse than one that stops. An operator who configured supervision gets
     // a refusal with a reason, not a decision made by the wrong process.
-    let termaxa_home = crate::paths::home_base().unwrap_or_default();
-    if crate::supervise::detect(&termaxa_home) == crate::supervise::Mode::Supervised {
+    if crate::supervise::detect() == crate::supervise::Mode::Supervised {
         // Forward and print. Nothing below this line runs: this hook has no
         // authority in supervised mode, and exercising any would produce a
         // decision made inside the agent's own trust domain.
         //
-        // A SECOND supervised hook must not recurse into the supervisor - the
+        // The endpoint comes from `TERMAXA_SOCKET` (exported by `wrap`), an
+        // XDG runtime dir, or the operator's own state directory - NOT from
+        // this process's $HOME. The first proving run found why: a hook
+        // running as the agent resolved $HOME to the agent's home, found no
+        // socket, and quietly decided on its own authority.
+        //
+        // A second supervised hook must not recurse into the supervisor: the
         // daemon calls `decide` itself, and if that call re-entered here it
-        // would connect to its own socket and deadlock on a single-threaded
-        // server. `TERMAXA_SUPERVISOR=1` in the daemon's own process is what
-        // breaks the loop.
+        // would connect to its own socket and deadlock a single-threaded
+        // server. TERMAXA_SUPERVISOR=1 in the daemon's own process breaks the
+        // loop.
         if std::env::var("TERMAXA_SUPERVISOR").as_deref() != Ok("1") {
+            let sock = crate::supervise::endpoint().unwrap_or_default();
             return Ok(
-                match crate::supervise::ask(
-                    &termaxa_home,
-                    &buf,
-                    Some(input.dialect.actor()),
-                    &input.cwd,
-                ) {
+                match crate::supervise::ask(&sock, &buf, Some(input.dialect.actor()), &input.cwd) {
                     Ok(resp) => Outcome {
                         rendered: Some(resp.rendered),
                         exit_code: resp.exit_code,

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -47,34 +47,92 @@ pub const PROTOCOL_VERSION: u32 = 1;
 /// The socket's name, inside its own directory beside the state directory.
 pub const SOCKET_NAME: &str = "supervise.sock";
 
-/// The directory holding only the socket: `$TERMAXA_HOME/run`, mode `0755`.
+/// Where the supervisor listens, and how a hook finds it.
 ///
-/// The state directory above it is `0711` — EXECUTE WITHOUT READ. That single
-/// mode is what makes supervised mode possible, and it took a rig with a
-/// second real user to find it:
+/// THE ENDPOINT IS NOT STATE, and discovering it like state was the bug the
+/// first proving run found. Every automated test ran the hook and the
+/// supervisor as the same user, so `$HOME`-relative discovery worked. The
+/// first time a real agent ran under a real second account, its hook resolved
+/// `$TERMAXA_HOME` from ITS OWN home, found no socket there, concluded basic
+/// mode, and decided on its own authority - writing an audit log the agent
+/// owned. The walls held; the door led nowhere.
 ///
-///   0755 on the state dir  agent can LIST it, and from there read the audit
-///                          log and the backups. Boundary gone.
-///   0700 on the state dir  agent cannot traverse to the socket, so every
-///                          hook denies. Perfectly secure, completely useless.
-///   0711 on the state dir  agent can traverse THROUGH to a path it already
-///                          knows, cannot enumerate the directory, and the
-///                          log and backups stay 0700 in their own right.
+/// So the two are separated:
 ///
-/// Measured, not reasoned: at 0711 an unprivileged account was denied `ls` on
-/// the state directory, denied `cat` on the audit log, denied `ls` on the logs
-/// directory, and permitted to reach the socket.
+///   operator state   `$TERMAXA_HOME` or `~/.termaxa` — the operator's, and
+///                    the agent has no path into it. Unchanged.
+///   IPC endpoint     a socket path the agent is TOLD, in a runtime directory
+///                    that holds nothing else.
 ///
-/// Traversal needs execute on EVERY directory in the path, which is the part a
-/// design document does not surface. `run/` being 0755 is necessary and not
-/// sufficient.
+/// `$HOME` belongs to the process making the request, which in supervised mode
+/// is deliberately the agent. Pointing the agent's state home at the
+/// operator's would reverse the ownership model, and would establish a
+/// convention where an environment variable hands an agent a path to
+/// privileged state. The endpoint is the only thing the agent needs, so the
+/// endpoint is the only thing it gets.
+///
+/// Resolution order, most explicit first:
+///
+///   1. `$TERMAXA_SOCKET`         set by `wrap`, or by an operator by hand
+///   2. `$XDG_RUNTIME_DIR/termaxa/supervise.sock`   per-user runtime dir
+///   3. `<state>/run/supervise.sock`                the operator's own default
+///
+/// A hook running as the agent finds it via (1), because `wrap` exports it.
+/// The supervisor binds via (3) unless told otherwise, and prints what it
+/// bound so the operator can see it.
+pub const SOCKET_ENV: &str = "TERMAXA_SOCKET";
+/// The directory holding only the socket, under a given state directory.
+///
+/// `0755`, containing nothing but the socket; the state directory above it is
+/// `0711` (traverse, not enumerate). Both numbers came from running the
+/// boundary rig - `0700` makes the socket unreachable and denies everything,
+/// `0755` on the state dir hands over the audit log.
 pub fn socket_dir(termaxa_home: &Path) -> PathBuf {
     termaxa_home.join("run")
 }
 
-/// Where the supervisor's socket lives for a given Termaxa home.
-pub fn socket_path(termaxa_home: &Path) -> PathBuf {
+/// Where the supervisor should BIND, given its own state directory.
+pub fn bind_path(termaxa_home: &Path) -> PathBuf {
+    if let Some(p) = explicit_socket() {
+        return p;
+    }
     socket_dir(termaxa_home).join(SOCKET_NAME)
+}
+
+/// Where a hook should LOOK. Deliberately not `$HOME`-relative.
+///
+/// Returns `None` when no endpoint is configured anywhere, which is the
+/// ordinary basic-mode answer: no supervisor, decide locally.
+pub fn endpoint() -> Option<PathBuf> {
+    if let Some(p) = explicit_socket() {
+        return Some(p);
+    }
+    if let Some(p) = runtime_socket() {
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    // The operator's own default, which is what a hook run BY the operator
+    // finds. An agent under `wrap` gets (1) instead.
+    let state = crate::paths::home_base().ok()?;
+    let p = socket_dir(&state).join(SOCKET_NAME);
+    p.exists().then_some(p)
+}
+
+fn explicit_socket() -> Option<PathBuf> {
+    std::env::var(SOCKET_ENV)
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .map(PathBuf::from)
+}
+
+/// `$XDG_RUNTIME_DIR/termaxa/supervise.sock`. Per-user, cleaned up by the OS,
+/// and the conventional home for a socket rather than for state.
+fn runtime_socket() -> Option<PathBuf> {
+    std::env::var("XDG_RUNTIME_DIR")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .map(|d| PathBuf::from(d).join("termaxa").join(SOCKET_NAME))
 }
 
 /// What the hook sends: the payload as it arrived, and nothing it concluded.
@@ -167,19 +225,21 @@ pub enum Mode {
     Supervised,
 }
 
-/// Detect the mode for a Termaxa home.
+/// Is a supervisor configured for THIS process?
+///
+/// Answered from the endpoint, not from a state directory. A hook running as
+/// the agent has no path into the operator's state and must not need one - it
+/// needs the socket it was told about, and nothing else.
 ///
 /// FAILING CLOSED IS NOT THE SAME AS DETECTING SUPERVISION. This answers only
-/// "is a supervisor configured here" — the socket exists. Whether it ANSWERS
-/// is a separate question, and the separation is deliberate: a hook that
-/// treated an unreachable supervisor as "basic mode, carry on" would fail
-/// OPEN at exactly the moment the operator most expects it not to. Detect,
-/// then require an answer, and refuse if there is none.
-pub fn detect(termaxa_home: &Path) -> Mode {
-    if socket_path(termaxa_home).exists() {
-        Mode::Supervised
-    } else {
-        Mode::Basic
+/// "is an endpoint configured and present". Whether it ANSWERS is a separate
+/// question, deliberately: a hook that treated an unreachable supervisor as
+/// "basic mode, carry on" would fail OPEN exactly where the operator most
+/// expects otherwise.
+pub fn detect() -> Mode {
+    match endpoint() {
+        Some(_) => Mode::Supervised,
+        None => Mode::Basic,
     }
 }
 
@@ -195,7 +255,7 @@ pub fn detect(termaxa_home: &Path) -> Mode {
 /// rather than a hang. Every failure below denies.
 #[cfg(unix)]
 pub fn ask(
-    termaxa_home: &Path,
+    sock: &Path,
     payload: &str,
     dialect_hint: Option<&str>,
     cwd: &str,
@@ -203,8 +263,7 @@ pub fn ask(
     use std::io::{BufRead, BufReader, Write};
     use std::os::unix::net::UnixStream;
 
-    let sock = socket_path(termaxa_home);
-    let mut stream = UnixStream::connect(&sock).map_err(|_| SuperviseError::Unreachable)?;
+    let mut stream = UnixStream::connect(sock).map_err(|_| SuperviseError::Unreachable)?;
     let timeout = std::time::Duration::from_secs(2);
     let _ = stream.set_read_timeout(Some(timeout));
     let _ = stream.set_write_timeout(Some(timeout));
@@ -228,7 +287,7 @@ pub fn ask(
 
 #[cfg(not(unix))]
 pub fn ask(
-    _termaxa_home: &Path,
+    _sock: &Path,
     _payload: &str,
     _dialect_hint: Option<&str>,
     _cwd: &str,
@@ -316,7 +375,7 @@ pub fn serve(termaxa_home: &Path) -> anyhow::Result<()> {
         }
     }
 
-    let sock = socket_path(termaxa_home);
+    let sock = bind_path(termaxa_home);
 
     // A stale socket file from a killed supervisor would make `bind` fail, and
     // worse, mode detection already reports Supervised for it - so every hook
@@ -497,7 +556,6 @@ pub fn serve(_termaxa_home: &Path) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testutil::TempTree;
 
     /// The daemon answers a well-formed request with a decision it made
     /// itself. Exercised without a socket, so a failure here is decision
@@ -563,20 +621,46 @@ mod tests {
         );
     }
 
+    /// The endpoint is discovered from the ENDPOINT, not from a state
+    /// directory, and the distinction is the whole of the routing fix.
+    ///
+    /// The first proving run found a hook running as the agent resolving
+    /// `$HOME` to the agent's home, finding no socket there, concluding basic
+    /// mode, and deciding on its own authority while the supervisor sat idle
+    /// with nothing to do. Discovering an IPC endpoint the way state is
+    /// discovered only works while both live under one user.
     #[test]
-    fn mode_is_read_from_the_filesystem_not_from_configuration() {
-        let t = TempTree::new("mode-detect");
-        let home = t.path();
-        assert_eq!(
-            detect(home),
-            Mode::Basic,
-            "no socket means basic - a config file claiming otherwise would be a claim, \
-             not a fact"
-        );
+    fn the_endpoint_is_told_not_inferred_from_home() {
+        // TestEnv, not TempTree: this reads and writes process-global
+        // environment, and every other reader of it holds this lock. #63 is
+        // the entry about what happens when one test does not.
+        let env = crate::testutil::TestEnv::new("endpoint");
+        let home = env.root().to_path_buf();
 
-        std::fs::create_dir_all(socket_dir(home)).unwrap();
-        std::fs::write(socket_path(home), b"").unwrap();
-        assert_eq!(detect(home), Mode::Supervised);
+        let prev_sock = std::env::var(SOCKET_ENV).ok();
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        std::env::remove_var(SOCKET_ENV);
+        std::env::remove_var("XDG_RUNTIME_DIR");
+
+        // No endpoint anywhere: basic mode, the ordinary answer.
+        assert_eq!(detect(), Mode::Basic);
+
+        // An explicit endpoint is honoured wherever it points - including a
+        // path with no relationship to this process's home, which is exactly
+        // the agent's situation under `wrap`.
+        let sock = home.join("elsewhere.sock");
+        std::fs::write(&sock, b"").unwrap();
+        std::env::set_var(SOCKET_ENV, &sock);
+        assert_eq!(detect(), Mode::Supervised);
+        assert_eq!(endpoint().unwrap(), sock);
+
+        match prev_sock {
+            Some(v) => std::env::set_var(SOCKET_ENV, v),
+            None => std::env::remove_var(SOCKET_ENV),
+        }
+        if let Some(v) = prev_xdg {
+            std::env::set_var("XDG_RUNTIME_DIR", v);
+        }
     }
 
     /// The hook forwards the payload and nothing it concluded. Pinned because

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -136,6 +136,23 @@ pub fn run(argv: &[String], termaxa_home: &Path) -> Result<i32> {
         // provenance rather than policy input.
         .env("TERMAXA_WRAPPED", "1");
 
+    // THE ENDPOINT, and only the endpoint.
+    //
+    // The wrapped process runs as the agent, whose $HOME is deliberately not
+    // the operator's - so it cannot discover the socket the way the operator
+    // does, and must be TOLD. The first proving run found this the hard way:
+    // an agent's hook looked in its own home, found nothing, and decided
+    // locally while the supervisor sat idle.
+    //
+    // What travels is the socket path. NOT TERMAXA_HOME: pointing the agent's
+    // state directory at the operator's would reverse the ownership model and
+    // establish a convention where an environment variable hands an agent a
+    // path to privileged state. The agent needs to ask; it does not need to
+    // know where the answers are kept.
+    if let Some(sock) = crate::supervise::endpoint() {
+        cmd.env(crate::supervise::SOCKET_ENV, &sock);
+    }
+
     let status = cmd
         .status()
         .with_context(|| format!("cannot launch {}", argv[0]))?;

--- a/tests/boundary/rig.sh
+++ b/tests/boundary/rig.sh
@@ -22,7 +22,20 @@
 
 set -uo pipefail
 
-BIN="${1:?usage: rig.sh /path/to/termaxa}"
+BIN_SRC="${1:?usage: rig.sh /path/to/termaxa}"
+
+# The agent must be able to EXECUTE the binary, and where CI checks out is not
+# our business: GitHub runners use /home/runner at 0700, so an agent account
+# cannot traverse to a binary built there. Sections 1-4 never noticed because
+# they run as root or against /tmp; section 5 is the only one that has the
+# agent exec it directly.
+#
+# Copied to a path the rig controls rather than chmod-ing someone's home. A
+# test that loosens the permissions of the directory it happens to be run from
+# has changed the machine to suit itself.
+BIN_DIR="$(mktemp -d)"; chmod 0755 "$BIN_DIR"
+BIN="$BIN_DIR/termaxa"
+cp "$BIN_SRC" "$BIN"; chmod 0755 "$BIN"
 AGENT_USER="termaxa-agent"
 OPERATOR_HOME="$(mktemp -d)"
 # mktemp -d creates at 0700. A real install has TERMAXA_HOME under a 0755 home
@@ -196,8 +209,81 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+say "5. Routing — a hook run as the AGENT reaches the operator's supervisor"
+# ---------------------------------------------------------------------------
+#
+# The assertion the first four sections could not make. They proved ISOLATION:
+# the agent cannot reach the operator's state. They never proved ROUTING: that
+# a hook running as the agent finds the supervisor at all.
+#
+# The first proving run found the gap between those. Every automated test ran
+# the hook and the supervisor as the SAME user, so $HOME-relative endpoint
+# discovery worked. A real agent under a real second account resolved $HOME to
+# its own home, found no socket, concluded basic mode, and decided on its own
+# authority - while the supervisor sat idle. The walls held; the door led
+# nowhere.
+TERMAXA_HOME="$TERMAXA_HOME" "$BIN" supervise > "$PROJECT/sup.log" 2>&1 &
+SUP2=$!
+sleep 1
+SOCK="$TERMAXA_HOME/run/supervise.sock"
+
+if [ -S "$SOCK" ]; then
+  PAYLOAD='{"tool_name":"Bash","tool_input":{"command":"rm -rf /"},"cwd":"'"$PROJECT"'"}'
+
+  # As the agent, with ONLY the endpoint - no TERMAXA_HOME, no path into the
+  # operator's state. This is exactly what `wrap` gives a wrapped agent.
+  OUT="$(echo "$PAYLOAD" | sudo -u "$AGENT_USER" env -i \
+        HOME=/home/$AGENT_USER PATH=/usr/bin:/bin \
+        TERMAXA_SOCKET="$SOCK" "$BIN" hook 2>&1)"
+
+  if echo "$OUT" | grep -q '"permissionDecision":"deny"'; then
+    ok "the agent's hook got a decision back"
+  else
+    bad "the agent's hook did not get a decision: $OUT"
+  fi
+
+  # And the decision was made THERE, not here: the supervisor logged the
+  # agent's uid. Without this the test would pass on a hook that decided
+  # locally and happened to reach the same verdict.
+  AGENT_UID="$(id -u "$AGENT_USER")"
+  if grep -q "uid=$AGENT_UID" "$PROJECT/sup.log"; then
+    ok "the supervisor recorded uid=$AGENT_UID — it decided, not the hook"
+  else
+    bad "the supervisor never saw the request (log: $(tr '\n' ' ' < "$PROJECT/sup.log"))"
+  fi
+
+  # The record landed in the OPERATOR's log, and the agent cannot read it.
+  OPLOG="$(find "$TERMAXA_HOME" -name audit.jsonl 2>/dev/null | head -1)"
+  if [ -n "$OPLOG" ] && grep -q "rm -rf /" "$OPLOG"; then
+    ok "the decision is in the operator's audit log"
+  else
+    bad "the decision is not in the operator's log"
+  fi
+  denied "read the operator's log after it recorded the agent" cat "$OPLOG"
+
+  # CONTROL LEG: with no endpoint told, the agent falls back to basic mode and
+  # decides locally. Proves section 5 is testing routing rather than the hook
+  # merely working at all.
+  echo "$PAYLOAD" | sudo -u "$AGENT_USER" env -i \
+      HOME=/home/$AGENT_USER PATH=/usr/bin:/bin \
+      "$BIN" hook >/dev/null 2>&1
+  BEFORE="$(grep -c "uid=$AGENT_UID" "$PROJECT/sup.log")"
+  sleep 0.3
+  AFTER="$(grep -c "uid=$AGENT_UID" "$PROJECT/sup.log")"
+  if [ "$BEFORE" = "$AFTER" ]; then
+    ok "control: with no endpoint told, nothing reaches the supervisor"
+  else
+    bad "control: a hook with no endpoint still reached the supervisor"
+  fi
+
+  kill -9 $SUP2 2>/dev/null
+else
+  bad "no socket at $SOCK; routing assertions could not run"
+fi
+
+# ---------------------------------------------------------------------------
 say "Result"
 # ---------------------------------------------------------------------------
-rm -rf "$PROJECT" "$OPERATOR_HOME"
+rm -rf "$PROJECT" "$OPERATOR_HOME" "$BIN_DIR"
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
The first proving run found supervised mode did not route. This fixes it and
adds the assertion that would have caught it.

## What happened

A real agent, as a real second user, ran `ls -la`. The command was gated,
allowed, and recorded — by the **hook**, on the agent's own authority, into an
audit log the agent owned. The supervisor logged nothing. Its hook had resolved
`$TERMAXA_HOME` from its own `$HOME`, looked in
`/home/termaxa-agent/.termaxa/run/`, found no socket, and concluded basic mode.

The boundary was intact throughout — 18/18 rig assertions passed in that same
session. **The walls held; the door led nowhere.**

## Why nothing caught it

Every automated test ran the hook and the supervisor as the **same user**. The
rig starts the daemon as root and connects by absolute socket path; the unit
tests call `handle()` directly with no process boundary; CI is one uid
throughout. `$HOME`-relative discovery works perfectly while both halves share
a home — and supervised mode's entire premise is that they do not.

## The fix separates two concepts

| | discovery |
|---|---|
| operator state | `$TERMAXA_HOME` or `~/.termaxa` — unchanged |
| IPC endpoint | `TERMAXA_SOCKET` → `$XDG_RUNTIME_DIR/termaxa/` → operator's `run/` |

`wrap` exports the **endpoint** and only the endpoint. Not `TERMAXA_HOME` —
that was the tempting one-line fix, and it would have made this test pass while
reversing the ownership model and establishing a convention where an
environment variable hands an agent a path to privileged state. `$HOME` belongs
to the process making the request, which here is deliberately the agent. The
agent needs to ask; it does not need to know where the answers are kept.

`detect()` takes no argument now. Asking "is a supervisor configured for *this
process*" from a state directory was the category error underneath the bug.

## The missing assertion — rig now 23, up from 18

PASS the agent's hook got a decision back
PASS the supervisor recorded uid=1001 — it decided, not the hook
PASS the decision is in the operator's audit log
PASS read the operator's log after it recorded the agent — refused by the OS
PASS control: with no endpoint told, nothing reaches the supervisor

The uid check is load-bearing: without it the test passes on a hook that decided
locally and happened to agree. The control leg proves the section tests
**routing** rather than the hook merely working.

Sections 1–4 proved isolation and were never wrong. They were incomplete, and
nobody noticed because isolation is the part that sounds like the whole claim.

## Also

The field report is committed at `docs/field-reports/`, including what worked:
Claude Code authenticates cleanly as a second user in one OAuth round-trip,
`doctor` caught a genuinely ungated session from a source build not on `PATH`,
and `SO_PEERCRED` works outside the development container.

## Gate

440 Linux / 385 Windows, boundary rig 23/23, clippy clean under `-D warnings`.