### PR TITLE
wrap: the first real agent under the shim - the shim sees the shell, and four things it found are fixed

### DIFF
--- a/examples/policy.yaml
+++ b/examples/policy.yaml
@@ -141,9 +141,35 @@ rules:
     action: allow
   - match: "cp .termaxa*"
     action: allow
-  - match: "*.termaxa*"
+  # A belt over the path rule in protect.rs for commands whose grammar the
+  # gate does not model (`sed -i`, an editor, `python -c`). Named by what
+  # they hold, because a plain `*.termaxa*` also matched the PATH line
+  # `wrap` itself injects into every shell it starts -
+  # `export PATH=~/.termaxa/shims:...` - and refused Claude Code's own
+  # startup snapshot (Sep 10, 2026). The matcher knows only `*`, so the
+  # separator is spanned by it; `shims/` with the slash is a file inside
+  # the shim directory, while `shims:` in a PATH is not.
+  - match: "*.termaxa*policy*"
     action: deny
     reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  - match: "*.termaxa*projects*"
+    action: deny
+    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  - match: "*.termaxa*backups*"
+    action: deny
+    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  - match: "*.termaxa*logs*"
+    action: deny
+    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  - match: "*.termaxa*shims/*"
+    action: deny
+    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  # Pointing git's hook directory anywhere runs whatever is there on the
+  # next commit. It used to be caught only when the target was inside
+  # `.termaxa`; the hazard is the redirection itself.
+  - match: "*git config*hooksPath*"
+    action: deny
+    reason: "Redirecting git hooks runs arbitrary code on the next commit. Do it yourself."
 
   # ---- destructive: hard stops ----
   - match: "git push*--force*"
@@ -362,6 +388,12 @@ rules:
   - match: "kubectl describe*"
     action: allow
   - match: "docker ps*"
+    action: allow
+  # A variable assignment runs nothing. Claude Code's startup snapshot sets
+  # PATH inside the shell `wrap` hands it (Sep 10, 2026); asking about that
+  # line unattended is a refusal of the agent's own setup. A substitution in
+  # the value (`export X=$(...)`) is still escalated by the context check.
+  - match: "export *"
     action: allow
 
   # ---- PowerShell read-only cmdlets ----

--- a/src/init.rs
+++ b/src/init.rs
@@ -147,9 +147,35 @@ rules:
     action: allow
   - match: "cp .termaxa*"
     action: allow
-  - match: "*.termaxa*"
+  # A belt over the path rule in protect.rs for commands whose grammar the
+  # gate does not model (`sed -i`, an editor, `python -c`). Named by what
+  # they hold, because a plain `*.termaxa*` also matched the PATH line
+  # `wrap` itself injects into every shell it starts -
+  # `export PATH=~/.termaxa/shims:...` - and refused Claude Code's own
+  # startup snapshot (Sep 10, 2026). The matcher knows only `*`, so the
+  # separator is spanned by it; `shims/` with the slash is a file inside
+  # the shim directory, while `shims:` in a PATH is not.
+  - match: "*.termaxa*policy*"
     action: deny
     reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  - match: "*.termaxa*projects*"
+    action: deny
+    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  - match: "*.termaxa*backups*"
+    action: deny
+    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  - match: "*.termaxa*logs*"
+    action: deny
+    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  - match: "*.termaxa*shims/*"
+    action: deny
+    reason: "Termaxa's own config is off limits — that is the gate. Edit it yourself."
+  # Pointing git's hook directory anywhere runs whatever is there on the
+  # next commit. It used to be caught only when the target was inside
+  # `.termaxa`; the hazard is the redirection itself.
+  - match: "*git config*hooksPath*"
+    action: deny
+    reason: "Redirecting git hooks runs arbitrary code on the next commit. Do it yourself."
 
   # ---- destructive: hard stops ----
   - match: "git push*--force*"
@@ -368,6 +394,12 @@ rules:
   - match: "kubectl describe*"
     action: allow
   - match: "docker ps*"
