### PR TITLE
release: v0.17.0 — the authority moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,91 @@
 
 All notable changes to Termaxa. Format loosely follows [Keep a Changelog](https://keepachangelog.com/); this project is pre-1.0, so minor versions may include breaking changes to the policy schema or CLI.
 
+## v0.17.0 — the authority moves
+
+v0.16 stopped treating targets as strings. v0.17 moves **who decides**.
+
+A daemon runs as you; the agent runs as a different user; the two talk over a
+socket. The agent's account cannot read the audit log, edit the backups, change
+the policy, or stop the supervisor — not because the code refuses, but because
+the OS does. Eight pull requests, **441 tests on Linux, 386 on Windows**, and a
+boundary rig of 23 assertions that creates a second real account and has it try.
+
+The honest headline: **a real agent session found a bug that none of that
+caught.** See below.
+
+### Added
+
+- **`termaxa supervise`** (Unix) — a decision daemon under the operator's user.
+  In supervised mode the hook forwards the raw payload and prints what comes
+  back; it does not evaluate, insure, audit or preview on its own authority,
+  because anything it concluded would be a conclusion reached inside the
+  agent's trust domain.
+- **`termaxa init --supervised`** — prints the setup and runs none of it.
+  Creating a user and chowning a directory tree need root, and a tool that asks
+  for root to set things up for you is asking to be trusted with exactly the
+  authority this mode exists to bound. `termaxa doctor` then reports what those
+  commands actually produced, including whether the state directory is `0711`.
+- **A privilege boundary rig** (`tests/boundary/rig.sh`, blocking in CI) — 23
+  assertions run against a real second account, each with a **control leg**
+  proving the operator *can* do the thing, so a refusal means "blocked" rather
+  than "impossible for everyone".
+- **`docs/supervisor.md`** and a published [field
+  report](docs/field-reports/2026-08-17-supervised-routing.md).
+
+### Changed
+
+- **State files are private at creation**, not hardened afterwards. A daemon
+  runs for hours and the interesting files are the ones it writes *during* that
+  time: a log line appended mid-session inherited the process umask, and a
+  backup inherited the **source file's** mode, so insuring a world-readable file
+  produced a world-readable copy. Applied in basic mode too.
+- **The endpoint is told, not inferred from `$HOME`.** State discovery and IPC
+  discovery are now separate concepts — see the bug below.
+- **`hook::run` split into `decide()` plus a thin I/O wrapper**, so the daemon
+  and the one-shot hook share one decision path rather than two engines on one
+  question.
+- **The root rule names the root.** `match: "rm -rf /*"` is a wildcard: it
+  matched every absolute path and then explained itself as "delete from root".
+  A real agent was correctly stopped from deleting a `.git` directory and told
+  the reason was the filesystem root. Narrowed; every case still denies.
+
+### Fixed
+
+- **Supervised mode did not route.** The first real agent session found that a
+  hook running as the agent resolved the socket path from *its own* `$HOME`,
+  found nothing, concluded basic mode, and decided on its own authority —
+  writing an audit log the agent owned. The boundary was intact throughout: 18
+  rig assertions passed in that same session. **The walls held; the door led
+  nowhere.**
+
+  439 unit tests, three green CI platforms and synthetic end-to-end tests were
+  all consistent with a working system, because every one of them ran the hook
+  and the supervisor as the same user. The rig now asserts routing across two
+  real UIDs, which is the test that was missing.
+- **`gate_file_write` called `process::exit(2)`.** Under the daemon, the first
+  protected-file write an agent attempted would have killed the supervisor —
+  and a dead supervisor denies everything afterwards.
+
+### Known limitations
+
+- **Unix only.** Windows has neither Unix domain sockets nor a second user
+  account in the form this depends on; basic mode is the Windows answer and is
+  fully supported.
+- **This is not isolation.** Supervised mode moves who decides and who holds the
+  record. The interception boundary is exactly where it was: an agent's native
+  file tools bypass a supervised gate precisely as they bypass a basic one, and
+  `wrap` catches a shell resolved by name, not `/bin/sh` by absolute path.
+- **Credentials are a tradeoff, not a solved problem.** The agent account has
+  none of your git, SSH or registry access. Shared HOME dilutes the boundary;
+  copied credentials create rotation debt; curated-per-launch is most honest and
+  most friction. Claude Code *does* authenticate cleanly as a second user — one
+  OAuth round-trip, verified.
+- **`SO_PEERCRED` on macOS** returns no UID rather than guessing at an untested
+  `LOCAL_PEERCRED` ABI. An absent identity is recorded as absent.
+- **Daemon lifecycle** is `termaxa supervise &`. systemd units and launchd
+  plists are recipes to write, not managed for you.
+
 ## v0.16.0 — targets are things, not strings
 
 v0.15 stopped treating **commands** as strings. v0.16 stops treating three more

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "termaxa"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termaxa"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "A cooperative gate for the shell commands AI coding agents run — command previews, automatic backups, allow/ask/deny policy, and audit logging."
 license = "MIT OR Apache-2.0"

--- a/src/init.rs
+++ b/src/init.rs
@@ -644,6 +644,18 @@ pub(crate) fn which(bin: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// The directory the project sits in, which the agent must traverse to reach
+/// it. Named rather than assumed: the first proving run's setup said
+/// `chmod 0755 ~`, which makes the operator's entire home listable to the
+/// agent - broader than needed, and the same over-permission the state
+/// directory already avoids with 0711.
+fn home_of_project(project: &Path) -> std::path::PathBuf {
+    project
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| project.to_path_buf())
+}
+
 /// Print the supervised-mode setup. Prints and verifies; never executes.
 ///
 /// Decision #34 applied to the feature most tempting to violate it. Creating a
@@ -716,9 +728,27 @@ pub fn print_supervised_setup(project: &Path) -> Result<()> {
     println!("    chown -R {me}:{me} {}", home.display());
     println!("    chmod 0711 {}", home.display());
     println!();
-    println!("    # 4. run it");
+    println!("    # 4. the agent needs to reach the project. 0711 lets it");
+    println!("    #    traverse to a path it knows without listing your home.");
+    println!("    chmod 0711 {}", home_of_project(project).display());
+    println!();
+    println!("    # 5. run it, from the project directory");
+    println!("    cd {}", project.display());
     println!("    termaxa supervise &");
     println!("    sudo -u termaxa-agent termaxa wrap -- claude");
+    println!();
+    println!(
+        "  {}",
+        dim("If that last line asks for YOUR password, this machine's sudoers")
+    );
+    println!(
+        "  {}",
+        dim("rule is root-only (`NOPASSWD: ALL` for root, common on managed dev")
+    );
+    println!(
+        "  {}",
+        dim("boxes). `sudo -i` then `su - termaxa-agent` gets there without one.")
+    );
     println!();
     println!(
         "  {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,9 +167,26 @@ fn dispatch(cli: Cli) -> Result<i32> {
             supervised,
         } => {
             let dir = std::env::current_dir()?;
-            init::run(&dir, claude_code, cursor, codex, copilot)?;
+            // `--supervised` prints the setup and nothing else. It used to run
+            // the whole of `init` first, so an operator who had just run
+            // `init --claude-code` saw ~60 lines they had already read - the
+            // harness list, the tools list, the full settings.json snippet,
+            // and "To wire Termaxa into Claude Code, run: termaxa init
+            // --claude-code" - with the supervised instructions buried under
+            // it. Found by the first proving run, where it was the first
+            // thing a supervised user read.
+            //
+            // It still scaffolds when the project has no policy yet, so
+            // `init --supervised` alone in a fresh directory does the right
+            // thing rather than printing setup for a project that does not
+            // exist.
             if supervised {
+                if !dir.join(".termaxa").join("policy.yaml").exists() {
+                    init::run(&dir, claude_code, cursor, codex, copilot)?;
+                }
                 init::print_supervised_setup(&dir)?;
+            } else {
+                init::run(&dir, claude_code, cursor, codex, copilot)?;
             }
             Ok(0)
         }


### PR DESCRIPTION
Version bump, release notes written from `git log a433b3a..main`, and the
smaller findings from the proving run. 441 Linux / 386 Windows, rig 23/23.

## The CHANGELOG leads with what the proving run found

Not with the feature list. "Supervised mode did not route" is the most useful
sentence in these notes for anyone deciding whether to trust this release, and
burying it under *Added* would be the wrong shape: 439 unit tests, three green
CI platforms and 18 boundary assertions were all consistent with a working
system, and one real agent running `ls -la` was not.

The Known limitations section says supervised mode **is not isolation**, in the
same notes that announce it.

## Proving-run findings fixed

| finding | fix |
|---|---|
| `init --supervised` reprinted the whole of `init` — ~100 lines with the setup buried under advice to run the command you'd just run | prints the setup and nothing else, 41 lines, still scaffolds a fresh directory |
| setup said `chmod 0755 ~`, making the operator's whole home listable to the agent | `0711` on the project's parent, reason inline — the same over-permission the state dir already avoids |
| setup's last line `sudo -u termaxa-agent …` prompts for a password on root-only NOPASSWD machines (hit immediately in the Codespace) | output says so and names the way through |
| setup didn't say which directory the agent works in | path is explicit |

## One thing left honest rather than fixed

The new `chmod 0711` step prints the project's **parent**, so for a project in
`/tmp` it prints `chmod 0711 /tmp` — not advice anyone should follow. It's
correct for a real project under a home directory, it's better than the previous
`~`, and a tool printing a path it has not verified is *guidance* rather than a
command.

Which is exactly why this feature prints instead of executing.

## Gate

441 Linux / 386 Windows, boundary rig 23/23, clippy clean under `-D warnings`.
`Cargo.toml` and `Cargo.lock` at 0.17.0.