### PR TITLE
v0.18.6: the agent keeps its own shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes to Termaxa. Format loosely follows [Keep a Changelog](https://keepachangelog.com/); this project is pre-1.0, so minor versions may include breaking changes to the policy schema or CLI.
 
+## v0.18.6 — the agent keeps its own shell
+
+v0.18.5 handed every wrapped agent the `bash` shim whenever bash existed.
+Measured Sep 11, 2026 in the #91 container with zsh installed: Claude Code
+took `CLAUDE_CODE_SHELL` over its own detection — not one zsh probe — and
+ran everything through `bash -l`. On a Linux box without zsh that was the
+fix working; on a machine with zsh, which is every Mac, it moved the agent
+off the shell it would have chosen, and a `PATH` or alias that lives in
+`~/.zshrc` was gone for it.
+
+### Fixed
+
+- **`wrap` names the shim for the shell the agent would have chosen
+  itself** (#96): the `zsh` shim when a real zsh exists (it is only written
+  when one does), else `bash`, else `sh` — Claude Code's own order. A
+  `CLAUDE_CODE_SHELL` that already names one of the shims is kept as the
+  operator's choice; a path outside the shim directory is still overridden
+  and said. Measured after in the same container: five spawns through
+  `shims/zsh`, the tool calls arriving as `zsh -c -l "setopt
+  NO_EXTENDED_GLOB NO_BARE_GLOB_QUAL … eval '…'"` and judged by the command
+  inside — `ls` allowed and executed, `rm -rf ./scratch` denied with no
+  shell spawned for it, twelve files intact. The `setopt` reading's first
+  live receipt; v0.18.5 had it only in the suite.
+- **The wrap tests read an explicit search path** (#97). CI run 191 failed
+  on macOS in a wrap test with "sh exists on any unix test machine": the
+  test binary's `isolating_path` guard had rewritten the process `PATH` on
+  another thread while the test walked it. Environment variables are
+  process-global. `install_shims_on` and `real_shell_on` take the search
+  path as an argument; with `PATH=/nonexistent` forced for the whole
+  binary, all seven wrap tests pass. Production reads `PATH` as before.
+
+### Added
+
+- **`cd` and git's read-only heads in the starter** (#96): `cd`, `cd *`,
+  `git ls-files*`, `git show*`, `git rev-parse*`, `git blame*`,
+  `git describe*`, `git stash list*`, `git config --get*`, a bare
+  `git remote`, and `git tag` in its listing forms only (`git tag -d`
+  deletes, so `tag *` stays on the default). The receipt: an agent under
+  `wrap` refused unattended on `cd /home/dev/proj && git ls-files scratch`
+  — a read-only command, refused on the one word in it that had no rule.
+  168 rules become 181. `init` never rewrites an existing policy: add them
+  by hand or regenerate.
+
+### Known limitations
+
+- The startup snapshot is still refused under `wrap` (#94). The zsh form
+  is 149 segments and falls to the default on the assignment itself; the
+  bash form's 42 draw the unresolvable-target refusal on `head -n 1000 >>
+  "$SNAPSHOT_FILE"`. Claude Code carries on without it.
+- Measured on Claude Code, on Linux with and without zsh. Codex under
+  `wrap` is a separate run.
+
 ## v0.18.5 — `wrap` is told where Claude Code's shell is, and reads what it sends
 
 `wrap` had never seen Claude Code. v0.18.4 said it had; the correction is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "termaxa"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termaxa"
-version = "0.18.5"
+version = "0.18.6"
 edition = "2021"
 description = "A cooperative gate for the shell commands AI coding agents run — command previews, automatic backups, allow/ask/deny policy, and audit logging."
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ See [SECURITY.md](SECURITY.md) for the full threat model.
 
 ## Contributing
 
-Issues and PRs welcome. `cargo test` must pass; CI runs on Linux, macOS, and Windows. The codebase is dependency-light Rust: ~11,800 lines of production code in `src/`, plus ~13,800 lines of tests (unit tests live beside the code they test; `tests/` holds the integration ones). More test than product, on purpose — `src/policy.rs` and `src/preview.rs` are the best places to start reading, and the test module at the bottom of each file explains what the code is defending against.
+Issues and PRs welcome. `cargo test` must pass; CI runs on Linux, macOS, and Windows. The codebase is dependency-light Rust: ~11,900 lines of production code in `src/`, plus ~13,900 lines of tests (unit tests live beside the code they test; `tests/` holds the integration ones). More test than product, on purpose — `src/policy.rs` and `src/preview.rs` are the best places to start reading, and the test module at the bottom of each file explains what the code is defending against.
 
 If you can make an agent get past the gate in a way that isn't already documented above, that's the most useful contribution you can make: [open an issue](https://github.com/termaxa/termaxa/issues) or email security@termaxa.com.
 


### PR DESCRIPTION
Release prep for v0.18.6; the entry is in CHANGELOG.md.