### PR TITLE
v0.17: the root rule names the root, and nothing else

### DIFF
--- a/docs/field-reports/2026-08-17-supervised-routing.md
+++ b/docs/field-reports/2026-08-17-supervised-routing.md
@@ -173,6 +173,47 @@ to the supervisor.
 
 ---
 
+## Second session, 2026-08-18: the fix confirmed, and two more findings
+
+After the routing fix, the same environment, a real agent again.
+
+**The fix works where the bug was found.** `uid=1001` in the supervisor log on
+the agent's first command, the decision recorded in the OPERATOR's log
+(`2026-08-18T10:27:32Z`), and the agent's own log unchanged from the previous
+day. Then three more from real Claude Code tool calls, and a fourth with
+`exit=2` when it tried `rm -rf .git`.
+
+**The agent read a deny as information, not as an obstacle.** Its own words:
+
+> This is a guardrail on recursive deletes, not something I should work around
+> by rewriting the command — the block is the environment telling me this class
+> of operation needs to come from you directly.
+
+It then offered the `!` prefix — the documented escape hatch — rather than
+retrying with a variation. That is the cooperative-agent model in SECURITY.md
+behaving as described, observed rather than assumed.
+
+**Finding: the root rule explained itself wrongly.** The deny read
+`Recursive delete from root is blocked` for `/home/codespace/proving/.git`,
+which is not the root. `match: "rm -rf /*"` is a wildcard, so it matched every
+absolute path and then explained itself with the root's reason. Right verdict,
+wrong sentence — the same class as v0.16's `(removed)` versus "Overwriting"
+mismatch. Narrowed to `rm -rf /` and `rm -rf / *`; the broad `*rm -rf*` rule
+catches everything else and says something true about it.
+
+**Non-finding, recorded because I got it wrong first:** I concluded from the
+session that previews do not survive the supervised path, because the deny the
+agent displayed carried no blast radius. Measured afterwards, basic and
+supervised produce byte-identical reasons including `— 26 files`. The agent had
+quoted only the first line. The docs' "previews in supervised mode" unknown is
+answered: they survive.
+
+**Also observed:** asked to "delete everything in the .git directory", the
+agent declined on its own and offered four options before Termaxa saw anything.
+The gate was never consulted. Worth remembering when reading any demo — a
+cooperative agent's own caution and the gate's enforcement are different
+mechanisms, and only one of them is ours.
+
 ## Note on method
 
 The run took about ninety minutes, most of it setup, and found this in the

--- a/examples/policy.yaml
+++ b/examples/policy.yaml
@@ -149,9 +149,19 @@ rules:
   - match: "git push*--force*"
     action: deny
     reason: "Force pushes are blocked by policy. Open a PR instead."
-  - match: "rm -rf /*"
+  # The filesystem root, and only the root. `rm -rf /*` would be a WILDCARD
+  # matching every absolute path — `rm -rf /home/me/project/.git` included —
+  # and would then explain itself as "delete from root", which is the right
+  # verdict wearing the wrong sentence. A proving run caught it: an agent was
+  # correctly stopped from deleting a .git directory and told the reason was
+  # the filesystem root. The broad `*rm -rf*` rule below catches everything
+  # else and says something true about it.
+  - match: "rm -rf /"
     action: deny
-    reason: "Recursive delete from root is blocked."
+    reason: "Recursive delete from the filesystem root is blocked."
+  - match: "rm -rf / *"
+    action: deny
+    reason: "Recursive delete from the filesystem root is blocked."
   # GNU rm refuses `rm -rf /` on its own; --no-preserve-root is the one
   # spelling it obeys. The rule above is named for the command everybody
   # quotes, this one is named for the command that actually works.

--- a/src/init.rs
+++ b/src/init.rs
@@ -155,9 +155,19 @@ rules:
   - match: "git push*--force*"
     action: deny
     reason: "Force pushes are blocked by policy. Open a PR instead."
-  - match: "rm -rf /*"
+  # The filesystem root, and only the root. `rm -rf /*` would be a WILDCARD
+  # matching every absolute path — `rm -rf /home/me/project/.git` included —
+  # and would then explain itself as "delete from root", which is the right
+  # verdict wearing the wrong sentence. A proving run caught it: an agent was
+  # correctly stopped from deleting a .git directory and told the reason was
+  # the filesystem root. The broad `*rm -rf*` rule below catches everything
+  # else and says something true about it.
+  - match: "rm -rf /"
     action: deny
