### PR TITLE
policy: a shell wrapper no rule names is transparent; the string inside decides

### DIFF
--- a/src/policy.rs
+++ b/src/policy.rs
@@ -334,6 +334,15 @@ impl Policy {
         let mut worst: Option<(usize, Decision)> = None;
         for (i, seg) in segments.iter().enumerate() {
             let d = self.evaluate(seg, ctx);
+            // A shell wrapper whose string was read is transparent unless a
+            // rule names it. Under a policy with no rule for `sh`, the
+            // wrapper segment fell to the default and outranked the allow
+            // its own string had earned - every command through the `wrap`
+            // shim was asked. The string decides; `deny sh *` still counts,
+            // because that rule names the wrapper. Decision of 2026-09-03.
+            if seg.wraps && d.matched_rule.is_none() {
+                continue;
+            }
             let replace = match &worst {
                 None => true,
                 // higher severity wins; on ties, an explicitly-matched rule
@@ -349,7 +358,12 @@ impl Policy {
                 worst = Some((i, d));
             }
         }
-        let (i, d) = worst.expect("segments nonempty");
+        let Some((i, d)) = worst else {
+            // Every segment was an unnamed wrapper - only reachable if the
+            // depth limit cut the reading off with nothing inside. Judge the
+            // whole line as typed.
+            return self.evaluate(command, ctx);
+        };
         Decision {
             action: d.action,
             // The compound's verdict is the worst segment's verdict, so it
@@ -1047,6 +1061,45 @@ rules:
         let d = policy.evaluate_command(r#"sh -c "ls -la""#, &here());
         assert_eq!(d.action, Action::Ask, "{}", d.reason);
         assert!(d.reason.contains("(inside sh -c)"), "{}", d.reason);
+    }
+
+    /// A wrapper no rule names is transparent: `sh -c "echo hi"` is allowed
+    /// by the starter policy's `echo *`, where the `sh` segment used to fall
+    /// to the default and outrank it. A rule that names the wrapper still
+    /// counts, and a script file - not read, so not a wrapper - still falls
+    /// to the default.
+    #[test]
+    fn an_unnamed_wrapper_is_transparent_and_a_named_one_is_not() {
+        let starter = Policy::builtin().unwrap();
+        let d = starter.evaluate_command(r#"sh -c "echo hi""#, &here());
+        assert_eq!(d.action, Action::Allow, "{}", d.reason);
+        assert!(d.reason.contains("(inside sh -c)"), "{}", d.reason);
+        assert_eq!(
+            starter
+                .evaluate_command(r#"sh -c "no-such-command-tmx""#, &here())
+                .action,
+            Action::Ask,
+            "an unmatched command inside still falls to the default"
+        );
+        assert_eq!(
+            starter.evaluate_command("sh script.sh", &here()).action,
+            Action::Ask,
+            "a script file is not read, so it is not transparent"
+        );
+        let names_the_shell: Policy = serde_yaml::from_str(
+            r#"
+default: ask
+rules:
+  - match: "sh *"
+    action: deny
+  - match: "echo *"
+    action: allow
+"#,
+        )
+        .unwrap();
+        let d = names_the_shell.evaluate_command(r#"sh -c "echo hi""#, &here());
+        assert_eq!(d.action, Action::Deny, "{}", d.reason);
+        assert!(d.reason.contains("segment 1/2"), "{}", d.reason);
     }
 
     #[test]

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -341,6 +341,7 @@ fn expand_into(out: &mut Vec<Segment>, segments: Vec<Segment>, via: Option<&str>
         } else {
             None
         };
+        seg.wraps = inner.is_some();
         out.push(seg);
         if let Some((shell, script)) = inner {
             let label = format!("{shell} -c");
@@ -404,6 +405,12 @@ pub struct Segment {
     /// `split_segments_deep` found it inside a `-c` string. `None` for a
     /// segment typed at the top level (#62).
     pub via: Option<String>,
+    /// True when this segment is a shell wrapper whose `-c` string was read
+    /// and follows it as segments of its own. The policy treats such a
+    /// segment as transparent unless a rule names it: the string inside
+    /// decides, not the policy default applied to `sh` (#65, decision of
+    /// 2026-09-03).
+    pub wraps: bool,
 }
 
 impl Segment {
@@ -501,6 +508,7 @@ fn flush(
             command: command.trim().to_string(),
             redirects: std::mem::take(redirects),
             via: None,
+            wraps: false,
         });
     } else {
         // Nothing but whitespace between separators: whatever the redirect


### PR DESCRIPTION
Follows #65 — the policy decision it recorded.

Under the starter policy every command through the `wrap` shim was asked. The shim forwards `sh -c "echo hi"`; #62 reads that as two segments; the inner `echo hi` matches `echo *` and is allowed, but the wrapper segment `sh -c "echo hi"` matches nothing, falls to the default `ask`, and the most severe segment wins. Measured 2026-09-03: `wrap -- sh -c 'echo hi'` printed `segment 1/2 'sh -c "echo hi"' - no rule matched; policy default is ask`. True before #62 as well, when the wrapper text was the only segment; #65 made it visible by making the wrapper execute at all.

Decision of 2026-09-03: a wrapper whose `-c` string was read contributes no verdict unless a rule names it. `Segment.wraps` marks such a segment; `evaluate_command` skips it when its verdict came from the default. A rule that names the wrapper - `deny sh *`, or the cli_surface fixture's `allow sh*` - still counts, because that is the policy speaking about the wrapper. A script file (`sh script.sh`) is not read, so it is not a wrapper and still falls to the default. If every segment is an unnamed wrapper - only possible when the depth limit cut the reading off with nothing inside - the line is judged as typed. The alternative, a starter rule `allow sh *`, was rejected because it also allows a script file the gate cannot read.

After: `wrap -- sh -c 'echo hi'` with no stdin prints `decision: allow / segment 2/2 'echo hi' (inside sh -c) - matched rule 'echo *'`, then `hi`. An unmatched command inside still asks; `sh script.sh` still asks.

Tests: the starter policy allows `sh -c "echo hi"` with the inner segment named, asks about an unmatched command inside, asks about a script file; a policy that denies `sh *` denies the wrapped echo and names the wrapper.