### PR TITLE
docs: give supervised mode a section, and correct the limitations it changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ From now on, every Bash command Claude Code runs in this project passes through 
 ```console
 $ termaxa check "git status && rm -rf /"
 decision  deny
-reason    segment 2/2 `rm -rf /` — Recursive delete from root is blocked.
+reason    segment 2/2 `rm -rf /` — Recursive delete from the filesystem root is blocked.
 ```
 
 Termaxa splits compound commands and judges each part. `git status &&` buys nothing.
@@ -162,7 +162,7 @@ $ termaxa doctor
 
 Termaxa doctor
 ──────────────────────────────────────────
-✓ termaxa 0.15.0
+✓ termaxa 0.17.0
   /home/you/.cargo/bin/termaxa
 
 Policy
@@ -180,9 +180,13 @@ Preview support
 · pg_dump    Postgres backups unavailable
 · terraform  plan previews unavailable
 
+Mode
+✓ basic        everything runs as you; protection is cooperative
+
 State
 ✓ /home/you/.termaxa/projects/project-4005e00d
   3 audit entries (3 from hooks)
+  ✓ chain valid: entries 1–3
 
 ──────────────────────────────────────────
 ✓ Everything checks out.
@@ -266,6 +270,37 @@ A sandbox contains damage *to the sandbox*. But your repo, your database, and yo
 **Why not OPA / policy engines?**
 
 OPA decides allow/deny well. It has no execution previews, no automatic backups, no rollback, and no agent-native hook. Termaxa is policy *plus* the things you actually want when an agent is holding the keyboard.
+
+## Supervised mode (Unix, v0.17)
+
+Everything above runs as **you**. The hook reads the policy, decides, writes the audit log and takes backups with the same filesystem authority the agent has — which is enough for the threat model Termaxa is built for, and not enough for one specific claim: in basic mode, **the audit log is the agent's own account of itself**.
+
+Supervised mode moves the authority. A small daemon runs as you; the agent runs as a different user; the two talk over a socket:
+
+```
+  agent user                          you
+  ----------                          ---
+  claude --> termaxa hook --socket--> termaxa supervise
+                                        |
+                                        +- reads the policy
+                                        +- decides
+                                        +- takes the backup
+                                        +- writes the audit log
+```
+
+The agent's user cannot read the audit log, edit the backups, change the policy, or stop the supervisor — **not because the code refuses, but because the OS does.**
+
+```bash
+termaxa init --supervised     # prints the setup; runs none of it
+termaxa supervise &           # as you
+sudo -u termaxa-agent termaxa wrap -- claude
+```
+
+`init --supervised` prints and never executes: creating a user and chowning a directory tree need root, and a tool that asks for root to "set things up for you" is asking to be trusted with exactly the authority this mode exists to bound. `termaxa doctor` then reports what those commands actually produced.
+
+**What it does not change.** This is still an enforcement layer, not an isolation layer. An agent's native file tools bypass a supervised gate exactly as they bypass a basic one, and `wrap` catches a shell resolved by name — not `/bin/sh` by absolute path. What changes is who decides and who holds the record.
+
+**How well it is proved.** A boundary rig creates a second real account and has it try: 23 assertions, each with a control leg proving the operator *can* do the thing, so a refusal means "blocked" rather than "impossible for everyone". It has also run with a real agent twice — and the [field report](docs/field-reports/2026-08-17-supervised-routing.md) is published including what broke, because the first session found agent commands never reached the supervisor at all. Full setup, the credential tradeoff, and what remains untested: [docs/supervisor.md](docs/supervisor.md).
 
 ## Architecture
 
@@ -354,9 +389,9 @@ Colour is on when output is a terminal and off when it isn't. `NO_COLOR`, `TERMA
 
 Termaxa is pre-1.0. It's real and tested, and it is not magic. Specifically:
 
