### PR TITLE
docs: install via Homebrew tap; winget + no-curl-sh policy; release step 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,18 @@ Termaxa is a third option: a gate the agent's commands pass through. It reads a 
 
 ## Quick start (5 minutes)
 
-**1. Install.** Download a prebuilt binary from [Releases](https://github.com/termaxa/termaxa/releases) and put it on your PATH — or, with a Rust toolchain:
+**1. Install.**
 
 ```bash
-cargo install termaxa
+brew install termaxa/tap/termaxa     # macOS / Linux (prebuilt, sha256-pinned)
+cargo install termaxa                # any OS, with a Rust toolchain
+```
+
+Windows: download `termaxa-windows-x86_64.exe` from [Releases](https://github.com/termaxa/termaxa/releases), rename to `termaxa.exe`, put it on your PATH. (A winget manifest is submitted; this line updates when it lands.)
+
+There is deliberately no `curl | sh` installer — Termaxa itself flags that pattern as a hazard, and the gate's rules apply to the gate. Every binary is a checksummed Release asset built by the tag-gated CI.
+
+```bash
 termaxa                       # what this is, and what to try next
 termaxa check "rm -rf /"      # works immediately — no setup, no project config
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,3 +21,13 @@
 7. After the GitHub release publishes, run cargo publish — otherwise cargo install termaxa lags behind the GitHub release.
    - Deliberately manual. crates.io publishes are permanent — a version can be yanked, never deleted or re-published with different content. GitHub releases can be edited or removed. Automating the irreversible step would remove the last human checkpoint before a permanent action, which is the argument this tool makes about destructive commands. The gate applies to us too.
 8. After bumping Cargo.toml: run cargo build (updates Cargo.lock), then commit both Cargo.toml and Cargo.lock together in the release-prep commit, before tagging. Then tag → push → CI green → cargo publish.
+
+9. Update the package managers (after cargo publish):
+   - Homebrew tap: in termaxa/homebrew-tap, bump `version` and the three
+     sha256s in Formula/termaxa.rb (sha256sum the downloaded release
+     assets — never copy hashes you didn't compute). The tap's own CI
+     installs the formula on macOS and Linux; green there is the gate.
+   - winget: `wingetcreate update Termaxa.Termaxa --urls <new .exe url> --version <ver> --submit`
+     (or bump the three manifests in the winget-pkgs fork by hand).
+   Both are deliberately manual, same reasoning as step 7: publishing to
+   package managers is the last human checkpoint before strangers' machines.


### PR DESCRIPTION
The funnel measurement said it plainly: three distribution actions Aug 21–25 moved the crates.io counter by ~0–2 while attention demonstrably occurred. The leak is conversion — `cargo install` filters out everyone without a Rust toolchain, and the prebuilt binaries (which the release workflow has shipped all along, four targets, sha256s) were findable but not installable in one line.

This PR is the main-repo half of the fix:

- README leads with `brew install termaxa/tap/termaxa` (the tap pins the exact v0.17.0 assets by sha256 — verified by downloading all four and computing hashes, and by running the Linux binary: `termaxa 0.17.0`), keeps `cargo install`, and names the Windows path honestly — winget is *submitted*, and the line updates when it lands, never before.
- The no-`curl|sh` policy is stated as policy: Termaxa itself flags that pattern, and the gate's rules apply to the gate.
- RELEASING.md gains step 9: every release updates the tap hashes and winget manifest, manually and deliberately — same reasoning as the manual crates.io publish. The last checkpoint before strangers' machines stays human.

Shipping separately (not claimed by this PR): the tap repo itself, whose own CI brew-installs the formula on macOS and Linux — green there is the formula's gate, since the maintainer's machine is Windows — and the three winget manifests for microsoft/winget-pkgs.

Gate for this commit (docs-only, run anyway): fmt clean, 447 tests green on Linux.