+    action: allow
+  # A variable assignment runs nothing. Claude Code's startup snapshot sets
+  # PATH inside the shell `wrap` hands it (Sep 10, 2026); asking about that
+  # line unattended is a refusal of the agent's own setup. A substitution in
+  # the value (`export X=$(...)`) is still escalated by the context check.
+  - match: "export *"
     action: allow
 
   # ---- PowerShell read-only cmdlets ----

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1374,7 +1374,7 @@ rules:
         // policy the agent had written.
         let d = p.evaluate_command("echo 'default: allow' > .termaxa/policy.yaml", &here());
         assert_eq!(d.action, Action::Deny);
-        assert_eq!(d.matched_rule.as_deref(), Some("*.termaxa*"));
+        assert_eq!(d.matched_rule.as_deref(), Some("*.termaxa*policy*"));
 
         for cmd in [
             "cat /tmp/mine.yaml > .termaxa/policy.yaml",
@@ -1400,7 +1400,7 @@ rules:
         let idx_self = p
             .rules
             .iter()
-            .position(|r| r.label() == "*.termaxa*")
+            .position(|r| r.label() == "*.termaxa*policy*")
             .expect("self-defence rule must exist");
         let idx_echo = p
             .rules
@@ -1495,7 +1495,7 @@ rules:
             "the hook-config denies must outrank the review exceptions"
         );
         assert!(
-            idx("cat .termaxa*") < idx("*.termaxa*"),
+            idx("cat .termaxa*") < idx("*.termaxa*policy*"),
             "the review exceptions must outrank the deny they except"
         );
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -92,38 +92,54 @@ pub fn run(paths: &crate::paths::Paths, argv: &[String]) -> Result<i32> {
                 }
                 println!("└");
             }
