### PR TITLE
Stop three tests reading process state they do not own (#51)

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -1085,6 +1085,9 @@ mod tests {
         .expect("stub must be writable");
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
             .expect("stub must be executable");
+        // Written is not yet executable under parallel load — see #51 and the
+        // helper's own note. Same shape as the preview stub, same wait.
+        crate::testutil::wait_until_executable(&path);
 
         let previous = std::env::var_os("PATH");
         let combined = match &previous {

--- a/src/init.rs
+++ b/src/init.rs
@@ -948,7 +948,7 @@ mod tests {
     fn here() -> crate::resolve::EvalContext {
         crate::resolve::EvalContext::at(std::path::Path::new("."))
     }
-    use crate::testutil::TempTree;
+    use crate::testutil::{TempTree, TestEnv};
 
     /// `examples/policy.yaml` is the file people copy. It had drifted to 28
     /// rules against the starter's 44 — missing every broad delete deny and
@@ -974,7 +974,15 @@ mod tests {
         // Captured by rendering into a string rather than by scraping stdout:
         // the point is the CONTENT, and a test that shells out would be
         // testing the terminal.
-        let rig = std::fs::read_to_string("tests/boundary/rig.sh").unwrap();
+        // Anchored to the crate root rather than the cwd. The cwd belongs to
+        // the PROCESS, `TestEnv::chdir` moves it, and this test holds no lock
+        // — so a relative read here is a bet that no cwd mover is scheduled
+        // beside it. Measured on this tree, that bet loses 6 times in 30 runs
+        // at `--test-threads=16` and never at default threads (#51).
+        let rig = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/boundary/rig.sh"),
+        )
+        .unwrap();
         assert!(
             rig.contains("chmod 0711 \"$TERMAXA_HOME\""),
             "the rig uses 0711 on the state dir; if that changed, the printed \
@@ -993,8 +1001,16 @@ mod tests {
     /// you to run it again with a flag it had already worked out.
     #[test]
     fn one_detected_harness_needs_no_flag() {
-        let t = TempTree::new("autodetect-one");
-        let dir = t.path();
+        // "Exactly one" is a claim about what detection SEES, and half of what
+        // it sees is `which` reading the machine. Without the isolated PATH
+        // this test asserts a property of the developer's box: on one with
+        // `codex` installed it detects two and fails every run, at any thread
+        // count (#51). The neighbouring empty-project test dodged the same
+        // trap by weakening its assertion; this one keeps the exact count and
+        // controls the environment that makes it true.
+        let mut env = TestEnv::new("autodetect-one");
+        env.isolate_path();
+        let dir = env.root();
         std::fs::create_dir_all(dir.join(".claude")).unwrap();
 
         let found = detect_harnesses(dir);

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -337,7 +337,19 @@ fn terraform_preview(bin: &str, destroy: bool) -> Option<Preview> {
     if destroy {
         args.push("-destroy");
     }
-    let out = std::process::Command::new(bin).args(&args).output().ok()?;
+    let out = match std::process::Command::new(bin).args(&args).output() {
+        Ok(out) => out,
+        Err(_e) => {
+            // Production stays best-effort and silent, as below. The test
+            // binary names the failure, because "the planner would not start"
+            // and "the plan came back non-zero" are different facts that both
+            // arrive here as `None` — and #51 spent a red CI leg on not being
+            // able to tell them apart from the log.
+            #[cfg(test)]
+            eprintln!("terraform preview: could not run {bin}: {_e}");
+            return None;
+        }
+    };
     if !out.status.success() {
         return None; // uninitialized dir, bad config — best effort, stay silent
     }
@@ -763,6 +775,11 @@ mod terraform_stub_tests {
         .expect("stub must be writable");
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
             .expect("stub must be executable");
+
+        // Both stub helpers in this suite write an executable and then have
+        // it exec'd immediately, which is the ETXTBSY window (#51). The wait
+        // lives in `testutil` so neither has to carry the reasoning.
+        crate::testutil::wait_until_executable(&path);
         path
     }
 

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -1,7 +1,7 @@
 //! Test-only isolation for the process-global state this suite reaches into.
 //!
-//! `TERMAXA_HOME` and the working directory belong to the PROCESS, and cargo
-//! runs tests as threads inside one process. Three tests in `paths.rs` used to
+//! `TERMAXA_HOME`, the working directory and `PATH` belong to the PROCESS, and
+//! cargo runs tests as threads inside one process. Three tests in `paths.rs` used to
 //! set them by hand and delete the trees they pointed at, which produced a
 //! flake that read as a missing policy (#17) and, on every green run in
 //! between, quietly wrote state into the developer's real `~/.termaxa`.
@@ -18,6 +18,14 @@
 //! - [`TestEnv`] is a `TempTree` plus the lock, `TERMAXA_HOME` pointed into
 //!   the tree, and the cwd restored on the way out. Only tests that need the
 //!   environment redirected should pay for the serialisation.
+//!   [`TestEnv::isolate_path`] adds `PATH` to what it covers, for the tests
+//!   whose subject is what `which` can find (#51).
+//!
+//! The third global arrived late for a reason worth keeping: `PATH` was being
+//! rewritten by hand in two modules, correctly in one and without a restore
+//! guard in the other, while the newest test to depend on it did neither and
+//! quietly asserted a property of the developer's machine. A global the guard
+//! has no word for is one every test has to remember on its own.
 //!
 //! ```ignore
 //! let tmp = TempTree::new("my-case");
@@ -170,6 +178,55 @@ fn listing(dir: &Path) -> BTreeSet<OsString> {
     }
 }
 
+/// Wait for a just-written stub to actually be executable.
+///
+/// "Written" and "executable" are not the same instant in a multithreaded
+/// process. `exec` refuses a file any process still holds open for writing
+/// (`ETXTBSY`). The writing descriptor here is closed by the time this runs —
+/// but a sibling test that forks while it was open leaves the child holding a
+/// copy until that child reaches its own `exec`, and a stub exec'd inside that
+/// window fails. Nothing is misusing anything: `fork` in a threaded process
+/// copies descriptors it was never told about.
+///
+/// Measured with this write-then-exec shape lifted into a standalone program:
+/// 37 of 4800 execs at 16 threads returned `ExecutableFileBusy`, none serially
+/// (#51). Both stub helpers in this suite have that shape, which is why the
+/// wait lives here rather than in either of them.
+///
+/// Retry-then-verdict, the shape #47 settled on: the window is microseconds
+/// and closes on its own, and once an `exec` has succeeded no writer remains
+/// to reopen it. Running the stub once is harmless — these print and exit.
+pub fn wait_until_executable(path: &Path) {
+    for attempt in 0..10 {
+        if attempt > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        match std::process::Command::new(path).arg("--warmup").output() {
+            Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => continue,
+            _ => return,
+        }
+    }
+}
+
+/// Absolute path of `bin` on the current `PATH`, if it resolves to a file.
+///
+/// Used only to find the lookup tool itself before [`TestEnv::isolate_path`]
+/// takes `PATH` away, so the isolated directory can still answer honestly.
+#[cfg(not(windows))]
+fn locate(bin: &str) -> Option<PathBuf> {
+    let out = std::process::Command::new("which").arg(bin).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let first = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .next()?
+        .trim()
+        .to_string();
+    let path = PathBuf::from(first);
+    path.is_file().then_some(path)
+}
+
 /// Names present at drop that were not present at construction.
 fn arrivals(before: &BTreeSet<OsString>, after: &BTreeSet<OsString>) -> Vec<OsString> {
     after.difference(before).cloned().collect()
@@ -185,6 +242,11 @@ pub struct TestEnv {
     tree: TempTree,
     previous_home: Option<OsString>,
     previous_cwd: Option<PathBuf>,
+    /// `None` until [`TestEnv::isolate_path`] runs; `Some(previous)` after,
+    /// where `previous` is itself absent if the process had no `PATH`.
+    /// Captured once, like the cwd, so repeated calls still restore the value
+    /// the test started from.
+    previous_path: Option<Option<OsString>>,
     watch: Option<(PathBuf, BTreeSet<OsString>)>,
 }
 
@@ -214,6 +276,7 @@ impl TestEnv {
             tree,
             previous_home,
             previous_cwd: None,
+            previous_path: None,
             watch,
         }
     }
@@ -251,6 +314,63 @@ impl TestEnv {
         std::env::set_current_dir(dir).expect("cwd must be settable");
     }
 
+    /// Point `PATH` at a directory holding the lookup tool and nothing else,
+    /// so `which`-style detection runs for real and honestly reports absence.
+    ///
+    /// `PATH` is the third process-global this suite reaches into, after
+    /// `TERMAXA_HOME` and the working directory, and it is the one the guard
+    /// had no word for. `init`'s autodetect test asserted an exact harness
+    /// count while `which` was still reading the developer's machine, so it
+    /// passed only where no second agent CLI happened to be installed — on a
+    /// box with `codex` on `PATH` it fails 30 runs out of 30, at any thread
+    /// count (#51). The sibling test one screen down already carries a comment
+    /// warning about exactly this; the knowledge existed and did not reach the
+    /// newer test, which is the argument for putting it here instead.
+    ///
+    /// Emptying `PATH` is the obvious move and it is the wrong one. Measured
+    /// both ways: with `PATH` empty the `which` spawn itself fails with
+    /// `NotFound` and the lookup reports "absent" because it never ran, which
+    /// is a test passing through a broken mechanism rather than a real
+    /// negative. Keeping the finder reachable and nothing else keeps the
+    /// lookup honest.
+    /// Returns the directory now standing in for `PATH`, so a test that needs
+    /// a lookup to SUCCEED can put something there to be found.
+    pub fn isolate_path(&mut self) -> PathBuf {
+        if self.previous_path.is_none() {
+            self.previous_path = Some(std::env::var_os("PATH"));
+        }
+
+        let only_bin = self.tree.path().join("only-bin");
+        std::fs::create_dir_all(&only_bin).expect("the isolated bin dir must be creatable");
+
+        // Windows keeps `where.exe` in System32 along with the rest of the OS,
+        // and none of the harness CLIs live there, so naming that directory
+        // alongside ours gives the same shape without copying a system binary
+        // out of it.
+        if cfg!(windows) {
+            let system32 = std::env::var_os("SystemRoot")
+                .map(|root| PathBuf::from(root).join("System32"))
+                .unwrap_or_else(|| PathBuf::from(r"C:\Windows\System32"));
+            std::env::set_var(
+                "PATH",
+                format!("{};{}", only_bin.display(), system32.display()),
+            );
+            return only_bin;
+        }
+
+        // Locate the finder through the PATH the process still has, then put a
+        // copy of it — and nothing else — in front of the test.
+        //
+        // A host with no `which` at all is left with an empty directory on
+        // purpose: there, `init::which` already answers false for everything,
+        // so this reports the same thing the host itself would.
+        if let Some(finder) = locate("which") {
+            let _ = std::fs::copy(&finder, only_bin.join("which"));
+        }
+        std::env::set_var("PATH", &only_bin);
+        only_bin
+    }
+
     /// Watch a stand-in directory instead of the real one, so the check at
     /// drop can be tested without writing to anybody's home.
     #[cfg(test)]
@@ -266,6 +386,14 @@ impl Drop for TestEnv {
         // longer exists breaks `getcwd` for everything scheduled after it.
         if let Some(cwd) = self.previous_cwd.take() {
             let _ = std::env::set_current_dir(cwd);
+        }
+        // Same reasoning as the cwd above: a PATH left pointing into a tree
+        // that is about to be deleted breaks every lookup scheduled after it.
+        if let Some(previous) = self.previous_path.take() {
+            match previous {
+                Some(path) => std::env::set_var("PATH", path),
+                None => std::env::remove_var("PATH"),
+            }
         }
         match self.previous_home.take() {
             Some(previous) => std::env::set_var("TERMAXA_HOME", previous),
@@ -350,6 +478,67 @@ mod tests {
         assert!(!root.exists(), "the guard must remove its own tree");
         assert_eq!(std::env::var_os("TERMAXA_HOME"), home_before);
         assert_eq!(std::env::current_dir().ok(), Some(cwd_before));
+    }
+
+    /// The anti-rot test for the third global, and it has to assert BOTH
+    /// halves.
+    ///
+    /// "The harness was not found" is the easy half and it is worthless alone:
+    /// an empty `PATH` produces exactly that answer, because the `which` spawn
+    /// itself fails and the lookup reports absence without ever running.
+    /// Measured, and the reason this helper copies the finder in rather than
+    /// clearing the variable. So the test also puts a binary in the isolated
+    /// directory and requires it to be FOUND — that is the assertion that
+    /// fails if isolation ever degrades into breaking the mechanism.
+    #[cfg(not(windows))]
+    #[test]
+    fn isolating_path_hides_the_machine_without_breaking_the_lookup() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let mut env = TestEnv::new("path-isolation");
+        let bin = env.isolate_path();
+
+        let planted = bin.join("termaxa-not-a-real-harness");
+        std::fs::write(&planted, "#!/bin/sh\nexit 0\n").expect("plant must be writable");
+        std::fs::set_permissions(&planted, std::fs::Permissions::from_mode(0o755))
+            .expect("plant must be executable");
+
+        assert!(
+            crate::init::which("termaxa-not-a-real-harness"),
+            "the lookup must still run: a binary in the isolated directory has \
+             to be found, or every negative below is just a broken spawn"
+        );
+        for harness in ["codex", "copilot", "openhands"] {
+            assert!(
+                !crate::init::which(harness),
+                "{harness} was found through an isolated PATH — the developer's \
+                 machine is still reaching the test"
+            );
+        }
+    }
+
+    #[test]
+    fn the_guard_puts_path_back() {
+        let _outer = lock();
+        let path_before = std::env::var_os("PATH");
+
+        {
+            let mut env = TestEnv::build(None, "restores-path");
+            let bin = env.isolate_path();
+            // Leading rather than equal: Windows keeps System32 behind ours so
+            // `where.exe` stays reachable.
+            let live = std::env::var("PATH").expect("the guard exports a PATH");
+            assert!(
+                live.starts_with(&bin.display().to_string()),
+                "the guard must put its own bin dir in front while it is alive, got {live}"
+            );
+        }
+
+        assert_eq!(
+            std::env::var_os("PATH"),
+            path_before,
+            "a PATH left pointing into a deleted tree breaks every lookup after it"
+        );
     }
 
     /// Run `f` with panic output silenced, and report whether it panicked.

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -196,6 +196,11 @@ fn listing(dir: &Path) -> BTreeSet<OsString> {
 /// Retry-then-verdict, the shape #47 settled on: the window is microseconds
 /// and closes on its own, and once an `exec` has succeeded no writer remains
 /// to reopen it. Running the stub once is harmless — these print and exit.
+/// Unix only, and not merely because both callers are: `ETXTBSY` is a unix
+/// errno, and Windows keeps a just-written file busy through sharing
+/// violations on a different code path. A stub there would need its own
+/// measurement before it got its own wait.
+#[cfg(unix)]
 pub fn wait_until_executable(path: &Path) {
     for attempt in 0..10 {
         if attempt > 0 {
@@ -343,11 +348,16 @@ impl TestEnv {
         let only_bin = self.tree.path().join("only-bin");
         std::fs::create_dir_all(&only_bin).expect("the isolated bin dir must be creatable");
 
-        // Windows keeps `where.exe` in System32 along with the rest of the OS,
-        // and none of the harness CLIs live there, so naming that directory
-        // alongside ours gives the same shape without copying a system binary
-        // out of it.
-        if cfg!(windows) {
+        // `#[cfg]` and not `cfg!`: the two branches call different functions,
+        // and `cfg!` is a runtime bool that leaves BOTH of them compiled on
+        // both platforms. `locate` exists only off Windows, so the first
+        // version of this compiled here and failed the Windows leg.
+        #[cfg(windows)]
+        {
+            // Windows keeps `where.exe` in System32 along with the rest of the
+            // OS, and none of the harness CLIs live there, so naming that
+            // directory behind ours gives the same shape without copying a
+            // system binary out of it.
             let system32 = std::env::var_os("SystemRoot")
                 .map(|root| PathBuf::from(root).join("System32"))
                 .unwrap_or_else(|| PathBuf::from(r"C:\Windows\System32"));
@@ -355,7 +365,6 @@ impl TestEnv {
                 "PATH",
                 format!("{};{}", only_bin.display(), system32.display()),
             );
-            return only_bin;
         }
 
         // Locate the finder through the PATH the process still has, then put a
@@ -364,10 +373,14 @@ impl TestEnv {
         // A host with no `which` at all is left with an empty directory on
         // purpose: there, `init::which` already answers false for everything,
         // so this reports the same thing the host itself would.
-        if let Some(finder) = locate("which") {
-            let _ = std::fs::copy(&finder, only_bin.join("which"));
+        #[cfg(not(windows))]
+        {
+            if let Some(finder) = locate("which") {
+                let _ = std::fs::copy(&finder, only_bin.join("which"));
+            }
+            std::env::set_var("PATH", &only_bin);
         }
-        std::env::set_var("PATH", &only_bin);
+
         only_bin
     }
 


### PR DESCRIPTION
Closes #51.

All three members are fixed, and one of them is not the bug the issue describes. Everything below was measured on this tree, 4 cores, Linux.

## Member 1, the cwd: confirmed exactly as reported

`init::tests::the_supervised_setup_prints_the_modes_the_rig_proved` reads `tests/boundary/rig.sh` relative to the cwd, holds no `TestEnv` lock, and lives in a binary where `TestEnv::chdir` moves the process cwd.

| mode | result |
|---|---|
| default threads, 30 runs | 0 failures |
| `--test-threads=16`, 30 runs | **6 failures**, all at `init.rs:977` |

Fixed by anchoring to `CARGO_MANIFEST_DIR`, which `testutil.rs:407` and `tests/docs_encoding.rs:33` already use for this.

## A fourth member the issue does not have: PATH

While reproducing member 1, `init::tests::one_detected_harness_needs_no_flag` failed **30 runs out of 30**, at any thread count. Not a race.

`detect_harnesses` reads project evidence *and* `PATH`, through `which()`. This box has `codex` installed, so detection returns two harnesses and the exact-count assertion fails. On a box without it, it passes forever. The test was asserting a property of the developer's machine.

This is your third clause, and the interesting part is that the project already knew: `an_empty_project_detects_nothing_from_its_own_evidence`, one screen below, carries this comment.

> `which` may still find harnesses on a developer machine, so this asserts the PROJECT contributes nothing rather than that the list is empty — the latter would fail on any box with claude installed.

The knowledge was written down and did not reach the newer test. So I put it in the guard rather than in another comment: `TestEnv::isolate_path()`.

**Emptying PATH is the obvious implementation and it is the wrong one.** Measured:

```
PATH inherited          which claude -> spawned, success=true
PATH emptied            which claude -> SPAWN FAILED: entity not found
PATH = dir with `which` which claude -> spawned, success=false
```

With `PATH` empty the lookup answers "absent" because the `which` spawn never ran. That is a test passing through a broken mechanism. The helper copies the finder into the isolated directory instead, so the lookup runs and honestly reports absence.

Its own test asserts both halves: it plants a binary in the isolated directory and requires it to be **found**, then requires the harness CLIs not to be. Without the first assertion the whole test would pass under an empty PATH, which is the failure mode it exists to prevent. Verified by mutation, dropping the finder copy makes it fail on exactly that line:

```
panicked at src/testutil.rs:503:
the lookup must still run: a binary in the isolated directory has to be
found, or every negative below is just a broken spawn
```

`testutil`'s module doc now names PATH as the third process-global alongside `TERMAXA_HOME` and the cwd.

## Member 2, the terraform stub: real, but not by the proposed mechanism

The issue proposes that `Command::output()` inherits a cwd moved into a deleted tree and the spawn fails. I probed that directly before writing any fix:

```
cwd after deletion: Err(NotFound)
spawn OK: status=exit status: 0 stdout="Plan: 2 to add, 0 to change, 1 to destroy."
/bin/echo OK: "hi"
```

**A deleted cwd does not break an absolute-path spawn on Linux.** The stub runs and returns its plan. And taking a `TestEnv` would not have helped either way, since the thread that forks need not hold the lock.

The mechanism I did reproduce is ETXTBSY. Both stub helpers write an executable and have it exec'd immediately. `exec` refuses a file any process still holds open for writing; our own write descriptor is closed by then, but a sibling test that forks while it was open leaves the child holding a copy until that child reaches its own `exec`. `fork` in a threaded process copies descriptors it was never told about. Nothing here is misusing anything.

Lifting the write-then-exec shape out of `stub()` into a standalone program:

```
ok=4763  spawn_err=37  nonzero=0   (of 4800, 16 threads)
SPAWN ERR kind=ExecutableFileBusy raw=Some(26) msg=Text file busy (os error 26)
```

37 of 4800 at 16 threads, none serially. Rare, load-only, unix-only, and `.output().ok()?` turns it into `None`, which is also what a failed plan looks like. That matches the CI leg you saw: ubuntu red, macOS green on the same tree, never on your 1-core box, never on Windows because there is no `fork` and no ETXTBSY.

Two changes:

- `testutil::wait_until_executable` waits the window out, retry-then-verdict in the shape #47 settled on. It lives in `testutil` because `preview.rs` and `backup.rs` both have this shape, and I would rather not fix it in one and leave it in the other.
- `terraform_preview` now names the spawn error in test builds. Production behaviour is byte-identical: still best-effort, still `None`, still silent. This is your suggestion 2, and my own diagnosis needed it. I could only tell these apart by probing outside the suite.

**Honest limit:** ETXTBSY is proven in isolation, not inside the suite. I have not made it fire in a real `cargo test` run, and at 37-in-4800 under a fork-heavy harness I would not expect to soon. So the mechanism is measured, the fix addresses that mechanism, and "this is what happened on that CI leg" remains an inference from the signature rather than a reproduction. Worth saying, given the standard.

## Not changed, but noticed

`preview.rs`'s `both_apply_and_destroy_reach_the_planner` restores `PATH` by hand with no guard, while `backup.rs`'s `stub_on_path` uses a `PathGuard` with `Drop`. The preview one captures before asserting so it is careful rather than lucky, and the comment says so. Left alone: it is out of this issue's scope, and now that `isolate_path` exists the two hand-rolled versions are worth one look together rather than a drive-by here.

## Verification

- 449 tests green across 9 suites, `cargo fmt --check` clean, `cargo clippy --all-targets` silent
- `--test-threads=16`, 30 runs: **0 failures**, against 30 of 30 failing before
- `--test-threads=32`, 40 runs: **0 failures**
- Base `ef5eb0b`
