### PR TITLE
wrap: the agent keeps its own shell - the zsh shim when a real zsh exists, an operator's shim is kept - and cd joins the starter with git's read-only heads

### DIFF
--- a/examples/policy.yaml
+++ b/examples/policy.yaml
@@ -421,6 +421,39 @@ rules:
     action: allow
   - match: "id *"
     action: allow
+  # `cd` runs nothing, and an agent under `wrap` was refused on
+  # `cd /home/dev/proj && git ls-files scratch` (Sep 11, 2026) - a read-only
+  # command, refused unattended on the one word in it that had no rule. The
+  # git heads below never write the tree: `ls-files`, `show`, `rev-parse`,
+  # `blame`, `describe`, `stash list`, `config --get`, a bare `remote`, and
+  # `tag` in its listing forms only (`git tag -d` deletes, so `tag *` stays
+  # on the default).
+  - match: "cd"
+    action: allow
+  - match: "cd *"
+    action: allow
+  - match: "git ls-files*"
+    action: allow
+  - match: "git show*"
+    action: allow
+  - match: "git rev-parse*"
+    action: allow
+  - match: "git blame*"
+    action: allow
+  - match: "git describe*"
+    action: allow
+  - match: "git stash list*"
+    action: allow
+  - match: "git config --get*"
+    action: allow
+  - match: "git remote"
+    action: allow
+  - match: "git tag"
+    action: allow
+  - match: "git tag -l*"
+    action: allow
+  - match: "git tag --list*"
+    action: allow
   - match: "git remote -v"
     action: allow
   - match: "git fetch*"

--- a/src/init.rs
+++ b/src/init.rs
@@ -427,6 +427,39 @@ rules:
     action: allow
   - match: "id *"
     action: allow
+  # `cd` runs nothing, and an agent under `wrap` was refused on
+  # `cd /home/dev/proj && git ls-files scratch` (Sep 11, 2026) - a read-only
+  # command, refused unattended on the one word in it that had no rule. The
+  # git heads below never write the tree: `ls-files`, `show`, `rev-parse`,
+  # `blame`, `describe`, `stash list`, `config --get`, a bare `remote`, and
+  # `tag` in its listing forms only (`git tag -d` deletes, so `tag *` stays
+  # on the default).
+  - match: "cd"
+    action: allow
+  - match: "cd *"
+    action: allow
+  - match: "git ls-files*"
+    action: allow
+  - match: "git show*"
+    action: allow
+  - match: "git rev-parse*"
+    action: allow
+  - match: "git blame*"
+    action: allow
+  - match: "git describe*"
+    action: allow
+  - match: "git stash list*"
+    action: allow
+  - match: "git config --get*"
+    action: allow
+  - match: "git remote"
+    action: allow
+  - match: "git tag"
+    action: allow
+  - match: "git tag -l*"
+    action: allow
+  - match: "git tag --list*"
+    action: allow
   - match: "git remote -v"
     action: allow
   - match: "git fetch*"

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1183,6 +1183,22 @@ rules:
             "Claude Code's first act: {}",
             d.reason
         );