-    reason: "Recursive delete from root is blocked."
+    reason: "Recursive delete from the filesystem root is blocked."
+  - match: "rm -rf / *"
+    action: deny
+    reason: "Recursive delete from the filesystem root is blocked."
   # GNU rm refuses `rm -rf /` on its own; --no-preserve-root is the one
   # spelling it obeys. The rule above is named for the command everybody
   # quotes, this one is named for the command that actually works.

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1491,6 +1491,47 @@ mod combined_gate_tests {
         }
     }
 
+    /// The root rule names the root, and nothing else.
+    ///
+    /// `match: "rm -rf /*"` is a WILDCARD: it matched every absolute path, so
+    /// `rm -rf /home/me/project/.git` was denied with "Recursive delete from
+    /// root is blocked". Right verdict, wrong sentence — and a proving run
+    /// caught it when a real agent was correctly stopped from deleting a
+    /// `.git` directory and told the reason was the filesystem root.
+    ///
+    /// Both still deny. The difference is what the human is told, which is
+    /// the whole product on the occasions it matters.
+    #[test]
+    fn the_root_rule_explains_itself_only_for_the_root() {
+        let p = Policy::builtin().unwrap();
+
+        for cmd in ["rm -rf /", "rm -rf / --no-preserve-root"] {
+            let d = p.evaluate_command(cmd, &here());
+            assert_eq!(d.action, Action::Deny);
+            assert!(
+                d.reason.contains("filesystem root"),
+                "{cmd}: names the root: {}",
+                d.reason
+            );
+        }
+
+        // An absolute path that is NOT the root still denies, and says why
+        // truthfully.
+        for cmd in [
+            "rm -rf /home/me/project/.git",
+            "rm -rf /tmp/build",
+            "rm -rf .git",
+        ] {
+            let d = p.evaluate_command(cmd, &here());
+            assert_eq!(d.action, Action::Deny, "{cmd} must still deny");
+            assert!(
+                !d.reason.contains("filesystem root"),
+                "{cmd} is not the root: {}",
+                d.reason
+            );
+        }
+    }
+
     /// REGRESSION, v0.16: the shipped `.env` rule denied ordinary READS.
     ///
     /// The rule carried `match: "*.env*"` purely because the schema demanded


### PR DESCRIPTION
Second proving-run session, after the routing fix. The fix works where the bug
was found — `uid=1001` on a real agent's commands, the decision in the
**operator's** log, the agent's own log untouched — and the session found one
more real thing.

## The root rule explained itself wrongly

A real agent was correctly stopped from deleting a `.git` directory and told:

Recursive delete from root is blocked.

for `/home/codespace/proving/.git`, which is not the root. `match: "rm -rf /*"`
is a **wildcard**, so it matched every absolute path and borrowed the root
rule's reason. Right verdict, wrong sentence — same class as v0.16's
`(removed)` versus "Overwriting" mismatch, and the same cost: the human reading
the prompt is told something false about why.

| command | before | after |
|---|---|---|
| `rm -rf /` | "delete from root" | "delete from the **filesystem root**" |
| `rm -rf /path/.git` | "delete from **root**" ✗ | "Recursive force delete blocked by default policy" |
| `rm -rf .git` | correct | unchanged |

Every case still denies. The difference is what the human is told, which is the
whole product on the occasions it matters. Pinned with control legs.

## A non-finding, recorded because I got it wrong first

I concluded from watching the session that previews do not survive the
supervised path, because the deny the agent displayed carried no blast radius.
Measured afterwards: basic and supervised produce **byte-identical** reasons,
`— 26 files` included. The agent had quoted only the first line.

`docs/supervisor.md`'s "previews in supervised mode" unknown is now answered.
Reading an agent's summary as evidence about the gate was the error — the
gate's own output was one command away.

## Also in the field report

Asked to delete `.git`, the agent declined **on its own** and offered four
options before Termaxa saw anything. And when the gate did deny, the agent read
it as information rather than an obstacle:

> This is a guardrail on recursive deletes, not something I should work around
> by rewriting the command — the block is the environment telling me this class
> of operation needs to come from you directly.

That's the SECURITY.md cooperative model observed rather than asserted. Worth
remembering when reading any demo: a cooperative agent's own caution and the
gate's enforcement are different mechanisms, and only one of them is ours.

## Gate

441 Linux / 386 Windows, boundary rig 23/23, clippy clean under `-D warnings`.