-            print!("Proceed? [y/N] ");
-            io::stdout().flush()?;
-            let mut line = String::new();
-            let read = io::stdin().read_line(&mut line)?;
-
-            // NO ONE TO ASK is not the same as a refusal, and saying
-            // "declined" when nobody declined is a lie the user cannot debug.
-            // `read_line` returns Ok(0) on a closed or non-interactive stdin -
-            // which is exactly what a `wrap` shim hands us, since the agent
-            // is not a person at a terminal.
-            //
-            // The verdict is unchanged: an `ask` nobody can answer must not
-            // run. Falling through to the y/N match would already have
-            // declined, by accident of an empty string failing to equal "y";
-            // this makes it a decision with a message that fits (#48 - a gate
-            // whose refusals are unexplainable gets uninstalled).
-            if read == 0 {
+            // An answer has to come from a person at a terminal. Under
+            // `wrap`, the agent's Bash tool hands us a pipe that never
+            // closes: the prompt blocked for 120 s until the harness gave
+            // up (Claude Code, Sep 10, 2026) - and the agent itself noted
+            // it could have piped `y` into the same stdin. Both end here:
+            // no terminal, no ask, refused with the reason. A pipe with a
+            // `y` in it is not a human.
+            if !stdin_is_terminal() {
                 eprintln!(
-                    "termaxa: this needs a human and stdin is not interactive — \
-                     refused rather than run unasked."
+                    "termaxa: this needs a human at a terminal and stdin is not one \
+                     (a pipe, a harness, a script) — refused rather than run unasked. \
+                     Add an allow rule, or run it yourself."
                 );
                 (Some(false), None)
-            } else if matches!(line.trim().to_lowercase().as_str(), "y" | "yes") {
-                if insure(&mut backup_id) {
-                    let code = execute(argv)?;
-                    (Some(true), Some(code))
+            } else {
+                print!("Proceed? [y/N] ");
+                io::stdout().flush()?;
+                let mut line = String::new();
+                let read = io::stdin().read_line(&mut line)?;
+
+                // NO ONE TO ASK is not the same as a refusal, and saying
+                // "declined" when nobody declined is a lie the user cannot debug.
+                // `read_line` returns Ok(0) on a closed or non-interactive stdin -
+                // which is exactly what a `wrap` shim hands us, since the agent
+                // is not a person at a terminal.
+                //
+                // The verdict is unchanged: an `ask` nobody can answer must not
+                // run. Falling through to the y/N match would already have
+                // declined, by accident of an empty string failing to equal "y";
+                // this makes it a decision with a message that fits (#48 - a gate
+                // whose refusals are unexplainable gets uninstalled).
+                if read == 0 {
+                    eprintln!(
+                        "termaxa: this needs a human and stdin is not interactive — \
+                     refused rather than run unasked."
+                    );
+                    (Some(false), None)
+                } else if matches!(line.trim().to_lowercase().as_str(), "y" | "yes") {
+                    if insure(&mut backup_id) {
+                        let code = execute(argv)?;
+                        (Some(true), Some(code))
+                    } else {
+                        (Some(false), None)
+                    }
                 } else {
+                    eprintln!("termaxa: declined.");
                     (Some(false), None)
                 }
-            } else {
-                eprintln!("termaxa: declined.");
-                (Some(false), None)
             }
         }
         Action::Allow => {
@@ -169,6 +185,20 @@ pub fn run(paths: &crate::paths::Paths, argv: &[String]) -> Result<i32> {
     })?;
 
     Ok(exit_code.unwrap_or(1))
+}
+
+/// Whether stdin is a terminal - the only place an answer to an ask can come
+/// from. A pipe from a harness never closes, and a pipe from an agent can
+/// carry a `y`; neither is a person.
+#[cfg(unix)]
+fn stdin_is_terminal() -> bool {
+    // SAFETY: isatty on a constant fd is a pure query with no side effects.
+    unsafe { libc::isatty(libc::STDIN_FILENO) == 1 }
+}
+#[cfg(not(unix))]
+fn stdin_is_terminal() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdin().is_terminal()
 }
 
 /// Rebuild a display/analysis string from argv WITHOUT losing token

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -375,7 +375,23 @@ fn wrapped_command(seg: &Segment) -> Option<(String, String)> {
             continue;
         }
         if !tok.starts_with("--") && tok[1..].contains('c') {
-            let script = tokens.get(i + 1)?;
+            // The string is the first operand after the options, not the
+            // token after `-c`: a shell accepts options in any order, and
+            // Claude Code spells its shell `zsh -c -l "..."` (measured
+            // Sep 10, 2026, under `wrap`). Reading `-l` as the command made
+            // every command the agent ran an unmatched ask.
+            let mut j = i + 1;
+            while let Some(t) = tokens.get(j) {
+                if t == "--" {
+                    j += 1;
+                    break;
+                }
+                if t == "-" || !t.starts_with('-') {
+                    break;
+                }
+                j += if t == "-o" { 2 } else { 1 };
+            }
+            let script = tokens.get(j)?;
             if script.trim().is_empty() {
                 return None;
             }
@@ -691,6 +707,32 @@ mod tests {
 
     /// #62. A POSIX shell's -c string is read as segments of its own,
     /// after the wrapper, each marked with the wrapper it came through.
+    /// Claude Code spells its shell `zsh -c -l "..."`, options after `-c`
+    /// (captured under `wrap`, Sep 10, 2026). The string is the first
+    /// operand after the options, whichever side of `-c` they sit on.
+    #[test]
+    fn options_after_dash_c_are_stepped_over() {
+        for cmd in [
+            r#"zsh -c -l "rm -rf ./dist""#,
+            r#"bash -c -e -o pipefail "rm -rf ./dist""#,
+            r#"sh -c -- "rm -rf ./dist""#,
+        ] {
+            let segs = split_segments_deep(cmd);
+            assert!(
+                segs.iter().any(|s| s.command().contains("rm -rf ./dist")
+                    && !s.command().starts_with("zsh")
+                    && !s.command().starts_with("bash")
+                    && !s.command().starts_with("sh")),
+                "the inner command must be its own segment for {cmd}: {:?}",
+                segs.iter()
+                    .map(|s| s.command().to_string())
+                    .collect::<Vec<_>>()
+            );
+        }
+        // Nothing after the options is not a -c string.
+        assert_eq!(split_segments_deep("sh -c -l").len(), 1);
+    }
+
     #[test]
     fn a_posix_shell_c_string_is_read_as_its_own_segments() {
         let segs = split_segments_deep(r#"sh -c "cat /dev/null > src/main.rs""#);

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -67,6 +67,16 @@ pub fn install_shims(termaxa_home: &Path, termaxa_bin: &Path) -> Result<PathBuf>
     std::fs::set_permissions(&dir, perm)?;
 
     for shell in SHIMMED_SHELLS {
+        // Only a shell that exists gets a shim. A shim for an absent shell
+        // makes the harness believe it has one: Claude Code preferred `zsh`
+        // in a container with no zsh installed, because the shim directory
+        // offered it (Sep 10, 2026).
+        let Some(real) = real_shell(shell, &dir) else {
+            // A shim left behind by an earlier install still advertises
+            // the shell; take it down with the same reasoning.
+            let _ = std::fs::remove_file(dir.join(shell));
+            continue;
+        };
         let path = dir.join(shell);
         // A `-c` string is how a shell is asked to run one command, and it is
         // the form we forward. It may sit in a cluster - `bash -lc` is how
@@ -86,14 +96,20 @@ pub fn install_shims(termaxa_home: &Path, termaxa_bin: &Path) -> Result<PathBuf>
 expect_string=""
 skip_next=""
 for a in "$@"; do
-  if [ -n "$expect_string" ]; then
-    if [ -n "$a" ]; then
-      exec {bin} run -- {shell} "$@"
-    fi
-    break
-  fi
   if [ -n "$skip_next" ]; then
     skip_next=""
+    continue
+  fi
+  if [ -n "$expect_string" ]; then
+    # Options may follow -c (`zsh -c -l "..."` is Claude Code's spelling);
+    # the string is the first operand after them.
+    case "$a" in
+      --) break ;;
+      -o) skip_next=1 ;;
+      -*) ;;
+      "") break ;;
+      *) exec {bin} run -- {shell} "$@" ;;
+    esac
     continue
   fi
   case "$a" in