+        // Refused on `cd` under `wrap`, Sep 11, 2026: a read-only command
+        // with one word in it that had no rule.
+        let d = starter.evaluate_command(
+            &bash(
+                r#"ls -la /home/dev/proj/scratch; echo "---git-tracked---"; cd /home/dev/proj && git ls-files scratch"#,
+            ),
+            &here(),
+        );
+        assert_eq!(d.action, Action::Allow, "{}", d.reason);
+        let d = starter.evaluate_command("git tag -d v1.0", &here());
+        assert_eq!(
+            d.action,
+            Action::Ask,
+            "a tag delete stays on the default: {}",
+            d.reason
+        );
         let d = starter.evaluate_command(&bash("no-such-command-tmx"), &here());
         assert_eq!(
             d.action,

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -245,17 +245,40 @@ fn is_executable_file(p: &Path) -> bool {
     std::fs::metadata(p).map(|m| m.is_file()).unwrap_or(false)
 }
 
-/// The shell the agent is told to use: the `bash` shim when bash is
-/// installed, else the `sh` shim. Claude Code accepts only a bash or zsh
-/// path in `CLAUDE_CODE_SHELL` and `$SHELL`; other harnesses that read
-/// `$SHELL` get a shim either way.
+/// The shell the agent is told to use: the shim for the shell it would have
+/// chosen on its own. Claude Code looks for zsh first and bash second
+/// (measured Sep 10, 2026), and on a Mac the user's PATH and aliases live in
+/// `~/.zshrc`; v0.18.5 handed every such machine the `bash` shim and moved
+/// the agent to `bash -l` (measured Sep 11: zsh installed, not one zsh probe,
+/// five bash spawns). So: the `zsh` shim when a real zsh exists - the shim
+/// is only written when one does - else the `bash` shim, else the `sh` shim.
+/// The agent keeps its environment; only the gate is inserted. Claude Code
+/// accepts only a bash or zsh path in `CLAUDE_CODE_SHELL` and `$SHELL`;
+/// other harnesses that read `$SHELL` get a shim either way.
 pub(crate) fn agent_shell(shim_dir: &Path) -> PathBuf {
-    let bash = shim_dir.join("bash");
-    if bash.is_file() {
-        bash
-    } else {
-        shim_dir.join("sh")
+    for name in ["zsh", "bash"] {
+        let shim = shim_dir.join(name);
+        if shim.is_file() {
+            return shim;
+        }
     }
+    shim_dir.join("sh")
+}
+
+/// The shell to hand the agent, given what the operator set. A
+/// `CLAUDE_CODE_SHELL` that already names one of the shims is the operator
+/// choosing a shell inside the gate, and is kept as is. Anything else -
+/// unset, or a path outside the shim directory - becomes [`agent_shell`],
+/// and the override is returned so `run` can say so: a wrapper that silently
+/// routes nothing is the failure this repairs.
+pub(crate) fn chosen_shell(shim_dir: &Path, operator: Option<&Path>) -> (PathBuf, Option<PathBuf>) {
+    if let Some(op) = operator {
+        if op.parent() == Some(shim_dir) && op.is_file() {
+            return (op.to_path_buf(), None);
+        }
+        return (agent_shell(shim_dir), Some(op.to_path_buf()));
+    }
+    (agent_shell(shim_dir), None)
 }
 
 /// Launch `argv` with the shims in front of it.
@@ -274,22 +297,21 @@ pub fn run(argv: &[String], termaxa_home: &Path) -> Result<i32> {
     // `/bin/bash` by absolute path for its snapshot and every Bash tool
     // call, so on a box without zsh the shim saw nothing and `rm -rf
     // ./scratch` ran with no audit entry, three times. It does honour
-    // `CLAUDE_CODE_SHELL` (documented: a path to a bash or zsh binary), and
-    // reads `$SHELL` only when that names bash or zsh - the `sh` shim it was
-    // handed is neither. So both point at the `bash` shim when there is one,
-    // and the same run then went through the shim four times out of four.
-    // An operator value that points outside the shim directory is
-    // overridden and said so: a wrapper that silently routes nothing is the
-    // failure this repairs.
-    let shell = agent_shell(&dir);
-    if let Some(prev) = std::env::var_os("CLAUDE_CODE_SHELL") {
-        if Path::new(&prev) != shell {
-            eprintln!(
-                "termaxa wrap: CLAUDE_CODE_SHELL was {}; set to {} so Claude Code's shell is the gate",
-                Path::new(&prev).display(),
-                shell.display()
-            );
-        }
+    // `CLAUDE_CODE_SHELL` (documented: a path to a bash or zsh binary, taken
+    // over its own detection), and reads `$SHELL` only when that names bash
+    // or zsh - the `sh` shim it was handed is neither. So both point at the
+    // shim for the shell it would have chosen itself (`agent_shell`), and the
+    // same run then went through the shim five times out of five. An
+    // operator value naming one of the shims is kept; one pointing outside
+    // the shim directory is overridden and said so.
+    let operator = std::env::var_os("CLAUDE_CODE_SHELL").map(PathBuf::from);
+    let (shell, overridden) = chosen_shell(&dir, operator.as_deref());
+    if let Some(prev) = overridden {
+        eprintln!(
+            "termaxa wrap: CLAUDE_CODE_SHELL was {}; set to {} so Claude Code's shell is the gate",
+            prev.display(),
+            shell.display()
+        );
     }
 
     let mut cmd = std::process::Command::new(&argv[0]);
@@ -339,23 +361,70 @@ mod tests {
     use super::*;
     use crate::testutil::TempTree;
 
-    /// Claude Code takes a shell from `CLAUDE_CODE_SHELL` or `$SHELL` only
-    /// when the path names bash or zsh, so the agent is told to use the
-    /// `bash` shim; with no bash on the machine it is told the `sh` shim,
-    /// which other harnesses still honour.
+    /// The agent is told to use the shim for the shell it would have chosen
+    /// itself: zsh when a real zsh exists (the shim is only written when one
+    /// does), else bash, else sh. Pinned on a synthetic shim directory so it
+    /// does not depend on what the test machine has installed, and once on
+    /// the real one, where the answer is whichever of zsh and bash exists.
     #[cfg(unix)]
     #[test]
-    fn the_agent_is_told_to_use_the_bash_shim() {
+    fn the_agent_is_told_to_use_the_shim_for_the_shell_it_would_have_chosen() {
         let t = TempTree::new("wrap-agent-shell");
+        let fake = t.path().join("fake-shims");
+        std::fs::create_dir_all(&fake).unwrap();
+        for name in ["sh", "bash", "zsh"] {
+            std::fs::write(fake.join(name), "#!/bin/sh\n").unwrap();
+        }
+        assert_eq!(agent_shell(&fake), fake.join("zsh"));
+        std::fs::remove_file(fake.join("zsh")).unwrap();
+        assert_eq!(agent_shell(&fake), fake.join("bash"));
+        std::fs::remove_file(fake.join("bash")).unwrap();
+        assert_eq!(agent_shell(&fake), fake.join("sh"));
+
         let dir = install_shims(t.path(), Path::new("/usr/bin/termaxa")).unwrap();
+        let want = if dir.join("zsh").is_file() {
+            dir.join("zsh")
+        } else {
+            dir.join("bash")
+        };
+        assert_eq!(agent_shell(&dir), want);
+    }
+
+    /// An operator value that already names one of the shims is the operator
+    /// choosing a shell inside the gate, and is kept. A value outside the
+    /// shim directory - or naming a shim that does not exist - is replaced
+    /// and reported. Unset is the default.
+    #[cfg(unix)]
+    #[test]
+    fn an_operators_shim_is_kept_and_anything_else_is_overridden_and_said() {
+        let t = TempTree::new("wrap-chosen-shell");
+        let fake = t.path().join("fake-shims");
+        std::fs::create_dir_all(&fake).unwrap();
+        for name in ["sh", "bash", "zsh"] {
+            std::fs::write(fake.join(name), "#!/bin/sh\n").unwrap();
+        }
+        assert_eq!(chosen_shell(&fake, None), (fake.join("zsh"), None));
         assert_eq!(
-            agent_shell(&dir),
-            dir.join("bash"),
-            "bash exists on any unix test machine"
+            chosen_shell(&fake, Some(&fake.join("bash"))),
+            (fake.join("bash"), None),
+            "the operator's own shim is kept"
         );
-        let empty = t.path().join("no-shims");
-        std::fs::create_dir_all(&empty).unwrap();
-        assert_eq!(agent_shell(&empty), empty.join("sh"));
+        assert_eq!(
+            chosen_shell(&fake, Some(&fake.join("sh"))),
+            (fake.join("sh"), None)
+        );
+        let outside = Path::new("/opt/homebrew/bin/bash");
+        assert_eq!(
+            chosen_shell(&fake, Some(outside)),
+            (fake.join("zsh"), Some(outside.to_path_buf())),
+            "outside the shim directory: replaced and reported"
+        );
+        let missing = fake.join("fish");
+        assert_eq!(
+            chosen_shell(&fake, Some(&missing)),
+            (fake.join("zsh"), Some(missing.clone())),
+            "a shim that does not exist is not a shim"
+        );
     }
 
     #[cfg(unix)]

--- a/tests/cli_surface.rs
+++ b/tests/cli_surface.rs
@@ -578,10 +578,13 @@ fn wrap_reads_a_c_wherever_the_shell_would() {
 /// paths and then runs `/bin/bash` by absolute path, so the shim on `PATH`
 /// saw nothing and an unattended `rm -rf ./scratch` ran with no audit
 /// entry. It honours `CLAUDE_CODE_SHELL` and reads `$SHELL` only when that
-/// names bash or zsh. So the wrapped agent is handed the `bash` shim in
-/// both, and an operator value pointing elsewhere is overridden and said.
+/// names bash or zsh. So the wrapped agent is handed, in both, the shim for
+/// the shell it would have chosen itself - zsh when the machine has one,
+/// else bash (Sep 11: v0.18.5 handed a zsh machine the bash shim and moved
+/// the agent to `bash -l`). An operator value naming one of the shims is
+/// kept; one pointing elsewhere is overridden and said.
 #[test]
-fn wrap_hands_the_agent_the_bash_shim_by_name() {
+fn wrap_hands_the_agent_the_shim_for_its_own_shell_by_name() {
     let tmp = scratch("wrap-agent-shell");
     let (home, proj) = (tmp.join("home"), project(&tmp));
     std::fs::write(
@@ -603,7 +606,12 @@ fn wrap_hands_the_agent_the_bash_shim_by_name() {
         "",
         30,
     );
-    let shim = home.join("shims").join("bash");
+    let shims = home.join("shims");
+    let shim = if shims.join("zsh").is_file() {
+        shims.join("zsh")
+    } else {
+        shims.join("bash")
+    };
     let want = format!("shell={} claude={}", shim.display(), shim.display());
     assert!(
         out.stdout.contains(&want),
@@ -617,27 +625,44 @@ fn wrap_hands_the_agent_the_bash_shim_by_name() {
         out.stderr
     );
 
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_termaxa"));
-    let out = cmd
-        .args(["wrap", "--", "sh", "-c", "echo claude=$CLAUDE_CODE_SHELL"])
-        .current_dir(&proj)
-        .env("TERMAXA_HOME", &home)
-        .env("NO_COLOR", "1")
-        .env("CLAUDE_CODE_SHELL", "/opt/homebrew/bin/bash")
-        .stdin(Stdio::null())
-        .output()
-        .expect("the binary must be runnable");
-    let (stdout, stderr) = (
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr),
-    );
+    let run = |value: &str| {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_termaxa"));
+        let out = cmd
+            .args(["wrap", "--", "sh", "-c", "echo claude=$CLAUDE_CODE_SHELL"])
+            .current_dir(&proj)
+            .env("TERMAXA_HOME", &home)
+            .env("NO_COLOR", "1")
+            .env("CLAUDE_CODE_SHELL", value)
+            .stdin(Stdio::null())
+            .output()
+            .expect("the binary must be runnable");
+        (
+            String::from_utf8_lossy(&out.stdout).to_string(),
+            String::from_utf8_lossy(&out.stderr).to_string(),
+        )
+    };
+
+    let (stdout, stderr) = run("/opt/homebrew/bin/bash");
     assert!(
         stdout.contains(&format!("claude={}", shim.display())),
-        "the operator's value is overridden: {stdout}"
+        "an outside value is overridden: {stdout}"
     );
     assert!(
         stderr.contains("CLAUDE_CODE_SHELL was /opt/homebrew/bin/bash; set to"),
         "and the override is said: {stderr}"
+    );
+
+    // The operator pointing at one of the shims is choosing a shell inside
+    // the gate, and is kept - the sh shim exists on every machine.
+    let own = shims.join("sh");
+    let (stdout, stderr) = run(&own.display().to_string());
+    assert!(
+        stdout.contains(&format!("claude={}", own.display())),
+        "the operator's own shim is kept: {stdout}"
+    );
+    assert!(
+        !stderr.contains("CLAUDE_CODE_SHELL was"),
+        "and nothing is said: {stderr}"
     );
 }
 


### PR DESCRIPTION
v0.18.5 hands every wrapped agent the `bash` shim in `CLAUDE_CODE_SHELL` and
`SHELL` whenever bash exists (#92). Measured Sep 11, 2026 in the #91
container with zsh installed (`/usr/bin/zsh`, 5.9): Claude Code made not one
zsh probe, took the variable over its own detection, and ran every call
through `shims/bash` — five bash spawns, `bash -c -l` each time. On a Linux
box without zsh that is the fix working; on any machine with zsh, which is
every Mac, it moves the agent from the shell it would have chosen to
`bash -l`, and a `PATH` or alias that lives in `~/.zshrc` is gone for the
agent. A wrapper is meant to insert the gate and leave the environment as it
was. Second thing, same run: an operator who set `CLAUDE_CODE_SHELL` to the
`zsh` shim by hand was overridden to the bash shim and told so — the
override treated one of its own shims as foreign.
 
Third thing, from the run after the fix: the agent's second call,
`ls -la /home/dev/proj/scratch; echo "---git-tracked---"; cd /home/dev/proj
&& git ls-files scratch`, was refused unattended on segment 11/13 `cd
/home/dev/proj` — no rule matched. A read-only command refused on the one
word in it that had no rule is #48 exactly, with a receipt.
 
Three changes:
 
1. **`agent_shell` mirrors the harness's own order.** The `zsh` shim when
   one exists — it is only written when a real zsh does — else the `bash`
   shim, else `sh`. Claude Code looks for zsh first and bash second
   (measured under `strace`, #91), so the agent gets the shim for the shell
   it would have chosen itself.
2. **`chosen_shell` keeps an operator's shim.** A `CLAUDE_CODE_SHELL` that
   already names one of the shims is the operator choosing a shell inside
   the gate and is passed through; unset becomes `agent_shell`; a path
   outside the shim directory, or a shim that does not exist, is replaced
   and reported on one line, as before.
3. **The starter allows `cd`, `cd *`, and git's read-only heads**:
   `git ls-files*`, `git show*`, `git rev-parse*`, `git blame*`,
   `git describe*`, `git stash list*`, `git config --get*`, a bare
   `git remote`, and `git tag` in its listing forms only (`git tag -d`
   deletes, so `tag *` stays on the default). 168 rules become 181.
Measured after, same container, the fixed build, policy regenerated, both
knobs, hook aside:
 
- zsh present, nothing set: five spawns `shims/zsh → termaxa run`,
  `/usr/bin/zsh` only as the runner's child three times; the tool calls
  arrive as `zsh -c -l "setopt NO_EXTENDED_GLOB NO_BARE_GLOB_QUAL … eval
  '…'"` and are judged by the command inside — `ls` allowed and executed,
  `rm -rf ./scratch` denied ("Recursive force delete blocked by default
  policy") with no shell spawned for it, twelve files intact. The `setopt`
  reading's first live receipt; until this run it had only the suite.
- `CLAUDE_CODE_SHELL=<shims>/bash` set by hand: no override line, the bash
  path, same verdicts.
- The zsh startup snapshot is 149 segments and its worst is the assignment
  itself (`SNAPSHOT_FILE=…`, no rule, ask), where the bash form's 42
  segments draw the unresolvable-target refusal on `head -n 1000 >>
  "$SNAPSHOT_FILE"`. Both refused unattended; both are #94, which gains
  the assignment segment as a requirement from this run.
Tests: `agent_shell` and `chosen_shell` on a synthetic shim directory so
nothing depends on what the test machine has installed; the wrapped agent
printing the shim for its own shell from both variables, an outside value
overridden and said, an operator's shim kept and nothing said; the measured
`cd … && git ls-files` command allowed through the Claude Code form; `git
tag -d` still on the default.
 
Refs #91, #92, #48 (a gate that fires on ordinary work gets uninstalled),
#94 (the snapshot, both forms).
 