-- **Hooks advise; they don't enforce.** Termaxa gates commands an agent submits through the Claude Code or Cursor hook. Those agents are *cooperative* — they respect a `deny` and propose an alternative, which is what makes the gate work. An agent running in full-auto mode could, in principle, retry a blocked action through a different command or shell; the circuit breaker raises the cost of that, but a hook is an *integration* point for visibility and policy, not an *enforcement* boundary. `termaxa wrap -- <agent>` (Unix, v0.16) widens this: commands the agent runs *through a shell* pass through the gate even without a hook, though a caller naming `/bin/sh` by absolute path still does not. **Supervised mode** (Unix, v0.17) goes further and moves the *authority*: a daemon under your user decides, and the agent runs as a different account that cannot read the audit log, edit the backups, or stop the supervisor — proved by a rig that creates a second real user and has it try. See [docs/supervisor.md](docs/supervisor.md), which is also honest that no real agent session has run under it yet. For hard guarantees today, pair Termaxa with OS-level sandboxing.
+- **Hooks advise; they don't enforce.** Termaxa gates commands an agent submits through the Claude Code or Cursor hook. Those agents are *cooperative* — they respect a `deny` and propose an alternative, which is what makes the gate work. An agent running in full-auto mode could, in principle, retry a blocked action through a different command or shell; the circuit breaker raises the cost of that, but a hook is an *integration* point for visibility and policy, not an *enforcement* boundary. `termaxa wrap -- <agent>` (Unix, v0.16) widens this: commands the agent runs *through a shell* pass through the gate even without a hook, though a caller naming `/bin/sh` by absolute path still does not. [**Supervised mode**](#supervised-mode-unix-v017) (Unix, v0.17) goes further and moves the *authority* — but it moves who decides, not where the boundary is: an agent's native tools bypass it exactly as they bypass a basic gate. For hard guarantees today, pair Termaxa with OS-level sandboxing.
 - **Native agent tools bypass the gate.** The hook sees *shell* commands. An agent's own built-in file/edit tools don't go through the shell — observed in live testing, a Cursor agent switched to its native file-delete tool and removed files Termaxa never saw. Non-shell tool calls need OS-level isolation underneath.
-- **Cooperative, not a sandbox.** Termaxa governs commands that flow through the agent hook or `termaxa run`. An agent with raw, unhooked shell access is *not* contained — that needs OS-level sandboxing, a complementary layer. The threat model is *agents making expensive mistakes*, not a malicious agent actively evading you.
+- **Cooperative, not a sandbox.** Termaxa governs commands that flow through the agent hook, `termaxa run`, or a `wrap`ped shell. An agent with raw, unhooked shell access is *not* contained — that needs OS-level sandboxing, a complementary layer. Supervised mode does not change this: it makes the *record* trustworthy and the *decision* privileged, and leaves the interception boundary where it was. The threat model is *agents making expensive mistakes*, not a malicious agent actively evading you.
 - **Shell parsing is good, not perfect.** It splits on `&&`, `||`, `;`, `|`
   and flags `$(...)`. Subshells `( )` and deeply nested quoting are judged
   conservatively, not deeply understood. A path built from a variable
@@ -375,7 +410,7 @@ See [SECURITY.md](SECURITY.md) for the full threat model.
 
 ## Contributing
 
