### PR TITLE
wrap: an approved command runs outside the shims, so the wrapper executes what it allows (#65)

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -172,7 +172,17 @@ fn shell_join(argv: &[String]) -> String {
 }
 
 fn execute(argv: &[String]) -> Result<i32> {
-    let status = Command::new(&argv[0]).args(&argv[1..]).status()?;
+    // Outside the wrapper's shims (#65): under `termaxa wrap`, `sh` by name
+    // is the shim, and the shim is what brought us here.
+    let inherited = std::env::var_os("PATH");
+    let (program, path) = match crate::paths::home_base() {
+        Ok(home) => crate::wrap::outside_shims(&argv[0], inherited.as_deref(), &home),
+        Err(_) => (argv[0].clone().into(), inherited.unwrap_or_default()),
+    };
+    let status = Command::new(&program)
+        .args(&argv[1..])
+        .env("PATH", &path)
+        .status()?;
     Ok(status.code().unwrap_or(1))
 }
 

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -115,6 +115,70 @@ pub fn install_shims(termaxa_home: &Path, _termaxa_bin: &Path) -> Result<PathBuf
     )
 }
 
+/// The program and `PATH` an approved command runs with: the shim directory
+/// taken out of `PATH`, and a bare program name resolved through what is
+/// left, so it is the real shell and not the shim again.
+///
+/// #65. The shim forwards `sh -c "<cmd>"` to `termaxa run -- sh -c "<cmd>"`.
+/// The runner then executed `sh` by name, through the same `PATH` the
+/// wrapper had set up, and got the shim: an allowed command recursed
+/// without end (`wrap -- sh -c 'echo hi'` hung), an asked one asked twice
+/// and then found no stdin. Nothing ever reached `/bin/sh`. Measured on
+/// 2026-09-03; the residue test had pinned a deny and a bypass, never an
+/// execution.
+///
+/// The command's own children run with the same stripped `PATH`, which is
+/// the intent: what was approved was the command and what it spawns. A
+/// program given with a path separator is left alone; a bare name that
+/// resolves nowhere is left bare, for the OS to report as before.
+pub fn outside_shims(
+    program: &str,
+    path: Option<&std::ffi::OsStr>,
+    termaxa_home: &Path,
+) -> (std::ffi::OsString, std::ffi::OsString) {
+    let shims = shim_dir(termaxa_home);
+    let same_dir = |entry: &str| -> bool {
+        let e = Path::new(entry);
+        e == shims
+            || match (e.canonicalize(), shims.canonicalize()) {
+                (Ok(a), Ok(b)) => a == b,
+                _ => false,
+            }
+    };
+    let kept: Vec<String> = path
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default()
+        .split(path_separator())
+        .filter(|entry| !entry.is_empty() && !same_dir(entry))
+        .map(str::to_string)
+        .collect();
+    let stripped: std::ffi::OsString = kept.join(path_separator()).into();
+    let bare = !program.contains('/') && !program.contains('\\');
+    let resolved = if bare {
+        kept.iter()
+            .map(|dir| Path::new(dir).join(program))
+            .find(|candidate| is_executable_file(candidate))
+            .map(|p| p.into_os_string())
+            .unwrap_or_else(|| program.into())
+    } else {
+        program.into()
+    };
+    (resolved, stripped)
+}
+
+#[cfg(unix)]
+fn is_executable_file(p: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(p)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(p: &Path) -> bool {
+    std::fs::metadata(p).map(|m| m.is_file()).unwrap_or(false)
+}
+
 /// Launch `argv` with the shims in front of it.
 pub fn run(argv: &[String], termaxa_home: &Path) -> Result<i32> {
     if argv.is_empty() {
@@ -230,6 +294,62 @@ mod tests {
     /// This is the grades table's "escape via tools that execute without
     /// spawning through the wrapper", made concrete. A test that only proved
     /// the happy path would let someone read the wrapper as interception.
+    /// #65: the runner's own `sh` must be the real one. The shim directory
+    /// leaves `PATH`, a bare name resolves through what remains, a path
+    /// is left alone, and a name that resolves nowhere stays bare.
+    #[cfg(unix)]
+    #[test]
+    fn an_approved_command_runs_outside_the_shims() {
+        use std::os::unix::fs::PermissionsExt;
+        let t = TempTree::new("wrap-outside");
+        let dir = install_shims(t.path(), Path::new("/usr/bin/termaxa")).unwrap();
+        let real = t.dir("realbin");
+        std::fs::write(real.join("sh"), "#!/bin/sh\nexit 0\n").unwrap();
+        let mut p = std::fs::metadata(real.join("sh")).unwrap().permissions();
+        p.set_mode(0o755);
+        std::fs::set_permissions(real.join("sh"), p).unwrap();
+
+        let path = format!("{}:{}:/nonexistent", dir.display(), real.display());
+        let (program, stripped) = outside_shims("sh", Some(std::ffi::OsStr::new(&path)), t.path());
+        assert_eq!(
+            program,
+            real.join("sh").into_os_string(),
+            "the bare name resolves past the shim to the real shell"
+        );
+        let stripped = stripped.to_string_lossy().into_owned();
+        assert!(
+            !stripped.contains(&dir.display().to_string()),
+            "the shim directory is out of the child's PATH: {stripped}"
+        );
+        assert!(
+            stripped.starts_with(&real.display().to_string()),
+            "{stripped}"
+        );
+
+        // A trailing slash is the same directory.
+        let path = format!("{}/:{}", dir.display(), real.display());
+        let (_, stripped) = outside_shims("sh", Some(std::ffi::OsStr::new(&path)), t.path());
+        assert!(
+            !stripped.to_string_lossy().contains("shims"),
+            "{stripped:?}"
+        );
+
+        // A program given as a path is left alone; a name that resolves
+        // nowhere stays a name.
+        let (program, _) = outside_shims("/bin/sh", Some(std::ffi::OsStr::new(&path)), t.path());
+        assert_eq!(program, std::ffi::OsString::from("/bin/sh"));
+        let (program, _) = outside_shims(
+            "no-such-program-tmx",
+            Some(std::ffi::OsStr::new(&path)),
+            t.path(),
+        );
+        assert_eq!(program, std::ffi::OsString::from("no-such-program-tmx"));
+
+        // No shims on PATH at all: nothing changes but the resolution.
+        let (_, same) = outside_shims("sh", Some(std::ffi::OsStr::new("/usr/bin:/bin")), t.path());
+        assert_eq!(same, std::ffi::OsString::from("/usr/bin:/bin"));
+    }
+
     #[cfg(unix)]
     #[test]
     fn an_absolute_path_shell_is_outside_what_a_path_shim_can_reach() {

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -64,6 +64,49 @@ fn run_termaxa(
 }
 
 /// A scratch tree, cleared first so a crashed earlier run cannot leak in.
+/// Like `termaxa`, but gives up after `secs` and kills the child: the
+/// wrapper used to recurse without end (#65), and a hung test is worse
+/// than a failed one.
+fn termaxa_within(home: &Path, cwd: &Path, args: &[&str], stdin: &str, secs: u64) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_termaxa"));
+    cmd.args(args)
+        .current_dir(cwd)
+        .env("TERMAXA_HOME", home)
+        .env("NO_COLOR", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("the binary must be runnable");
+    {
+        let mut pipe = child.stdin.take().expect("stdin must be piped");
+        let _ = pipe.write_all(stdin.as_bytes());
+    }
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+    let mut timed_out = false;
+    while child
+        .try_wait()
+        .expect("the child must be pollable")
+        .is_none()
+    {
+        if std::time::Instant::now() > deadline {
+            let _ = child.kill();
+            timed_out = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let out = child.wait_with_output().expect("the child must exit");
+    assert!(
+        !timed_out,
+        "termaxa {args:?} did not finish within {secs}s — the wrapper is recursing again (#65)"
+    );
+    Output {
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        code: out.status.code().unwrap_or(-1),
+    }
+}
+
 fn scratch(tag: &str) -> PathBuf {
     let base = std::env::temp_dir().join(format!("termaxa-cli-{tag}-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&base);
@@ -356,5 +399,77 @@ fn rollback_restores_nothing_unless_it_is_confirmed() {
         out.stdout.contains("✓ 1 path(s) restored"),
         "the count is the report of what happened: {:?}",
         out.stdout
+    );
+}
+
+/// #65. Through the wrapper, an allowed command was never executed: the
+/// runner's `sh` resolved to the shim again and the wrapper recursed until
+/// killed. The residue test pinned a deny and a bypass; nothing pinned an
+/// execution. The fixture allows `sh*` and `exit*`, so `sh -c "exit 3"` is
+/// allowed at both levels, and its exit code must come back through the
+/// wrapper and the shim.
+#[test]
+fn wrap_executes_what_it_allows() {
+    let tmp = scratch("wrap-allow");
+    let (home, proj) = (tmp.join("home"), project(&tmp));
+    let out = termaxa_within(&home, &proj, &["wrap", "--", "sh", "-c", "exit 3"], "", 30);
+    assert_eq!(
+        out.code, 3,
+        "stdout: {}\nstderr: {}",
+        out.stdout, out.stderr
+    );
+    assert!(
+        !out.stderr.contains("not interactive"),
+        "the gate must not ask twice: {}",
+        out.stderr
+    );
+    // A shell nested inside the approved command is the real one, not the
+    // shim: one gate, and the inner exit code comes back.
+    let out = termaxa_within(
+        &home,
+        &proj,
+        &["wrap", "--", "sh", "-c", "sh -c 'exit 5'"],
+        "",
+        30,
+    );
+    assert_eq!(
+        out.code, 5,
+        "stdout: {}\nstderr: {}",
+        out.stdout, out.stderr
+    );
+}
+
+/// #65, the asked half: through the wrapper an approved delete asked twice
+/// and then refused for lack of stdin, leaving the file in place and no
+/// backup. Now it asks once, insures, and executes.
+#[test]
+fn wrap_executes_what_it_approves_after_insuring_it() {
+    let tmp = scratch("wrap-approve");
+    let (home, proj) = (tmp.join("home"), project(&tmp));
+    std::fs::write(proj.join("doomed.txt"), "precious").unwrap();
+
+    let out = termaxa_within(
+        &home,
+        &proj,
+        &["wrap", "--", "sh", "-c", "rm -rf ./doomed.txt"],
+        "y\n",
+        30,
+    );
+    assert!(
+        !proj.join("doomed.txt").exists(),
+        "the approved delete must have run\nstdout: {}\nstderr: {}",
+        out.stdout,
+        out.stderr
+    );
+    let asks = out.stdout.matches("Proceed?").count() + out.stderr.matches("Proceed?").count();
+    assert_eq!(
+        asks, 1,
+        "asked exactly once\nstdout: {}\nstderr: {}",
+        out.stdout, out.stderr
+    );
+    let backups = termaxa(&home, &proj, &["backups"], "").stdout;
+    assert!(
+        backups.contains("rm -rf ./doomed.txt"),
+        "the backup was taken before the delete ran: {backups}"
     );
 }


### PR DESCRIPTION
Closes #65

`termaxa wrap` puts a directory of shims first on PATH; the `sh` shim forwards `sh -c "<cmd>"` to `termaxa run -- sh -c "<cmd>"`. The runner then executed `sh` by name, through that same PATH, and got the shim again. Measured at `bee1fdc` on 2026-09-03 with the starter policy: `timeout 20 termaxa wrap -- sh -c 'echo hi'` printed one decision line and hung until killed; `hi` never appeared. An asked command asked twice, then "this needs a human and stdin is not interactive - refused", file untouched, no backup. `wrap -- ls src` - no shell - worked. Nothing that went through a shim had ever reached `/bin/sh`.

The residue test pinned a deny and a bypass, and its comment recorded a manual measurement of the same two. Neither executes. No test, and no measurement, had run an allowed command through the wrapper and looked for its output. The walls held; the door led nowhere.

`wrap::outside_shims`: the shim directory is taken out of PATH, and a bare program name is resolved through what remains, so the runner's own `sh` is the real one. A program given with a path is left alone; a name that resolves nowhere stays a name for the OS to report as before. The runner's `execute` uses it; away from the wrapper the shim directory is not on PATH and nothing changes but the resolution. The command's own children run with the same stripped PATH - what was approved was the command and what it spawns - so a shell nested inside an approved command is the real one: `wrap -- sh -c 'sh -c "exit 5"'` asks once and exits 5.

After, same tree, starter policy: `wrap -- sh -c 'echo hi'` approved prints `hi` and exits 0; the approved overwrite takes its backup and then empties the file; `wrap -- sh -c 'exit 3'` exits 3; a deny still denies.

Tests: `outside_shims` on a real shim directory and a real executable (bare name resolves past the shim, trailing slash is the same directory, a path is untouched, an unresolvable name stays bare, a PATH without shims is returned as is); and two through the binary, with a deadline so a regression fails instead of hanging CI - an allowed `sh -c "exit 3"` comes back with exit 3 and a nested shell with exit 5, and an approved `rm -rf ./doomed.txt` asks once, deletes, and leaves a backup that `termaxa backups` lists.

Two things this does not change, both measured while fixing it. Under the starter policy every wrapped command is asked, because no rule names `sh`: the wrapper segment falls to the default and the most severe segment decides. That was true before #62 and is a policy question - a rule for the wrapper, or a wrapper that is transparent when no rule names it - recorded for a decision. And the shim forwards only `-c` as the first argument; Codex's `bash -lc` passes through it untouched. Also recorded, not fixed here.