### PR TITLE
copilot: the shell is called powershell, a deny is exit-0 JSON, and the unrecognised refusal speaks the sender's shape

### DIFF
--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -82,6 +82,16 @@ pub fn run(dir: &Path) -> Result<i32> {
     let claude_settings = dir.join(".claude").join("settings.json");
     let cursor_hooks = dir.join(".cursor").join("hooks.json");
     let codex_hooks = dir.join(".codex").join("hooks.json");
+    // Codex also reads a user-level hooks file, and that is the one the
+    // live sessions of Sep 5-6, 2026 ran through; a Codex wired there is
+    // wired, whatever the project directory holds.
+    let codex_hooks_global = std::env::var_os("USERPROFILE")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(|h| {
+            std::path::PathBuf::from(h)
+                .join(".codex")
+                .join("hooks.json")
+        });
     let copilot_hooks = dir.join(".github").join("hooks").join("hooks.json");
 
     let mut any_agent = false;
@@ -116,11 +126,16 @@ pub fn run(dir: &Path) -> Result<i32> {
     // Codex / Copilot: only mention when detected, and label them honestly.
     if crate::init::which("codex") {
         any_agent = true;
-        let wired = hook_live(&codex_hooks, dir);
+        let mut wired = hook_live(&codex_hooks, dir);
+        if wired.0 == HookState::Absent {
+            if let Some(g) = &codex_hooks_global {
+                wired = hook_live(g, dir);
+            }
+        }
         report_agent("Codex CLI", wired, "termaxa init --codex", &mut problems);
         println!(
             "    {}",
-            dim("dialect built, not yet verified end-to-end (issue #10)")
+            dim("live-tested Sep 2026 (v0.18); an ask is a refusal under Codex")
         );
     }
     if crate::init::which("copilot") || crate::init::which("gh") {
@@ -135,7 +150,7 @@ pub fn run(dir: &Path) -> Result<i32> {
             );
             println!(
                 "    {}",
-                dim("dialect built, not yet verified end-to-end (issue #10)")
+                dim("dialect read from a live capture (Sep 2026); deny not yet seen in its UI (issue #10)")
             );
         }
     }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -163,8 +163,18 @@ pub fn parse_input(raw: &str) -> Option<ParsedHook> {
     }
 
     // ---- Copilot CLI: toolName + toolArgs (a JSON *string* holding the args) ----
+    //
+    // `shell`, `bash`, `run_in_terminal` are the documented names. The one
+    // Copilot CLI actually sent on Windows (captured Sep 9, 2026) was
+    // `powershell`, with `toolArgs` as an inline object carrying `command`,
+    // `description`, `mode` and `initial_wait`. `pwsh` and `cmd` are the
+    // obvious siblings and are unmeasured; listing them can only widen
+    // what is gated.
     if let Some(tool) = s("toolName") {
-        if tool == "shell" || tool == "bash" || tool == "run_in_terminal" {
+        if matches!(
+            tool.as_str(),
+            "shell" | "bash" | "run_in_terminal" | "powershell" | "pwsh" | "cmd"
+        ) {
             let args_val = match v.get("toolArgs") {
                 Some(serde_json::Value::String(st)) => {
                     serde_json::from_str::<serde_json::Value>(st).unwrap_or(serde_json::Value::Null)
@@ -632,9 +642,25 @@ fn refuse_unrecognised(raw: &str) -> Option<Outcome> {
             hash: None,
         });
     }
+    // A payload with `toolName` is Copilot-shaped (Claude Code, Codex and
+    // Cursor all say `tool_name`), and Copilot reads a deny only as exit-0
+    // JSON in its own shape - anything else is "hook errored", which
+    // `failClosed` still turns into a block but with the reason lost. That
+    // is exactly what the first live Copilot session showed, Sep 9, 2026:
+    // this refusal, in Claude Code's shape with exit 2, reached the user as
+    // "(hook errored)". Everyone else keeps the belt-and-suspenders exit 2.
+    let copilot_shaped = json.get("toolName").is_some();
     Some(Outcome {
-        rendered: Some(render_response(Dialect::ClaudeCode, "deny", &reason)),
-        exit_code: 2,
+        rendered: Some(render_response(
+            if copilot_shaped {
+                Dialect::Copilot
+            } else {
+                Dialect::ClaudeCode
+            },
+            "deny",
+            &reason,
+        )),
+        exit_code: if copilot_shaped { 0 } else { 2 },
         audit_seq: None,
     })
 }
@@ -1110,14 +1136,20 @@ pub fn decide(raw_payload: &str) -> Result<Outcome> {
 
     Ok(Outcome {
         rendered,
-        // Exit 2 is the belt under the JSON for Cursor and Copilot. Not for
-        // Codex: measured Sep 5, 2026, a Termaxa deny reached codex-cli
+        // Exit 2 is the belt under the JSON for Claude Code and Cursor. Not
+        // for Codex: measured Sep 5, 2026, a Termaxa deny reached codex-cli
         // 0.153.4 on Windows as "hook exited with code 1" - the wrapper that
         // runs the hook flattens a non-zero exit to 1, and Codex treats any
-        // exit other than 0 or 2 as a failed hook, which fails open. The JSON
-        // on stdout is Codex's documented channel; the exit code stays 0 so
-        // the JSON is read.
-        exit_code: if decision.action == Action::Deny && input.dialect != Dialect::Codex {
+        // exit other than 0 or 2 as a failed hook, which fails open. And not
+        // for Copilot: measured Sep 9, 2026, a non-zero exit reached Copilot
+        // CLI as `Denied by preToolUse hook ... (hook errored)` - the block
+        // landed only because `failClosed: true` turns an error into a
+        // denial, and the reason never reached the screen. For both, the
+        // JSON on stdout is the documented channel and the exit code stays 0
+        // so the JSON is read.
+        exit_code: if decision.action == Action::Deny
+            && !matches!(input.dialect, Dialect::Codex | Dialect::Copilot)
+        {
             2
         } else {
             0
@@ -1333,6 +1365,27 @@ mod tests {
     fn shared_shape_without_tag_defaults_to_claude() {
         let raw = r#"{"tool_name":"Bash","tool_input":{"command":"ls"}}"#;
         assert_eq!(parse_input(raw).unwrap().dialect, Dialect::ClaudeCode);
+    }
+
+    /// The payload Copilot CLI actually sent on Windows, captured live on
+    /// Sep 9, 2026 with TERMAXA_HOOK_DEBUG. The tool is `powershell`, not
+    /// `shell`; `toolArgs` is an inline object; `sessionId` and `timestamp`
+    /// are camelCase and milliseconds; there is no hookEventName at all.
+    #[test]
+    fn copilot_on_windows_calls_its_shell_powershell() {
+        let raw = r#"{"sessionId":"85a696df-84c3-4b99-95cd-4e076f2529d9","timestamp":1788992290306,"cwd":"C:\\Users\\User\\code\\capture-test","toolName":"powershell","toolArgs":{"command":"echo hi","description":"Print the requested greeting","mode":"sync","initial_wait":10}}"#;
+        let p = parse_input(raw).expect("the live Copilot payload must parse");
+        assert_eq!(p.dialect, Dialect::Copilot);
+        assert_eq!(p.command, "echo hi");
+        assert_eq!(
+            p.session.as_deref(),
+            Some("85a696df-84c3-4b99-95cd-4e076f2529d9")
+        );
+        assert!(!p.is_post);
+        for tool in ["pwsh", "cmd"] {
+            let raw = format!(r#"{{"toolName":"{tool}","toolArgs":{{"command":"rm -rf /"}}}}"#);
+            assert!(parse_input(&raw).is_some(), "{tool} is a shell tool too");
+        }
     }
 
     #[test]

--- a/tests/codex_dialect.rs
+++ b/tests/codex_dialect.rs
@@ -102,6 +102,25 @@ fn codex_payload(cwd: &Path, command: &str) -> String {
 }
 
 /// The same command in Claude Code's shape: no `turn_id`, no `model`.
+/// The payload Copilot CLI sent on Windows, captured live on Sep 9, 2026:
+/// the tool is `powershell`, `toolArgs` is an inline object, no
+/// hookEventName.
+fn copilot_payload(cwd: &Path, command: &str) -> String {
+    serde_json::json!({
+        "sessionId": "85a696df-84c3-4b99-95cd-4e076f2529d9",
+        "timestamp": 1788992290306u64,
+        "cwd": cwd.display().to_string(),
+        "toolName": "powershell",
+        "toolArgs": {
+            "command": command,
+            "description": "captured shape",
+            "mode": "sync",
+            "initial_wait": 10
+        }
+    })
+    .to_string()
+}
+
 fn claude_payload(cwd: &Path, command: &str) -> String {
     serde_json::json!({
         "session_id": "s-claude",
@@ -205,6 +224,55 @@ fn a_deny_exits_zero_for_codex_and_two_for_claude_code() {
     assert!(
         out.stdout.contains("\"permissionDecision\":\"deny\""),
         "{}",
+        out.stdout
+    );
+}
+
+/// Copilot CLI read a non-zero exit as `(hook errored)` and blocked only
+/// because `failClosed: true` turns an error into a denial - the reason
+/// never reached the screen. A Copilot deny now exits 0 with the verdict in
+/// Copilot's own JSON shape (top-level `permissionDecision`, no
+/// `hookSpecificOutput` wrapper).
+#[test]
+fn a_copilot_deny_exits_zero_in_copilots_own_shape() {
+    let tmp = scratch("copilot-deny");
+    let (home, proj) = (tmp.join("home"), project(&tmp));
+    std::fs::create_dir_all(proj.join("scratch")).unwrap();
+    std::fs::write(proj.join("scratch").join("a.txt"), "x").unwrap();
+    let out = termaxa(
+        &home,
+        &proj,
+        &["hook"],
+        &copilot_payload(&proj, "rm -rf ./scratch"),
+    );
+    assert_eq!(
+        out.code, 0,
+        "Copilot reads a non-zero exit as a hook error, not a deny: {}",
+        out.stderr
+    );
+    assert!(
+        out.stdout.contains("\"permissionDecision\":\"deny\"")
+            && !out.stdout.contains("hookSpecificOutput"),
+        "{}",
+        out.stdout
+    );
+    assert!(proj.join("scratch").join("a.txt").exists());
+}
+
+/// The first live Copilot session was refused on `echo hi`: the tool was
+/// named `powershell`, the parser did not know it, and the policy's
+/// `unrecognised: deny` fired - in Claude Code's JSON shape with exit 2,
+/// which Copilot showed as `(hook errored)`. Now the payload parses and the
+/// allow is a Copilot-shaped allow.
+#[test]
+fn copilots_powershell_tool_is_read_and_an_allow_is_answered() {
+    let tmp = scratch("copilot-allow");
+    let (home, proj) = (tmp.join("home"), project(&tmp));
+    let out = termaxa(&home, &proj, &["hook"], &copilot_payload(&proj, "echo hi"));
+    assert_eq!(out.code, 0, "{}", out.stderr);
+    assert!(
+        out.stdout.contains("\"permissionDecision\":\"allow\""),
+        "an explicit allow for a matched rule: {}",
         out.stdout
     );
 }

--- a/tests/hook_dialects.rs
+++ b/tests/hook_dialects.rs
@@ -156,7 +156,19 @@ fn copilot_is_recognised_by_every_shell_tool_it_names() {
     let tmp = scratch("copilot");
     let (home, proj) = (tmp.join("home"), project(&tmp, DENIES));
 
-    for tool in ["shell", "bash", "run_in_terminal"] {
+    // `powershell` is the name Copilot CLI actually sent on Windows (captured
+    // Sep 9, 2026); the other three are the documented ones. A Copilot deny
+    // is exit 0 with the verdict in the JSON: Copilot reads a non-zero exit
+    // as "(hook errored)", which failClosed still blocks but with the reason
+    // lost - so the gate is asserted through stdout here, not the exit code.
+    for tool in [
+        "shell",
+        "bash",
+        "run_in_terminal",
+        "powershell",
+        "pwsh",
+        "cmd",
+    ] {
         let out = hook(
             &home,
             &proj,
@@ -168,7 +180,16 @@ fn copilot_is_recognised_by_every_shell_tool_it_names() {
             }),
             &[],
         );
-        assert_eq!(out.code, 2, "{tool} must be gated: {:?}", out.stdout);
+        assert_eq!(
+            out.code, 0,
+            "{tool}: Copilot must not see a non-zero exit: {:?}",
+            out.stdout
+        );
+        assert!(
+            out.stdout.contains("\"permissionDecision\":\"deny\""),
+            "{tool} must be gated: {:?}",
+            out.stdout
+        );
     }
 
     // A tool that does not run a shell is not a shell, even carrying a command.


### PR DESCRIPTION

Refs #10

First live Copilot CLI session, Sep 9, 2026, Windows 11, Copilot Free, hook registered by `termaxa init --copilot` (`.github/hooks/hooks.json`, preToolUse, failClosed: true), payload captured with TERMAXA_HOOK_DEBUG:

  {"sessionId":"85a696df-...","timestamp":1788992290306,
   "cwd":"C:\\Users\\User\\code\\capture-test","toolName":"powershell",
   "toolArgs":{"command":"echo hi","description":"Print the requested
   greeting","mode":"sync","initial_wait":10}}

Both prompts - `echo hi` and `rm -rf ./scratch` - came back as `Denied by preToolUse hook from ".github_hooks_hooks.json" (hook errored)`. The block held only because failClosed turns an error into a denial; the gate had not decided anything.

Two findings, one fix each:

1. The tool is named `powershell`, not `shell`. The dialect accepted the three documented names (`shell`, `bash`, `run_in_terminal`); the real one on Windows was outside the list, so the payload was "not recognised", the policy's `unrecognised: deny` fired, and `echo hi` was refused. Now `powershell` (measured), `pwsh` and `cmd` (unmeasured siblings - listing them can only widen what is gated) are Copilot shell tools.

2. A non-zero exit is a hook error to Copilot, not a deny. The refusal went out in Claude Code's JSON shape with exit 2, and Copilot rendered it as "(hook errored)" with the reason lost. Same contract as Codex (#74): a Copilot deny now exits 0 and the JSON carries the verdict, in Copilot's own top-level shape. The unrecognised-payload refusal does the same when the payload has a `toolName` (Copilot is the only dialect that spells it that way), so a future shape drift reaches the user with the reason instead of as an error. Claude Code and Cursor keep exit 2.

Also in this commit, from the same session:

- `doctor` said "dialect built, not yet verified end-to-end (issue #10)" under Codex, which has been false since v0.18.0. It now says Codex is live-tested and that an ask is a refusal there; under Copilot it says the dialect was read from a live capture and the deny has not yet been seen in Copilot's UI - which is exactly true until the next run.
- `doctor` probed only the project-level `.codex/hooks.json`; the hooks file the live Codex sessions actually ran through is the user-level one (`~/.codex/hooks.json`). It now checks both and reports the first it finds.

Observed and not claimed: only one payload arrived per command. The `.claude/settings.json` in the same directory did not produce a second invocation in this session, so the note that Copilot CLI runs `.claude/settings.json` hooks fail-closed came from documentation and has not been observed here. Left as stated in known-limitations with that caveat.

Tests: the captured payload parses as Copilot with the command and session intact, and `pwsh`/`cmd` parse; in the Windows-capable integration binary, a Copilot deny exits 0 in Copilot's shape and a Copilot allow is answered; the older six-name Copilot test asserts the gate through stdout rather than the exit code, with the reason in the comment.

Refs #10.