### PR TITLE
fingerprint: satisfy clippy 1.98's chunks_exact_to_as_chunks

### DIFF
--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -108,7 +108,11 @@ pub fn sha256_hex(data: &[u8]) -> String {
     }
     msg.extend_from_slice(&bit_len.to_be_bytes());
 
-    for chunk in msg.chunks_exact(64) {
+    // Block-aligned by construction: the padding above ends the message at a
+    // multiple of 64, so the remainder as_chunks returns is always empty.
+    // (clippy 1.98's chunks_exact_to_as_chunks; the array type is also the
+    // truer one for a SHA-256 block.)
+    for chunk in msg.as_chunks::<64>().0 {
         let mut w = [0u32; 64];
         for (i, word) in w.iter_mut().enumerate().take(16) {
             let b = &chunk[i * 4..i * 4 + 4];


### PR DESCRIPTION
The Clippy CI step's own comment predicted this failure class when it
was made blocking: "clippy VERSIONS DIFFER between a developer machine
and CI." It fired again today in the other direction - clippy 1.98
reached the runners with a new lint and turned every PR red on a line
no PR had touched (fingerprint.rs:111, the SHA-256 block loop that
feeds the audit hash chain).

Reproduced on unmodified main under clippy 1.98 before changing
anything. The fix is the lint's own suggestion, and it is the truer
code: the padding directly above the loop ends the message at a
multiple of 64, so as_chunks::<64>() has an always-empty remainder and
each block arrives as a &[u8; 64] - the type a SHA-256 block actually
is - rather than a slice re-checked at each index.

Hashing unchanged by construction and by test: the full suite is green
(447 on Linux), including the audit-chain tests that would fail loudly
on any digest drift. Gated under clippy 1.98 itself - fmt clean,
clippy -D warnings clean - so this is verified with the same eyes that
rejected it.
