### PR TITLE
Make the preview and the backup name the same file (#50)

### DIFF
--- a/src/delete.rs
+++ b/src/delete.rs
@@ -454,6 +454,15 @@ pub struct Tok {
     /// expand variables, so for this question they are the same as no
     /// quotes at all).
     pub single_quoted: bool,
+    /// Char positions in `text` holding a `$` that reached the shell escaped.
+    ///
+    /// Consuming the backslash destroys the same evidence quote stripping
+    /// does: after it, `"\$SID"` and `"$SID"` are one string and only one of
+    /// them expands. The backslash cannot stay in `text` — a token that keeps
+    /// it names a different file than `pg::shell_tokens` names, which is the
+    /// divergence #50 is about — so where it stood travels beside the text,
+    /// the same way `single_quoted` does.
+    literal_dollars: Vec<usize>,
 }
 
 impl Tok {
@@ -486,6 +495,11 @@ impl Tok {
             if i > 0 && chars[i - 1] == '\\' {
                 continue;
             }
+            // Same fact, for the spelling where the backslash did not
+            // survive tokenization: `"\$SID"`.
+            if self.literal_dollars.contains(&i) {
+                continue;
+            }
             if let Some(next) = chars.get(i + 1) {
                 if next.is_ascii_alphabetic() || *next == '_' || *next == '{' {
                     return true;
@@ -507,8 +521,34 @@ fn tokenize_detailed(s: &str) -> Vec<Tok> {
     // An empty token never gets pushed, so the initial value only ever
     // reaches `out` alongside at least one single-quoted character.
     let mut all_single = true;
-    for c in s.chars() {
+    let mut literal_dollars: Vec<usize> = Vec::new();
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
         match (quote, c) {
+            // Inside double quotes a backslash escapes the next character,
+            // so `"a\"b"` is the one argument `a"b` and the quote it hides
+            // closes nothing. This is `pg::shell_tokens`' rule verbatim, and
+            // adopting it is #50: until v0.17 the backslash was literal
+            // here, so the preview resolved `a\b` while the backup engine
+            // copied `a"b` — one delete, two filenames, and the resolved-path
+            // policy layer reading the preview's.
+            //
+            // Verbatim includes where the rule is wrong: a shell keeps the
+            // backslash before an ordinary character, so `"a\nb"` is really
+            // `a\nb` and both lexers here say `anb`. That is a divergence
+            // from bash, not between the two engines, and closing it means
+            // moving both together rather than one of them now.
+            (Some('"'), '\\') => {
+                if let Some(next) = chars.next() {
+                    all_single = false;
+                    if next == '$' {
+                        // Only walked when an escaped `$` actually arrives,
+                        // which keeps the count off the hot path.
+                        literal_dollars.push(cur.chars().count());
+                    }
+                    cur.push(next);
+                }
+            }
             (Some(q), ch) if ch == q => quote = None,
             (Some(q), ch) => {
                 if q != '\'' {
@@ -522,6 +562,7 @@ fn tokenize_detailed(s: &str) -> Vec<Tok> {
                     out.push(Tok {
                         text: std::mem::take(&mut cur),
                         single_quoted: all_single,
+                        literal_dollars: std::mem::take(&mut literal_dollars),
                     });
                 }
                 all_single = true;
@@ -536,6 +577,7 @@ fn tokenize_detailed(s: &str) -> Vec<Tok> {
         out.push(Tok {
             text: cur,
             single_quoted: all_single,
+            literal_dollars,
         });
     }
     out
@@ -1009,6 +1051,7 @@ mod tests {
         assert!(flagged("rm -rf ${SID}")); // braced form
         assert!(!flagged("rm -rf 'lit$SID'")); // single quotes do not
         assert!(!flagged("rm -rf \\$SID")); // escaped, reaches shell literal
+        assert!(!flagged(r#"rm -rf "\$SID""#)); // same escape, inside quotes (#50)
         assert!(!flagged("rm -rf costs$5")); // digit: a filename
         assert!(!flagged("rm -rf x")); // control
                                        // `$(...)` is command substitution — a different hazard, not this
@@ -1045,6 +1088,61 @@ mod tests {
                 .map(|t| t.text)
                 .collect();
             assert_eq!(plain, detailed, "views diverged for {cmd:?}");
+        }
+    }
+
+    #[test]
+    fn the_preview_and_the_backup_name_the_same_files() {
+        // The property, not the behaviour (#50). Two lexers reach one delete:
+        // the preview reads targets through `tokenize_detailed`, and
+        // `backup::rm_targets` reads them through `pg::shell_tokens`. When
+        // they name different files, the preview counts one path and the
+        // insurance copies another — the two halves of the same promise
+        // describing different deletes.
+        //
+        // Pinning agreement rather than either reading is what makes this
+        // survive the shared lexer the roadmap wants: whatever the
+        // implementation becomes, this is its acceptance test.
+        fn through_the_backup_lexer(cmd: &str) -> Vec<String> {
+            let tokens = crate::pg::shell_tokens(cmd);
+            let Some((head, at)) = resolve_head(&tokens) else {
+                return Vec::new();
+            };
+            if !is_delete_command(&head) {
+                return Vec::new();
+            }
+            tokens[at + 1..]
+                .iter()
+                .filter(|t| !is_flag(&head, t))
+                .cloned()
+                .collect()
+        }
+
+        for cmd in [
+            // The measured divergence: bash resolves the argument to `a"b`,
+            // and until v0.17 only one of the two lexers agreed with it.
+            r#"rm -rf "a\"b""#,
+            r#"rm -rf "dir\"with\"quotes"/x"#,
+            // Neighbours that must not move while that one is fixed.
+            "rm -rf ./dist",
+            "rm -rf 'lit$SID'",
+            r#"rm -rf "spaced name""#,
+            r#"rm -rf 'single "inside' plain"#,
+            "\"rm\" -rf x",
+            "del /s /q C:\\tmp",
+            r#"rm -rf back\slash"#,
+            // Both lexers drop a backslash a shell would keep, so both say
+            // `anb`. Pinned deliberately: the property under test is that
+            // the preview and the insurance name one file, and this is the
+            // shape where they agree on a reading bash does not share.
+            r#"rm -rf "a\nb""#,
+            r#"rm -rf "\$SID""#,
+        ] {
+            assert_eq!(
+                extract_targets(cmd),
+                through_the_backup_lexer(cmd),
+                "preview and backup disagree about {cmd:?}"
+            );
         }
     }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -648,6 +648,20 @@ mod tests {
         );
     }
 
+    /// #50, one layer down from where it was found. The policy layer reads
+    /// its delete targets through `delete::extract_targets`, so the lexer
+    /// that named the wrong file named it here too: a `match_path` rule
+    /// written against the real filename missed, and the reason line quoted
+    /// a path nothing on disk had. The resolved reading is the file bash
+    /// deletes.
+    #[test]
+    fn an_escaped_quote_resolves_to_the_file_the_shell_deletes() {
+        assert_eq!(
+            roles(r#"rm -rf "a\"b""#),
+            vec![("a\"b".to_string(), TargetRole::Removed)]
+        );
+    }
+
     #[test]
     fn a_plain_relative_target_resolves_against_the_given_cwd_and_is_ordinary() {
         let t = TempTree::new("resolve-plain");


### PR DESCRIPTION
Closes #50.

Two lexers reach a delete, and they named different files. The preview finds its
targets through `delete::tokenize_detailed`, where a backslash was literal
everywhere. `backup::rm_targets` finds them through `pg::shell_tokens`, where a
backslash escapes the next character inside double quotes. Bash agrees with `pg`,
so for `rm -rf "a\"b"` the preview resolved, counted and displayed `a\b` while the
insurance copied `a"b`. The resolved-path policy layer reads the preview's token,
so a `match_path` rule written against the real filename missed.

The test came first and reproduced the issue as filed:

```
assertion `left == right` failed: preview and backup disagree about "rm -rf \"a\\\"b\""
  left: ["a\\b"]
 right: ["a\"b"]
```

## What changed

`tokenize_detailed` now applies `pg`'s rule verbatim.

**Verbatim includes where that rule is wrong.** A shell keeps the backslash before
an ordinary character, so `"a\nb"` is really `a\nb` and both lexers here say `anb`.
That is a divergence from bash rather than between the two engines, and it is
pinned in the agreement list with a comment saying so. Teaching `delete` the
bash-accurate rule on its own would have re-opened the gap this PR closes, one
character to the left.

**Consuming the backslash breaks `has_unexpanded_var`.** After the escape is gone,
`"\$SID"` and `"$SID"` are the same string and only one of them expands, so the
change would have added a fourth false positive to the three the r/ClaudeCode
review named. The escaped positions now travel beside the text the way
`single_quoted` already does, and `unexpanded_var_detection_is_quote_aware` grows
the case. Verified load-bearing by disabling the guard:

```
assertion failed: !flagged(r#"rm -rf "\$SID""#)
```

## The test pins agreement, not a reading

`the_preview_and_the_backup_name_the_same_files` runs each command through both
lexers and asserts they name the same targets. That property survives the shared
lexer the roadmap wants: whatever the implementation becomes, this is its
acceptance test. `an_escaped_quote_resolves_to_the_file_the_shell_deletes` in
`resolve.rs` pins the consequence one layer down, and also fails without the fix.

## Still open, deliberately not in this diff

`intent::tokens` is the fourth quote-tracking loop and still reads that command the
old way. Measured on this branch:

```
readings("rm -rf \"a\\\"b\"") -> "rm -rf \"a\\\"b\""   (raw)
                                "rm -rf a\\b"          (tokenized)
```

Same family, different blast radius: rule matching rather than a filename. One
member at a time, and that one deserves its own proof.

## Verification

451 tests pass, `cargo fmt --check` clean, `cargo clippy --all-targets -D warnings`
clean. Stated limit: my toolchain is 1.94.1, so the 1.98 lint set that produced #53
is first checked by CI rather than by me. Both new tests were confirmed to fail on
the pre-fix tree.