-Issues and PRs welcome. `cargo test` must pass; CI runs on Linux, macOS, and Windows. The codebase is dependency-light Rust: ~10,200 lines of production code in `src/`, plus ~10,600 lines of tests (unit tests live beside the code they test; `tests/` holds the integration ones). More test than product, on purpose — `src/policy.rs` and `src/preview.rs` are the best places to start reading, and the test module at the bottom of each file explains what the code is defending against.
+Issues and PRs welcome. `cargo test` must pass; CI runs on Linux, macOS, and Windows. The codebase is dependency-light Rust: ~10,250 lines of production code in `src/`, plus ~11,000 lines of tests (unit tests live beside the code they test; `tests/` holds the integration ones). More test than product, on purpose — `src/policy.rs` and `src/preview.rs` are the best places to start reading, and the test module at the bottom of each file explains what the code is defending against.
 
 If you can make an agent get past the gate in a way that isn't already documented above, that's the most useful contribution you can make: [open an issue](https://github.com/termaxa/termaxa/issues) or email security@termaxa.com.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,8 @@ If your threat model includes an agent *actively trying to evade you*, you need 
 
 **Termaxa is an enforcement and recovery layer, not an isolation layer.** It can decide what an intercepted action should do, explain the consequence before it happens, preserve recoverability, and record what happened. It does not make an untrusted agent unable to act outside the interception boundary. Everything below follows from that sentence.
 
+Supervised mode (v0.17) does not change it. It moves *who decides and who holds the record* outside the agent's reach, which is a real and measurable improvement to what the audit is worth — and it leaves the interception boundary exactly where it was. An agent's native file tools bypass a supervised gate precisely as they bypass a basic one.
+
 ### Where the line is, and what it costs
 
 The distinction is **intent to evade**, not degree of misbehaviour.
@@ -64,7 +66,7 @@ We state this because it would be very convenient to call every bypass "out of s
 
 Some of these are **architectural boundaries** — they follow from Termaxa being an enforcement layer rather than an isolation layer, and no amount of implementation work removes them. Others are **implementation gaps** tracked for correction. They are listed together deliberately, because both affect what you should rely on today, and separating them would invite reading a known bug as "out of scope." Each entry says which it is.
 
-*Implementation claims below are current as of v0.16. The threat model above is stable; this list is not.*
+*Implementation claims below are current as of v0.17. The threat model above is stable; this list is not.*
 
 - **Shell parsing is heuristic.** Termaxa splits on `&&`, `||`, `;`, `|`, a lone `&` and newlines, and detects `$(...)`/backticks (escalating those to a human). It does not fully parse subshells `( )`, process substitution, or variable-expanded command names. Unparseable constructs are judged conservatively (the policy default, which ships as `ask`), but "conservative" is not "guaranteed."
 - *(implementation, largely closed in v0.15/v0.16)* **The policy engine and the intent classifier once read a command differently.** The classifier strips quotes before tokenizing; policy matching normalized whitespace and case but matched a string that still contained them, so `"rm" -rf /` classified as a file-delete while missing the `rm -rf /*` deny rule. Since v0.15 policy matches against several readings including the tokenized form, so the quoted spelling is caught. The readings can only ADD matches, never remove one. What remains is that the two layers still have separate tokenizers, and a construct only one of them understands is judged by only one of them.
@@ -131,7 +133,7 @@ Since v0.16 each audit entry carries the hash of the one before it. `termaxa doc
 
 The hook runs as the agent's own user, which means the audit log is written with the agent's own filesystem authority. Anything that can edit an entry can recompute the chain over it. The chain can expose accidental corruption, partial writes, and unsophisticated edits — what it catches depends on what changed and what remains readable. It does not stop, and cannot detect, a process in the agent's trust domain that rewrites the record deliberately and recomputes the hashes.
 
-**This changes in supervised mode (v0.17), and the reason is privilege rather than cryptography.** There the supervisor owns the state directory, the agent's user has no access to it, and the audit log is written by an authority outside the agent's reach. The record becomes trustworthy because of who holds the pen — not because the hash got cleverer.
+**Supervised mode (Unix, v0.17) changes this, and the reason is privilege rather than cryptography.** The supervisor owns the state directory, the agent's user has no access to it, and the audit log is written by an authority outside the agent's reach. The record becomes trustworthy because of who holds the pen — not because the hash got cleverer. A boundary rig with a second real account asserts each half of that: the agent cannot read, append to, or delete the log, and cannot list the directory holding it.
 
 Stated plainly, so a changelog line reading "hash-chained audit log" is not mistaken for more than it is:
 
@@ -157,7 +159,11 @@ Two things worth reading off that table rather than around it.
 
 **The improvement between rows three and four is privilege, not cleverness.** Wrapped mode routes more commands through the same code; supervised mode moves *who runs that code*. That is the only step in the table that changes what the record is worth, which is why the audit chain section above draws its line exactly there.
 
-Setup, the credential tradeoff, and what supervised mode has and has not been proved against: [docs/supervisor.md](docs/supervisor.md). It is honest about the last part — the boundary is proved by an automated rig with a second real user, and not yet by a real agent session.
+Setup, the credential tradeoff, and what supervised mode has and has not been proved against: [docs/supervisor.md](docs/supervisor.md).
+
+**What it has been proved against, and what that cost.** The boundary is asserted by an automated rig that creates a second real account and has it try — 23 assertions, each with a control leg proving the operator *can* do the thing, so a refusal means "blocked" rather than "impossible for everyone". It has also been run once with a real agent, and the [field report](docs/field-reports/2026-08-17-supervised-routing.md) is published including what broke: the first session found that agent commands never reached the supervisor at all, because a hook running as the agent resolved the socket path from *its own* `$HOME`. The walls held; the door led nowhere. 439 unit tests, 18 boundary assertions and three green CI platforms were all consistent with a working system, because every one of them ran the hook and the supervisor as the same user.
+
+That is the honest state of this row: proved by a rig, proved once by a real session, and the one real session found a bug the rig could not see.
 
 **Migration.** Entries written before v0.16 have no hash. They stay readable and are reported as pre-chain rather than as breaks: Termaxa can prove continuity from the boundary onward, and does not retroactively claim to have protected history it was not there for. A broken link names the entry and leaves the rest of the record readable, because one corrupt line making the whole log unreadable would destroy more evidence than the corruption did.
 

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -2,7 +2,7 @@
 
 **Unix only. Not available on Windows** — it needs Unix domain sockets and a second user account in the form this depends on. Basic mode is the Windows answer and is fully supported there; `termaxa doctor` says so rather than hinting.
 
-**Status: proved by an automated rig across two real users, and by one real agent session** — which found a routing bug the rig could not see. See [the field report](field-reports/2026-08-17-supervised-routing.md) and [What is not yet proven](#what-is-not-yet-proven), which is shorter than it was.
+**Status: proved by an automated rig across two real users, and by two real agent sessions** — the first of which found a routing bug the rig could not see, and the second of which confirmed the fix and found a wrong deny message. See [the field report](field-reports/2026-08-17-supervised-routing.md) and [What is not yet proven](#what-is-not-yet-proven), which is shorter than it was.
 
 ---
 


### PR DESCRIPTION
Answering two review questions: does the README need a supervisor section, and
did any limitation change.

## Yes to the section

Supervised mode is the largest capability change in the product's history and
appeared in the README only as half a limitations bullet and one row of the
command table. A reader skimming would not learn it exists.

It now has a section: what moves, the three commands, why `init --supervised`
prints rather than executes, and how well it is proved — 23 rig assertions with
control legs, two real agent sessions, and a field report published including
what broke.

The section states what supervised mode **does not** change before it states how
well it works, because that ordering is the honest one for a security feature.

## Four limitations changed

| | change |
|---|---|
| "current as of v0.16" | → v0.17 |
| "This *changes in* supervised mode (v0.17)" | it has shipped — present tense, rig assertions named |
| "Cooperative, not a sandbox" | supervised mode does not change this, stated rather than implied |
| the enforcement/isolation sentence | supervised moves *who decides and who holds the record*; the interception boundary is where it was |

The last is the one that mattered. Without it a reader could finish the
supervised material believing the isolation problem had been solved, when what
changed is the authority behind the decision and the record. **An agent's native
file tools bypass a supervised gate precisely as they bypass a basic one** —
that sentence now appears in three places rather than being implied by silence.

## Gate

441 Linux / 386 Windows, docs only. `docs_encoding` green, clippy clean.