### PR TITLE
docs: the README's line counts come from the tree at v0.18.0, and the release ritual recounts them

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ See [SECURITY.md](SECURITY.md) for the full threat model.
 
 ## Contributing
 
-Issues and PRs welcome. `cargo test` must pass; CI runs on Linux, macOS, and Windows. The codebase is dependency-light Rust: ~10,250 lines of production code in `src/`, plus ~11,000 lines of tests (unit tests live beside the code they test; `tests/` holds the integration ones). More test than product, on purpose — `src/policy.rs` and `src/preview.rs` are the best places to start reading, and the test module at the bottom of each file explains what the code is defending against.
+Issues and PRs welcome. `cargo test` must pass; CI runs on Linux, macOS, and Windows. The codebase is dependency-light Rust: ~11,300 lines of production code in `src/`, plus ~13,200 lines of tests (unit tests live beside the code they test; `tests/` holds the integration ones). More test than product, on purpose — `src/policy.rs` and `src/preview.rs` are the best places to start reading, and the test module at the bottom of each file explains what the code is defending against.
 
 If you can make an agent get past the gate in a way that isn't already documented above, that's the most useful contribution you can make: [open an issue](https://github.com/termaxa/termaxa/issues) or email security@termaxa.com.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,11 @@
 2. Cut ONE release-prep commit containing:
    - CHANGELOG.md entry for the new version
    - Cargo.toml version bump (Cargo.lock updates on next build)
+   - README's line counts recounted from the tree (Contributing section):
+     production = every `src/*.rs` line before its `#[cfg(test)]` module;
+     tests = those modules plus `tests/`. crates.io renders the README of
+     the published crate permanently, so a stale number ships forever.
+     (v0.18.0 shipped with counts from Aug 18.)
    - commit message = the release headline, e.g.
      "v0.12.0: plugin registry — termaxa add <tool>"
    This is the commit that gets tagged, so its message becomes the


### PR DESCRIPTION

The Contributing section said ~10,250 lines of production code and ~11,000 of tests - figures set on Aug 18 (891c997), before v0.17.0. Measured at 1457dc1: 11,333 lines in `src/` before each file's `#[cfg(test)]` module, and 13,241 in those modules plus `tests/` (10,640 and 12,146 non-blank). The README now says ~11,300 and ~13,200.

RELEASING.md step 2 gains the recount, with the method, because crates.io renders the published crate's README permanently: a stale number ships forever. Caught before the v0.18.0 tag was pushed; the tag goes on this commit's merge instead of the release-prep commit, which is why the tag-triggered run will carry this title rather than the headline.