### PR TITLE
testutil: retry tree removal before calling it litter (#47)

### DIFF
--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -72,8 +72,28 @@ fn claim(label: &str) -> PathBuf {
 ///
 /// A cleanup that silently failed is how litter accumulates in the first
 /// place, so the guard says so rather than shrugging.
+///
+/// Removal retries briefly before the verdict (#47). On Windows a directory
+/// cannot be removed while any process holds a handle inside it, and a
+/// just-exited child's handles — a spawned `git`, most concretely — are
+/// released by the OS asynchronously. Under a loaded parallel test run that
+/// release loses a race a single `remove_dir_all` was never going to win;
+/// measured on `main`, the same teardown that passes every serial run fails
+/// every loaded one. Ten attempts over half a second is enough margin for
+/// handle release and still fast enough to fail loudly when a tree has
+/// genuinely outlived its guard. Unconditional rather than `cfg(windows)`:
+/// the loop exits on the first success, so where the first attempt already
+/// works this is the old code.
 fn release(root: &Path) -> bool {
-    let _ = std::fs::remove_dir_all(root);
+    for attempt in 0..10 {
+        if attempt > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        let _ = std::fs::remove_dir_all(root);
+        if !root.exists() {
+            return true;
+        }
+    }
     !root.exists()
 }
 


### PR DESCRIPTION
Closes #47.

`release()` was a single `remove_dir_all` followed by the verdict. On Windows a directory cannot be removed while any process holds a handle inside it, and a just-exited child's handles — the spawned `git push` in the restore test, concretely — are released by the OS asynchronously. Under a loaded parallel run that release loses a race one attempt was never going to win. Measured before changing anything (evidence table in #47): fails every loaded run on unmodified `main`, passes every serial one, both branches, Windows only.

The fix is ten attempts, 50 ms apart. The verdict keeps its meaning — a tree that survives half a second of retries has genuinely outlived its guard, and the assert still fails loudly. Unconditional rather than `cfg(windows)` because the loop exits on first success: where the first attempt already works, this is the old code.

No new test, deliberately: the race cannot be reproduced deterministically in a portable unit test, and a test that cannot fail is vacuous by this project's own standard. The gate for this change is the thing that was red going green.

## Gate

- Linux (fresh clone, branch applied from bundle): fmt clean, clippy `-D warnings` clean, 444 passed, 0 failed — which for this change proves no regression only; the race cannot fire on Linux.
- Windows, the gate that matters: full parallel `cargo test` on this branch — result to be pasted below when run. Prediction: 391/391, the first fully green Windows run since the race started firing.
