### PR TITLE
shell: a POSIX shell's -c string is read as the command it runs (#62)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,7 +58,7 @@ and insurance carry the weight rather than `ask`.
 
 > Would a cooperative agent, making an ordinary mistake, hit this?
 
-If yes, it is a bug and it gets fixed regardless of threat model — a careless agent hits `rm -r -f /` and `git push -f` exactly as readily as a hostile one. If it only fires under deliberate evasion — quoting a command name to dodge a rule, `bash -c` to hide a payload, a SQL comment inside a keyword — it is a documented limit, and this section is that documentation.
+If yes, it is a bug and it gets fixed regardless of threat model — a careless agent hits `rm -r -f /` and `git push -f` exactly as readily as a hostile one. If it only fires under deliberate evasion — quoting a command name to dodge a rule, a payload hidden in `python -c` or `eval`, a SQL comment inside a keyword — it is a documented limit, and this section is that documentation. (A POSIX shell's `-c` string — `sh`, `bash`, `dash`, `zsh` — is read as the command it runs, since v0.17.1 (#62): agents and harnesses spell ordinary commands that way. A script file, a heredoc, `eval`, and the Windows shells are not read; the last is tracked as its own issue.)
 
 We state this because it would be very convenient to call every bypass "out of scope," and that is exactly when a framing deserves suspicion.
 

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -35,18 +35,22 @@ pub struct BackupRecord {
 /// backup" about a file that would in fact be copied aside. A preview whose
 /// lines are meant to be facts cannot resolve against the process cwd.
 pub fn plan(command: &str, cwd: &Path) -> Option<String> {
-    let segments = crate::shell::split_segments(command);
-    if segments.len() > 1 {
-        return segments.iter().find_map(|s| plan(s, cwd));
-    }
+    // Every segment, including the ones inside a POSIX shell's -c string
+    // (#62); the first with a plan is the plan. Each segment is judged from
+    // the split's own reading of it, never by splitting its text again —
+    // a wrapper segment's text splits into the wrapper and its string,
+    // without end.
+    crate::shell::split_segments_deep(command)
+        .iter()
+        .find_map(|s| plan_segment(s, cwd))
+}
+
+fn plan_segment(segment: &crate::shell::Segment, cwd: &Path) -> Option<String> {
+    let command: &str = segment;
     // Tokens of the segment's own words. Tokenizing the full text put
     // `/dev/null` among rm's operands — it exists, so it was planned, and
     // copying a device is what made `take` fail on the real target (#61).
-    let own = segments
-        .first()
-        .map(|s| s.command().to_string())
-        .unwrap_or_default();
-    let tokens = crate::pg::shell_tokens(&own);
+    let tokens = crate::pg::shell_tokens(segment.command());
     if let Some((remote, branch)) = git_force_push_target(&tokens) {
         return Some(format!(
             "snapshot {}/{} to a local backup branch before it is overwritten",
@@ -76,11 +80,7 @@ pub fn plan(command: &str, cwd: &Path) -> Option<String> {
     // report and the mechanism disagreeing is the bug shape this release
     // keeps finding; found by roadmap 2.2, which is the first caller to ask
     // `plan` about a write.
-    let redirects: Vec<crate::shell::Overwrite> = crate::shell::split_segments(command)
-        .into_iter()
-        .flat_map(|s| s.redirects)
-        .collect();
-    if let Some(paths) = overwrite_paths(&redirects, cwd) {
+    if let Some(paths) = overwrite_paths(&segment.redirects, cwd) {
         return Some(format!(
             "copy {} path(s) to .termaxa/backups before they are overwritten",
             paths.len()
@@ -116,23 +116,24 @@ fn tf_state_target(tokens: &[String]) -> Option<PathBuf> {
 /// Take the backup. Returns the record on success, a printable error string
 /// on a failed attempt, or Ok(None) when the command needs no insurance.
 pub fn take(termaxa_dir: &Path, command: &str, cwd: &Path) -> Result<Option<BackupRecord>> {
-    let segments = crate::shell::split_segments(command);
-    if segments.len() > 1 {
-        for s in &segments {
-            if let Some(rec) = take(termaxa_dir, s, cwd)? {
-                return Ok(Some(rec)); // insure the first insurable segment
-            }
+    for segment in crate::shell::split_segments_deep(command) {
+        if let Some(rec) = take_segment(termaxa_dir, &segment, cwd)? {
+            return Ok(Some(rec)); // insure the first insurable segment
         }
-        return Ok(None);
     }
+    Ok(None)
+}
+
+fn take_segment(
+    termaxa_dir: &Path,
+    segment: &crate::shell::Segment,
+    cwd: &Path,
+) -> Result<Option<BackupRecord>> {
+    let command: &str = segment;
     // The segment's own words for the operand readers, its redirects for
     // the overwrite reader — both from the one split (#61).
-    let (own, redirects) = segments
-        .into_iter()
-        .next()
-        .map(|s| (s.command().to_string(), s.redirects))
-        .unwrap_or_default();
-    let tokens = crate::pg::shell_tokens(&own);
+    let tokens = crate::pg::shell_tokens(segment.command());
+    let redirects = &segment.redirects;
     let (ts_ms, ts) = now();
     let id = format!("b-{}", ts_ms);
 
@@ -144,7 +145,7 @@ pub fn take(termaxa_dir: &Path, command: &str, cwd: &Path) -> Result<Option<Back
         backup_files(termaxa_dir, &id, &ts, command, &paths)?
     } else if let Some(state) = tf_state_target(&tokens) {
         backup_files(termaxa_dir, &id, &ts, command, &[state])?
-    } else if let Some(paths) = overwrite_paths(&redirects, cwd) {
+    } else if let Some(paths) = overwrite_paths(redirects, cwd) {
         backup_files(termaxa_dir, &id, &ts, command, &paths)?
     } else {
         return Ok(None);
@@ -970,6 +971,51 @@ mod tests {
         assert!(
             state.join("backups").join("manifest.jsonl").is_file(),
             "an insured operation leaves a record behind"
+        );
+    }
+
+    /// #62. `sh -c "cat /dev/null > src/main.rs"` was asked, approved and
+    /// executed with no backup: insurance saw `sh` with two arguments.
+    #[test]
+    fn a_command_inside_a_shell_c_string_is_insured() {
+        let tmp = TempTree::new("bk-shell-c");
+        let state = tmp.dir("state");
+        let doomed = tmp.file("doomed.txt", "precious");
+        // Forward slashes on purpose. Inside the double-quoted -c string a
+        // backslash escapes the next character to this lexer (the #50 rule,
+        // where bash would keep `\U` as is), so a Windows temp path spelled
+        // `C:\Users\...` arrives as `C:Users...` and names nothing. That is
+        // #56's divergence, not this test's subject; Windows reads `C:/...`.
+        let d = doomed.display().to_string().replace('\\', "/");
+
+        for (command, expected_plan) in [
+            (
+                format!(r#"sh -c "cat /dev/null > {d}""#),
+                "copy 1 path(s) to .termaxa/backups before they are overwritten",
+            ),
+            (
+                format!(r#"bash -lc "rm -rf {d}""#),
+                "copy 1 path(s) to .termaxa/backups before deletion",
+            ),
+        ] {
+            assert_eq!(
+                plan(&command, &test_cwd()).as_deref(),
+                Some(expected_plan),
+                "{command}"
+            );
+            let record = take(&state, &command, &test_cwd())
+                .unwrap_or_else(|e| panic!("{command}: the backup must not fail: {e}"))
+                .unwrap_or_else(|| panic!("{command}: the command inside is insurable"));
+            assert_eq!(record.kind, "files", "{command}");
+            assert!(
+                record.note.starts_with("1 path(s)"),
+                "{command}: {}",
+                record.note
+            );
+        }
+        assert!(
+            plan("sh clean.sh", &test_cwd()).is_none(),
+            "a script file is not read"
         );
     }
 

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -241,7 +241,7 @@ pub fn extract_targets(command: &str) -> Vec<String> {
 /// travels beside it.
 pub fn extract_targets_detailed(command: &str) -> Vec<Tok> {
     let mut out = Vec::new();
-    for segment in crate::shell::split_segments(command) {
+    for segment in crate::shell::split_segments_deep(command) {
         // The segment's own words. The split already found every
         // redirection; reading the full text here made `2>/dev/null` and
         // `/dev/null` into targets, and the insurance that then tried to
@@ -989,6 +989,17 @@ mod tests {
         let long = format!("/home/user/{}", "a".repeat(60));
         assert_eq!(short(&long).chars().count(), 40);
         assert!(short(&long).ends_with("aaa"));
+    }
+
+    /// #62: the delete inside a POSIX shell's -c string names its target.
+    #[test]
+    fn a_delete_inside_a_shell_c_string_names_its_target() {
+        assert_eq!(extract_targets(r#"sh -c "rm -rf ./dist""#), vec!["./dist"]);
+        assert_eq!(
+            extract_targets(r#"bash -lc "cd /tmp && rm -rf ./dist ./build""#),
+            vec!["./dist", "./build"]
+        );
+        assert!(extract_targets("sh clean.sh ./dist").is_empty());
     }
 
     #[test]

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -92,7 +92,7 @@ impl Intent {
 /// segment, and returns the most severe intent found — mirroring the
 /// "most dangerous segment dictates the verdict" rule.
 pub fn classify_command(command: &str) -> Option<Intent> {
-    crate::shell::split_segments(command)
+    crate::shell::split_segments_deep(command)
         .iter()
         .filter_map(classify_segment)
         .max_by_key(|i| i.rank())
@@ -513,6 +513,31 @@ mod tests {
         ] {
             assert_eq!(classify_command(cmd), None, "{cmd} deletes nothing");
         }
+    }
+
+    /// #62: a POSIX shell's -c string is the command. `sh -c "cat /dev/null
+    /// > src/main.rs"` was asked by policy default, previewed nothing and
+    /// took no backup; to this classifier it was `sh` with two arguments.
+    #[test]
+    fn a_posix_shell_does_not_hide_the_command_it_runs() {
+        assert_eq!(
+            classify_command(r#"sh -c "cat /dev/null > src/main.rs""#),
+            Some(Intent::FileOverwrite)
+        );
+        assert_eq!(
+            classify_command(r#"bash -lc "rm -rf ./dist""#),
+            Some(Intent::FileDelete)
+        );
+        assert_eq!(
+            classify_command(r#"sudo sh -c "psql -d shop -c 'DROP TABLE users'""#),
+            Some(Intent::DbDestroy)
+        );
+        assert_eq!(classify_command(r#"sh -c "ls -la""#), None);
+        assert_eq!(
+            classify_command("sh clean.sh"),
+            None,
+            "a script file is not read"
+        );
     }
 
     /// v0.16: a wrapper program hid the real command from every engine.

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -326,7 +326,7 @@ impl Policy {
     /// Closes the v0.6.1 field-report bypass where `git status && <anything>`
     /// rode the `git status*` wildcard.
     pub fn evaluate_command(&self, command: &str, ctx: &crate::resolve::EvalContext) -> Decision {
-        let segments = crate::shell::split_segments(command);
+        let segments = crate::shell::split_segments_deep(command);
         if segments.len() <= 1 {
             return self.evaluate(command, ctx);
         }
@@ -358,10 +358,15 @@ impl Policy {
             source: d.source,
             matched_rule: d.matched_rule,
             reason: format!(
-                "segment {}/{} `{}` — {}",
+                "segment {}/{} `{}`{} — {}",
                 i + 1,
                 total,
                 segments[i],
+                segments[i]
+                    .via
+                    .as_deref()
+                    .map(|v| format!(" (inside {v})"))
+                    .unwrap_or_default(),
                 d.reason
             ),
         }
@@ -1009,6 +1014,39 @@ rules:
                 .action,
             Action::Deny
         );
+    }
+
+    /// #62: a rule that allows the shell does not allow what the shell is
+    /// told to run. The string's own segments are judged, and the reason
+    /// says which wrapper the losing segment was read through.
+    #[test]
+    fn a_shell_c_string_is_judged_by_what_it_runs() {
+        let policy: Policy = serde_yaml::from_str(
+            r#"
+default: ask
+rules:
+  - match: "sh *"
+    action: allow
+  - match: "rm -rf *"
+    action: deny
+"#,
+        )
+        .unwrap();
+        let d = policy.evaluate_command(r#"sh -c "rm -rf ./dist""#, &here());
+        assert_eq!(d.action, Action::Deny);
+        assert!(d.reason.contains("segment 2/2"), "{}", d.reason);
+        assert!(d.reason.contains("(inside sh -c)"), "{}", d.reason);
+        assert!(d.reason.contains("rm -rf ./dist"), "{}", d.reason);
+        // The wrapper rule still applies to what it names; the string is
+        // judged on its own, so an unmatched command inside falls to the
+        // default exactly as it would typed at the top level.
+        assert_eq!(
+            policy.evaluate_command("sh clean.sh", &here()).action,
+            Action::Allow
+        );
+        let d = policy.evaluate_command(r#"sh -c "ls -la""#, &here());
+        assert_eq!(d.action, Action::Ask, "{}", d.reason);
+        assert!(d.reason.contains("(inside sh -c)"), "{}", d.reason);
     }
 
     #[test]

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -63,8 +63,9 @@ pub fn generate(
     if let Some(p) = crate::delete::preview_for(command, root, cwd) {
         return Some(p);
     }
-    // Compound commands: preview the first segment that has one.
-    let segments = crate::shell::split_segments(command);
+    // Compound commands: preview the first segment that has one. A POSIX
+    // shell's -c string counts as segments of its own (#62).
+    let segments = crate::shell::split_segments_deep(command);
     if segments.len() > 1 {
         if let Some(p) = segments.iter().find_map(|s| generate_one(s, cwd, live)) {
             return Some(p);
@@ -1028,6 +1029,25 @@ mod live_gate_tests {
 
     /// Deletes never spawned anything, so they are unaffected either way —
     /// asserted so a future refactor can't quietly gate them too.
+    /// #62: a command inside a POSIX shell's -c string gets the preview it
+    /// would get typed at the top level — the demo command got none.
+    #[test]
+    fn a_shell_c_string_is_previewed_as_the_command_inside_it() {
+        let inner = "rm -rf /tmp/tmx-none-such";
+        let wrapped = format!(r#"sh -c "{inner}""#);
+        let direct = generate(inner, None, std::path::Path::new("."), false);
+        let through = generate(&wrapped, None, std::path::Path::new("."), false);
+        assert!(direct.is_some(), "the control leg previews");
+        assert_eq!(
+            through.as_ref().map(|p| &p.summary),
+            direct.as_ref().map(|p| &p.summary)
+        );
+        assert!(
+            generate("sh deploy.sh", None, std::path::Path::new("."), false).is_none(),
+            "a script file is not read"
+        );
+    }
+
     #[test]
     fn deletes_preview_identically_whether_live_or_not() {
         let live = generate(

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -245,7 +245,7 @@ pub fn command_targets(segment: &str, ctx: &EvalContext) -> Vec<ResolvedTarget> 
     // Redirects: the unified scanner already extracted them, with truncation
     // decided there. An append still names a destination - it does not
     // truncate, but the path is still one the command writes.
-    for seg in crate::shell::split_segments(segment) {
+    for seg in crate::shell::split_segments_deep(segment) {
         for o in &seg.redirects {
             out.push((o.target.clone(), TargetRole::Destination));
         }
@@ -258,7 +258,7 @@ pub fn command_targets(segment: &str, ctx: &EvalContext) -> Vec<ResolvedTarget> 
 
     // Per-command grammars, over the segment's own words: a redirect's
     // target is a Destination above, not an operand here (#61).
-    for seg in crate::shell::split_segments(segment) {
+    for seg in crate::shell::split_segments_deep(segment) {
         let tokens = crate::delete::tokenize_public(seg.command());
         let Some((head, at)) = crate::delete::resolve_head(&tokens) else {
             continue;

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -301,6 +301,83 @@ fn target_word(chars: &[char], cur: &mut String, mut j: usize) -> (String, usize
     (target, j)
 }
 
+/// POSIX shells whose `-c <string>` runs the string as a command line.
+/// Narrow on purpose (#62): each name here is one a cooperative harness or
+/// agent has been seen to spell. `ksh` and `ash` wait for a capture; `fish`
+/// has its own syntax and is not read.
+const POSIX_SHELLS: [&str; 4] = ["sh", "bash", "dash", "zsh"];
+
+/// How many `-c` strings deep the reading goes. `sh -c "sh -c '…'"` is two;
+/// four is more than any harness produces and bounds a pathological input.
+const MAX_WRAP_DEPTH: usize = 4;
+
+/// `split_segments`, and then through every POSIX shell `-c` string found.
+///
+/// #62. `sh -c "cat /dev/null > src/main.rs"` was a segment whose head is
+/// `sh`, with two arguments, to every engine: no overwrite intent, no
+/// preview, no insurance, and the ask it got came from the policy default.
+/// The `wrap` shim forwards every agent command in exactly that shape.
+///
+/// Additive: the wrapper segment stays, and the string's own segments follow
+/// it, each carrying the wrapper it was read through in `via`. Nothing that
+/// matched before stops matching — a rule on `sh *` still sees the wrapper —
+/// and the most dangerous segment still decides. The wrapper's own
+/// redirects (`sh -c "…" > log`) stay on the wrapper. Callers that judge a
+/// whole command line use this; callers handed one segment's text and
+/// asked about that segment alone keep `split_segments`.
+pub fn split_segments_deep(s: &str) -> Vec<Segment> {
+    let mut out = Vec::new();
+    expand_into(&mut out, split_segments(s), None, 0);
+    out
+}
+
+fn expand_into(out: &mut Vec<Segment>, segments: Vec<Segment>, via: Option<&str>, depth: usize) {
+    for mut seg in segments {
+        if let Some(v) = via {
+            seg.via = Some(v.to_string());
+        }
+        let inner = if depth < MAX_WRAP_DEPTH {
+            wrapped_command(&seg)
+        } else {
+            None
+        };
+        out.push(seg);
+        if let Some((shell, script)) = inner {
+            let label = format!("{shell} -c");
+            expand_into(out, split_segments(&script), Some(&label), depth + 1);
+        }
+    }
+}
+
+/// The shell and the string, when this segment is a POSIX shell running a
+/// `-c` string. The head is resolved past `sudo`/`env` and by file stem, so
+/// `sudo /bin/sh -c "…"` counts. The flag may be its own token or part of
+/// a cluster — `bash -lc "…"` is how Codex spells it — and the string is the
+/// token after it. `sh script.sh`, a bare `sh -c`, and a `-c` with nothing
+/// after it are not read.
+fn wrapped_command(seg: &Segment) -> Option<(String, String)> {
+    let tokens = crate::delete::tokenize_public(seg.command());
+    let (head, at) = crate::delete::resolve_head(&tokens)?;
+    if !POSIX_SHELLS.contains(&head.as_str()) {
+        return None;
+    }
+    let mut i = at + 1;
+    while let Some(tok) = tokens.get(i) {
+        if !tok.starts_with('-') || tok == "-" || tok.starts_with("--") {
+            return None; // a script file or an operand, not a -c string
+        }
+        if tok[1..].contains('c') {
+            let script = tokens.get(i + 1)?;
+            if script.trim().is_empty() {
+                return None;
+            }
+            return Some((head, script.clone()));
+        }
+        i += 1;
+    }
+    None
+}
+
 /// One shell segment, carrying the redirect targets found in it.
 ///
 /// v0.16 §1.5. Segments and redirect targets used to come from two separate
@@ -323,6 +400,10 @@ pub struct Segment {
     command: String,
     /// Files this segment writes over, in order of appearance.
     pub redirects: Vec<Overwrite>,
+    /// The shell wrapper this segment was read through, as `sh -c`, when
+    /// `split_segments_deep` found it inside a `-c` string. `None` for a
+    /// segment typed at the top level (#62).
+    pub via: Option<String>,
 }
 
 impl Segment {
@@ -419,6 +500,7 @@ fn flush(
             text: t.to_string(),
             command: command.trim().to_string(),
             redirects: std::mem::take(redirects),
+            via: None,
         });
     } else {
         // Nothing but whitespace between separators: whatever the redirect
@@ -590,6 +672,112 @@ mod tests {
         // a segment without redirections reads the same both ways
         let seg = &split_segments("rm -rf ./cache")[0];
         assert_eq!(seg.command(), &**seg);
+    }
+
+    /// #62. A POSIX shell's -c string is read as segments of its own,
+    /// after the wrapper, each marked with the wrapper it came through.
+    #[test]
+    fn a_posix_shell_c_string_is_read_as_its_own_segments() {
+        let segs = split_segments_deep(r#"sh -c "cat /dev/null > src/main.rs""#);
+        let texts: Vec<&str> = segs.iter().map(|s| &**s).collect();
+        assert_eq!(
+            texts,
+            [
+                r#"sh -c "cat /dev/null > src/main.rs""#,
+                "cat /dev/null > src/main.rs"
+            ]
+        );
+        assert_eq!(segs[0].via, None, "the wrapper was typed at the top level");
+        assert_eq!(segs[1].via.as_deref(), Some("sh -c"));
+        assert!(
+            segs[0].redirects.is_empty(),
+            "the quoted `>` is text to the wrapper"
+        );
+        assert_eq!(segs[1].redirects[0].target, "src/main.rs");
+
+        // Codex's spelling: the flag in a cluster, a compound inside.
+        let segs = split_segments_deep(r#"bash -lc "rm -rf ./dist && echo done""#);
+        let texts: Vec<&str> = segs.iter().map(|s| &**s).collect();
+        assert_eq!(
+            texts,
+            [
+                r#"bash -lc "rm -rf ./dist && echo done""#,
+                "rm -rf ./dist",
+                "echo done"
+            ]
+        );
+        assert!(segs[1..]
+            .iter()
+            .all(|s| s.via.as_deref() == Some("bash -c")));
+
+        // Resolved past sudo and by file stem; every shell on the list.
+        for cmd in [
+            r#"sudo sh -c "rm -rf ./dist""#,
+            r#"/bin/sh -c "rm -rf ./dist""#,
+            r#"dash -c "rm -rf ./dist""#,
+            r#"zsh -ec "rm -rf ./dist""#,
+            r#"sh -e -c "rm -rf ./dist""#,
+            "sh -c 'rm -rf ./dist'",
+        ] {
+            let segs = split_segments_deep(cmd);
+            assert_eq!(segs.len(), 2, "{cmd}");
+            assert_eq!(&*segs[1], "rm -rf ./dist", "{cmd}");
+        }
+
+        // The wrapper's own redirect stays on the wrapper.
+        let segs = split_segments_deep(r#"sh -c "echo hi" > out.log"#);
+        assert_eq!(segs.len(), 2);
+        assert_eq!(segs[0].redirects[0].target, "out.log");
+        assert!(segs[1].redirects.is_empty());
+        assert_eq!(&*segs[1], "echo hi");
+    }
+
+    /// What is deliberately not read: a script file, a bare `-c`, a shell
+    /// off the list, and the string beyond the depth limit.
+    #[test]
+    fn what_a_shell_wrapper_reading_leaves_alone() {
+        for cmd in [
+            "sh deploy.sh",
+            "bash ./scripts/clean.sh --force",
+            "sh -c",
+            "sh -c \"\"",
+            r#"fish -c "rm -rf ./dist""#,
+            r#"ksh -c "rm -rf ./dist""#,
+            r#"python -c "import shutil; shutil.rmtree('dist')""#,
+            "sh - script.sh",
+            "bash --norc script.sh",
+        ] {
+            let segs = split_segments_deep(cmd);
+            assert_eq!(segs.len(), 1, "{cmd}");
+            assert_eq!(segs[0].via, None, "{cmd}");
+        }
+        // Nesting is read to the limit and no further.
+        let two = r#"sh -c "bash -c 'rm -rf ./dist'""#;
+        let segs = split_segments_deep(two);
+        let texts: Vec<&str> = segs.iter().map(|s| &**s).collect();
+        assert_eq!(texts, [two, "bash -c 'rm -rf ./dist'", "rm -rf ./dist"]);
+        assert_eq!(segs[1].via.as_deref(), Some("sh -c"));
+        assert_eq!(segs[2].via.as_deref(), Some("bash -c"));
+        // Six wrappers deep, double-quoted with the inner quotes escaped.
+        let mut deep = "rm -rf ./dist".to_string();
+        for _ in 0..6 {
+            deep = format!(
+                "sh -c \"{}\"",
+                deep.replace('\\', "\\\\").replace('"', "\\\"")
+            );
+        }
+        let segs = split_segments_deep(&deep);
+        assert_eq!(
+            segs.len(),
+            MAX_WRAP_DEPTH + 1,
+            "one wrapper per level, then stop"
+        );
+        assert_ne!(
+            &*segs[MAX_WRAP_DEPTH], "rm -rf ./dist",
+            "the innermost string was not reached"
+        );
+        // The plain split is unchanged: one segment, no reading through.
+        assert_eq!(split_segments(two).len(), 1);
     }
 
     #[test]

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -78,7 +78,7 @@ fn project(root: &Path) -> PathBuf {
     std::fs::write(
         proj.join(".termaxa").join("policy.yaml"),
         "version: 1\ndefault: ask\nrules:\n  - match: \"rm -rf /*\"\n    action: deny\n  \
-         - match: \"sh*\"\n    action: allow\n",
+         - match: \"sh*\"\n    action: allow\n  - match: \"exit*\"\n    action: allow\n",
     )
     .expect("policy must be writable");
     proj


### PR DESCRIPTION
Closes #62

`sh -c "cat /dev/null > src/main.rs"` was asked by policy default, previewed nothing, and took no backup; approved, it emptied the file. Every engine saw `sh` with two arguments: the classifier's wrapper list is sudo/doas/env/nice/nohup/command, the quote-aware split rightly kept the `>` inside the string as text, and nothing read the string. Measured against `ff56bc9` on 2026-09-02. The `wrap` shim forwards every agent command in exactly that shape, and Codex spells its commands `bash -lc`.

`shell::split_segments_deep`: the plain split, and then through every POSIX shell -c string it finds. A segment whose head - past sudo/env, and by file stem, so `/bin/sh` counts - is `sh`, `bash`, `dash` or `zsh`, carrying `-c` as its own flag or in a cluster (`-lc`, `-ec`), is followed by the string's own segments, recursively, four levels deep. Additive: the wrapper stays, so nothing that matched before stops matching; the inner segments carry the wrapper they were read through in `via`, so a reason reads `segment 2/2 `rm -rf ./dist` (inside sh -c)`. The wrapper's own redirects stay on the wrapper. The list is narrow on purpose: `ksh` and `ash` wait for a capture, `fish` has its own syntax, and `cmd /c` and `powershell -Command` are a different dialect with their own issue (#64).

The engines that judge a whole command line - policy, intent, preview, delete targets, resolve, and insurance's plan and take - split deep. Insurance now judges each segment from the split's own reading of it, rather than splitting the segment's text again, because a wrapper's text splits into the wrapper and its string without end. `split_segments` itself is unchanged for callers handed one segment's text.

What is deliberately not read: `sh script.sh`, a heredoc, `eval`, a bare `-c`, and the string beyond the depth limit. SECURITY.md's limit sentence no longer lists `bash -c` among deliberate evasions and says what still is not read.

Behaviour change to state plainly: a rule that allows the shell no longer allows what the shell is told to run. `allow sh*` with `sh -c "exit 3"` inside is now judged as `exit 3` typed at the top level - the policy default, if no rule names it - exactly as a compound's unmatched segment is. The cli_surface fixture allowed `sh*` as the convenient way to run `exit 3`; it now allows `exit*` too. In wrap mode this is the point: the command is what the agent ran, and the rules should name commands.

After, against the same tree and database-free project: the demo command through `check` shows `overwrite impact / target src/main.rs / insurance: copy 1 path(s)`; through `run`, approved, `backup b-... 1 path(s) copied` and `termaxa backups` lists it, insuring `cat /dev/null > src/main.rs`; `bash -lc "rm -rf ./dist"` is denied with the delete impact shown; `sh deploy.sh` is unchanged. Through the `wrap` shim the same preview and backup now appear. The shim's execution of what it approved is a separate, pre-existing fault, filed as #65.

Tests: the string read as segments with `via`, the Codex cluster spelling, sudo and absolute-path heads, every shell on the list, the wrapper's redirect staying put; what is left alone, and nesting stopping at the limit; the classifier seeing overwrite, delete and DROP through the wrapper; delete targets through it; the preview matching the top-level command's; plan and take insuring both an overwrite and a delete inside; a policy allowing `sh *` still denying the delete inside, and asking about an unmatched command inside with the wrapper named. The insurance test spells its temp path with forward slashes: inside the double-quoted -c string this lexer reads a backslash as an escape (the #50 rule, where bash keeps `\U`), so a Windows path spelled `C:\Users` arrived as `C:Users` on the first Windows run and named nothing. That is #56's divergence, noted in the test and left to 2.2.