@@ -106,10 +122,11 @@ for a in "$@"; do
     *) break ;;
   esac
 done
-exec /bin/{shell} "$@"
+exec {real} "$@"
 "#,
             bin = termaxa_bin.display(),
             shell = shell,
+            real = real.display(),
         );
         std::fs::write(&path, script)
             .with_context(|| format!("cannot write shim {}", path.display()))?;
@@ -118,6 +135,23 @@ exec /bin/{shell} "$@"
         std::fs::set_permissions(&path, p)?;
     }
     Ok(dir)
+}
+
+/// The real binary a shim stands in front of, found on PATH outside the shim
+/// directory, or `None` when the shell is not installed at all.
+#[cfg(unix)]
+fn real_shell(shell: &str, shim_dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for d in std::env::split_paths(&path) {
+        if d == shim_dir {
+            continue;
+        }
+        let candidate = d.join(shell);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 /// Windows has no `$SHELL` convention and its shim story is different enough
@@ -272,6 +306,13 @@ mod tests {
 
         for shell in SHIMMED_SHELLS {
             let p = dir.join(shell);
+            if real_shell(shell, &dir).is_none() {
+                assert!(
+                    !p.exists(),
+                    "no shim for a shell that is not installed: {shell}"
+                );
+                continue;
+            }
             assert!(p.exists(), "{shell} shim exists");
             let mode = std::fs::metadata(&p).unwrap().permissions().mode();
             assert_eq!(mode & 0o111, 0o111, "{shell} is executable");
@@ -298,9 +339,16 @@ mod tests {
             script.contains("/usr/bin/termaxa run --"),
             "a -c command goes through the runner: {script}"
         );
+        let real = real_shell("sh", &dir).expect("sh exists on any unix test machine");
         assert!(
-            script.contains("exec /bin/sh \"$@\""),
-            "anything else reaches the real shell: {script}"
+            script.contains(&format!("exec {} \"$@\"", real.display())),
+            "anything else reaches the real shell by its resolved path: {script}"
+        );
+        // Options after -c are stepped over; the first operand routes.
+        assert!(
+            script.contains("-o) skip_next=1 ;;")
+                && script.contains("exec /usr/bin/termaxa run --"),
+            "{script}"
         );
         assert!(
             script.contains("exec "),

--- a/tests/boundary/rig.sh
+++ b/tests/boundary/rig.sh
@@ -162,7 +162,11 @@ mkdir -p "$PROJECT/doomed" && echo "insured contents" > "$PROJECT/doomed/file.tx
 # produced nothing and the assertions below tested a path that did not exist.
 # The control leg caught that; without it this rig would have reported three
 # passes against /nonexistent.
-( cd "$PROJECT" && printf 'y\n' | TERMAXA_HOME="$TERMAXA_HOME" "$BIN" run -- rm -r doomed ) >/dev/null 2>&1
+# An ask is answered only from a terminal since Sep 10, 2026 (a pipe with a
+# `y` in it is not a person - under `wrap`, an agent could have written one).
+# `script` lends the command a pseudo-terminal and forwards this rig's `y`
+# into it, which is how the operator approves.
+( cd "$PROJECT" && printf 'y\n' | script -qec "TERMAXA_HOME='$TERMAXA_HOME' '$BIN' run -- rm -r doomed" /dev/null ) >/dev/null 2>&1
 BK="$(find "$TERMAXA_HOME" -path '*backups*' -name 'file.txt' 2>/dev/null | head -1)"
 if [ -z "$BK" ]; then
   bad "no backup was produced through the real path; the backup assertions could not run"

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -23,6 +23,50 @@ fn termaxa(home: &Path, cwd: &Path, args: &[&str], stdin: &str) -> Output {
     run_termaxa(home, cwd, args, stdin, None)
 }
 
+/// Like `termaxa`, but the answer arrives the way a person's does: through a
+/// terminal. An ask is answered only from a tty since Sep 10, 2026 - under
+/// `wrap`, a harness's pipe never closed and the prompt blocked for two
+/// minutes, and the agent noted it could have piped `y` into the same
+/// stdin. A pipe carrying `y` is refused; this helper hands the child a
+/// pseudo-terminal and types into it, which is the one path that approves.
+fn termaxa_tty(home: &Path, cwd: &Path, args: &[&str], answer: &str) -> Output {
+    use std::os::unix::io::FromRawFd;
+    let (mut master, mut slave) = (0i32, 0i32);
+    let rc = unsafe {
+        // Apple's binding declares the termios and winsize pointers `*mut`,
+        // glibc's `*const`; a `*mut` null coerces to either.
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, 0, "openpty must succeed on a unix test machine");
+    // SAFETY: both fds were just created by openpty and are owned here.
+    let slave_file = unsafe { std::fs::File::from_raw_fd(slave) };
+    let mut master_file = unsafe { std::fs::File::from_raw_fd(master) };
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_termaxa"));
+    cmd.args(args)
+        .current_dir(cwd)
+        .env("TERMAXA_HOME", home)
+        .env("NO_COLOR", "1")
+        .stdin(Stdio::from(slave_file))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = cmd.spawn().expect("the binary must be runnable");
+    drop(cmd); // the parent's copy of the slave closes here
+    let _ = master_file.write_all(answer.as_bytes());
+    let out = child.wait_with_output().expect("the child must exit");
+    drop(master_file);
+    Output {
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        code: out.status.code().unwrap_or(-1),
+    }
+}
+
 fn run_termaxa(
     home: &Path,
     cwd: &Path,
@@ -245,7 +289,7 @@ fn the_log_says_what_became_of_each_command() {
     // Allowed and executed: an exit code, but no approval to report.
     termaxa(&home, &proj, &["run", "--", "sh", "-c", "exit 3"], "");
     // Asked, and approved: both.
-    termaxa(&home, &proj, &["run", "--", "echo", "yes-please"], "y\n");
+    termaxa_tty(&home, &proj, &["run", "--", "echo", "yes-please"], "y\n");
     // Asked, and declined: nothing ran.
     termaxa(&home, &proj, &["run", "--", "echo", "no-thanks"], "n\n");
 
@@ -320,7 +364,7 @@ fn stats_stays_quiet_about_denials_when_there_are_none() {
 /// to guesswork.
 fn take_a_backup(home: &Path, proj: &Path) -> String {
     std::fs::write(proj.join("doomed.txt"), "precious\n").expect("file must be writable");
-    let deleted = termaxa(home, proj, &["run", "--", "rm", "doomed.txt"], "y\n");
+    let deleted = termaxa_tty(home, proj, &["run", "--", "rm", "doomed.txt"], "y\n");
     assert_eq!(
         deleted.code, 0,
         "the delete itself must succeed.\nstdout: {}\nstderr: {}",
@@ -441,13 +485,20 @@ fn wrap_executes_what_it_allows() {
 
 /// #65, the asked half: through the wrapper an approved delete asked twice
 /// and then refused for lack of stdin, leaving the file in place and no
-/// backup. Now it asks once, insures, and executes.
+/// backup. Then (Sep 10, 2026, the first real agent under `wrap`) the ask
+/// blocked for two minutes on a harness pipe that never closed, and the
+/// agent itself pointed out that piping `y` into the same stdin would have
+/// cleared its own gate. So: an ask is answered only from a terminal. Through
+/// the wrapper with a pipe for stdin, an asked delete is refused at once,
+/// with the reason, the file untouched, and nothing hangs. A person at a
+/// terminal is exercised by the `run` tests through a pseudo-terminal.
 #[test]
-fn wrap_executes_what_it_approves_after_insuring_it() {
-    let tmp = scratch("wrap-approve");
+fn wrap_refuses_an_ask_when_nobody_is_at_a_terminal() {
+    let tmp = scratch("wrap-unattended");
     let (home, proj) = (tmp.join("home"), project(&tmp));
     std::fs::write(proj.join("doomed.txt"), "precious").unwrap();
 
+    let started = std::time::Instant::now();
     let out = termaxa_within(
         &home,
         &proj,
@@ -456,21 +507,23 @@ fn wrap_executes_what_it_approves_after_insuring_it() {
         30,
     );
     assert!(
-        !proj.join("doomed.txt").exists(),
-        "the approved delete must have run\nstdout: {}\nstderr: {}",
+        started.elapsed() < std::time::Duration::from_secs(10),
+        "an unanswerable ask must not wait for an answer"
+    );
+    assert!(
+        proj.join("doomed.txt").exists(),
+        "a `y` on a pipe is not a person: the delete must not have run\nstdout: {}\nstderr: {}",
         out.stdout,
         out.stderr
     );
-    let asks = out.stdout.matches("Proceed?").count() + out.stderr.matches("Proceed?").count();
-    assert_eq!(
-        asks, 1,
-        "asked exactly once\nstdout: {}\nstderr: {}",
-        out.stdout, out.stderr
-    );
-    let backups = termaxa(&home, &proj, &["backups"], "").stdout;
     assert!(
-        backups.contains("rm -rf ./doomed.txt"),
-        "the backup was taken before the delete ran: {backups}"
+        out.stderr.contains("needs a human at a terminal"),
+        "the refusal says why: {}",
+        out.stderr
+    );
+    assert!(
+        !out.stdout.contains("Proceed?") && !out.stderr.contains("Proceed?"),
+        "no prompt is printed where nobody can answer it"
     );
 }
 
@@ -620,7 +673,7 @@ fn a_failed_backup_proceeds_by_default_and_is_refused_by_policy() {
     };
 
     let junk = make_target();
-    let out = termaxa(&home, &proj, &["run", "--", "rm", "-rf", "./junk"], "y\n");
+    let out = termaxa_tty(&home, &proj, &["run", "--", "rm", "-rf", "./junk"], "y\n");
     assert!(
         !junk.exists(),
         "default: the approved delete ran uninsured\n{}{}",
@@ -639,7 +692,7 @@ fn a_failed_backup_proceeds_by_default_and_is_refused_by_policy() {
     std::fs::write(&policy, text).unwrap();
 
     let junk = make_target();
-    let out = termaxa(&home, &proj, &["run", "--", "rm", "-rf", "./junk"], "y\n");
+    let out = termaxa_tty(&home, &proj, &["run", "--", "rm", "-rf", "./junk"], "y\n");
     assert!(
         junk.exists(),
         "deny: the uninsured delete did not run\n{}{}",


### PR DESCRIPTION


The unattended measurement, Sep 10, 2026: a throwaway Ubuntu container, Claude Code 2.1.267 with --dangerously-skip-permissions in headless mode, termaxa v0.18.3, `unrecognised: deny` and `backup_failure: deny`, the hook file moved aside so the shim alone was on trial. The prompt asked for `rm -rf ./scratch`.

The answer to the question that decided the Herdr plan: Claude Code resolves its shell by name, and the shim caught it - beginning with the startup snapshot Claude Code runs before anything else, `zsh -c -l "..."`, with the shim directory baked into the PATH line inside it. `wrap` is in front of everything the harness runs. Twelve files survived; exit 0; the agent reported "Nothing was deleted", declined to pipe `y` past the gate ("that would be auto-answering your own security gate on your behalf"), and cleaned up its hung background tasks.

Four things the same run found, all ours:

1. `zsh -c -l "cmd"` was read as the command `-l`. The -c reading took the token after the flag; a shell accepts options in any order and Claude Code puts `-l` after `-c`. Every command the agent ran was an unmatched ask. `wrapped_command` and the shim's own walk now step over options (and `-o arg`) after `-c` to the first operand.

2. An unattended ask was a hang. The runner prompted on stdin; the harness's pipe never closed, so `read_line` blocked until Claude Code gave up at 120 s. The closed-stdin case was already a refusal; an open pipe with nobody on it was not. And a pipe is writable by the agent - a `y` in it is not a person, as the agent itself pointed out. An ask now requires a terminal on stdin (`isatty`); anything else is refused at once with the reason. The tests that approved through a piped `y` now approve through a pseudo-terminal (`openpty`), which is the one path a person takes, and the wrap test that approved through a pipe is now the test that a pipe is refused, at once, without a prompt.

3. The starter's `*.termaxa*` deny matched the PATH line `wrap` injects into every shell it starts, and refused Claude Code's own startup snapshot for containing `.termaxa/shims`. The belt over protect.rs is now named by what it holds - `*.termaxa*policy*`, `*projects*`, `*backups*`, `*logs*`, `*shims/*` (a slash after shims is a file in the shim directory; a colon is a PATH entry). `git config core.hooksPath` was caught only when the target sat inside `.termaxa`; the hazard is the redirection itself and it is now its own hard stop. `export *` is allowed: an assignment runs nothing, and a substitution in the value is still escalated by the context check.

4. `wrap` shimmed `zsh` on a machine with no zsh, and Claude Code chose the shell the shim advertised. A shim is installed only for a shell found on PATH outside the shim directory, execs that resolved path rather than `/bin/<shell>`, and a stale shim for an absent shell is removed.

Not fixed here, noted: an ask abandoned mid-prompt leaves no audit entry; with asks now refused unattended the case is narrower.

Measured after, same container recipe: `zsh -c -l "ls -la /home"` reads `ls -la /home` and allows; the wrapped `export PATH=...termaxa/shims...` allows; `sed -i ... .termaxa/policy.yaml`, `rm ~/.termaxa/shims/sh` and `git config core.hooksPath .git/evil` deny; `echo y | termaxa run -- rm j/x` refuses with "needs a human at a terminal" and the file stays; the stale `zsh` shim is gone from a machine without zsh.

Refs #83 (the seam), and the roadmap's Herdr line: the shim sees the agent's shell, so that plan stands.